### PR TITLE
github: Use cda-tum/setup-z3 to install Z3

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,12 +20,14 @@ jobs:
           ./elan-init -y --default-toolchain none
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
-    - name: Get z3 binary v4.11.2
-      run: |
-          set -o pipefail
-          curl -OJLsSf https://github.com/Z3Prover/z3/releases/download/z3-4.11.2/z3-4.11.2-x64-glibc-2.31.zip
-          unzip z3-4.11.2-x64-glibc-2.31.zip && rm z3-4.11.2-x64-glibc-2.31.zip
-          echo "./z3-4.11.2-x64-glibc-2.31/bin/z3" >> $GITHUB_PATH
+    - name: Setup Z3
+      id: z3
+      uses: cda-tum/setup-z3@v1
+      with:
+        version: 4.11.2
+        add_to_library_path: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
FYI, this is using https://github.com/cda-tum/setup-z3 in Github Action. I've tested it on my fork.

![Screenshot 2024-01-30 at 12 06 44 PM](https://github.com/leanprover/LNSym/assets/403281/f875c10e-1c75-4a31-8320-8045285a69a4)
