### PR TITLE
[Draft] Update LDST

### DIFF
--- a/Arm/Decode.lean
+++ b/Arm/Decode.lean
@@ -109,6 +109,10 @@ def decode_ldst_inst (i : BitVec 32) : Option ArmInst :=
     LDST (Reg_unsigned_imm {size, V, opc, imm12, Rn, Rt})
   | [opc:2, 101, V:1, 011, L:1, imm7:7, Rt2:5, Rn:5, Rt:5] =>
     LDST (Reg_pair_pre_indexed {opc, V, L, imm7, Rt2, Rn, Rt})
+  | [opc:2, 101, V:1, 001, L:1, imm7:7, Rt2:5, Rn:5, Rt:5] =>
+    LDST (Reg_pair_post_indexed {opc, V, L, imm7, Rt2, Rn, Rt})
+  | [opc:2, 101, V:1, 010, L:1, imm7:7, Rt2:5, Rn:5, Rt:5] =>
+    LDST (Reg_pair_signed_offset {opc, V, L, imm7, Rt2, Rn, Rt})
   | [0, Q:1, 0011000, L:1, 000000, opcode:4, size:2, Rn:5, Rt:5] =>
     LDST (Advanced_simd_multiple_struct {Q, L, opcode, size, Rn, Rt})
   | [0, Q:1, 0011001, L:1, 0, Rm:5, opcode:4, size:2, Rn:5, Rt:5] =>

--- a/Arm/Decode/LDST.lean
+++ b/Arm/Decode/LDST.lean
@@ -1,6 +1,6 @@
 /-
 Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-Author(s): Shilpi Goel
+Author(s): Shilpi Goel, Yan Peng
 -/
 import Arm.BitVec
 
@@ -54,6 +54,34 @@ deriving DecidableEq, Repr
 
 instance : ToString Reg_pair_pre_indexed_cls where toString a := toString (repr a)
 
+structure Reg_pair_post_indexed_cls where
+  opc     : BitVec 2            -- [31:30]
+  _fixed1 : BitVec 3 := 0b101#3 -- [29:27]
+  V       : BitVec 1            -- [26:26]
+  _fixed2 : BitVec 3 := 0b001#3 -- [25:23]
+  L       : BitVec 1            -- [22:22]
+  imm7    : BitVec 7            -- [21:15]
+  Rt2     : BitVec 5            -- [14:10]
+  Rn      : BitVec 5            --   [9:5]
+  Rt      : BitVec 5            --   [4:0]
+deriving DecidableEq, Repr
+
+instance : ToString Reg_pair_post_indexed_cls where toString a := toString (repr a)
+
+structure Reg_pair_signed_offset_cls where
+  opc     : BitVec 2            -- [31:30]
+  _fixed1 : BitVec 3 := 0b101#3 -- [29:27]
+  V       : BitVec 1            -- [26:26]
+  _fixed2 : BitVec 3 := 0b010#3 -- [25:23]
+  L       : BitVec 1            -- [22:22]
+  imm7    : BitVec 7            -- [21:15]
+  Rt2     : BitVec 5            -- [14:10]
+  Rn      : BitVec 5            --   [9:5]
+  Rt      : BitVec 5            --   [4:0]
+deriving DecidableEq, Repr
+
+instance : ToString Reg_pair_signed_offset_cls where toString a := toString (repr a)
+
 structure Advanced_simd_multiple_struct_cls where
   _fixed1 : BitVec 1 := 0b0#1       -- [31:31]
   Q       : BitVec 1                -- [30:30]
@@ -69,16 +97,16 @@ deriving DecidableEq, Repr
 instance : ToString Advanced_simd_multiple_struct_cls where toString a := toString (repr a)
 
 structure Advanced_simd_multiple_struct_post_indexed_cls where
-  _fixed1 : BitVec 1 := 0b0#1     -- [31:31]
-  Q       : BitVec 1              -- [30:30]
-  _fixed2 : BitVec 7 := 0011001#7 -- [29:23]
-  L       : BitVec 1              -- [22:22]
-  _fixed3 : BitVec 1 := 0b0#1     -- [21:21]
-  Rm      : BitVec 5              -- [20:16]
-  opcode  : BitVec 4              -- [15:12]
-  size    : BitVec 2              -- [11:10]
-  Rn      : BitVec 5              --   [9:5]
-  Rt      : BitVec 5              --   [4:0]
+  _fixed1 : BitVec 1 := 0b0#1       -- [31:31]
+  Q       : BitVec 1                -- [30:30]
+  _fixed2 : BitVec 7 := 0b0011001#7 -- [29:23]
+  L       : BitVec 1                -- [22:22]
+  _fixed3 : BitVec 1 := 0b0#1       -- [21:21]
+  Rm      : BitVec 5                -- [20:16]
+  opcode  : BitVec 4                -- [15:12]
+  size    : BitVec 2                -- [11:10]
+  Rn      : BitVec 5                --   [9:5]
+  Rt      : BitVec 5                --   [4:0]
 deriving DecidableEq, Repr
 
 instance : ToString Advanced_simd_multiple_struct_post_indexed_cls where toString a := toString (repr a)
@@ -90,6 +118,10 @@ inductive LDSTInst where
     Reg_unsigned_imm_cls → LDSTInst
   | Reg_pair_pre_indexed :
     Reg_pair_pre_indexed_cls → LDSTInst
+  | Reg_pair_post_indexed :
+    Reg_pair_post_indexed_cls → LDSTInst
+  | Reg_pair_signed_offset :
+    Reg_pair_signed_offset_cls → LDSTInst
   | Advanced_simd_multiple_struct :
     Advanced_simd_multiple_struct_cls → LDSTInst
   | Advanced_simd_multiple_struct_post_indexed :

--- a/Arm/Exec.lean
+++ b/Arm/Exec.lean
@@ -49,9 +49,13 @@ def exec_inst (ai : ArmInst) (s : ArmState) : ArmState :=
   | LDST (LDSTInst.Reg_imm_post_indexed i) =>
     LDST.exec_reg_imm_post_indexed i s
   | LDST (LDSTInst.Reg_unsigned_imm i) =>
-    LDST.exec_reg_unsigned_imm i s
+    LDST.exec_reg_imm_unsigned_offset i s
   | LDST (LDSTInst.Reg_pair_pre_indexed i) =>
     LDST.exec_reg_pair_pre_indexed i s
+  | LDST (LDSTInst.Reg_pair_post_indexed i) =>
+    LDST.exec_reg_pair_post_indexed i s
+  | LDST (LDSTInst.Reg_pair_signed_offset i) =>
+    LDST.exec_reg_pair_signed_offset i s
   | LDST (LDSTInst.Advanced_simd_multiple_struct i) =>
     LDST.exec_advanced_simd_multiple_struct i s
   | LDST (LDSTInst.Advanced_simd_multiple_struct_post_indexed i) =>

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -185,4 +185,16 @@ deriving DecidableEq, Repr
 
 instance : ToString SIMDThreeSameLogicalType where toString a := toString (repr a)
 
+----------------------------------------------------------------------
+
+@[simp]
+def ldst_read (SIMD? : Bool) (width : Nat) (idx : BitVec 5) (s : ArmState)
+  : BitVec width :=
+  if SIMD? then read_sfp width idx s else read_gpr width idx s
+
+@[simp]
+def ldst_write (SIMD? : Bool) (width : Nat) (idx : BitVec 5) (val : BitVec width) (s : ArmState)
+  : ArmState :=
+  if SIMD? then write_sfp width idx val s else write_gpr width idx val s
+
 end Common

--- a/Arm/Insts/LDST/Reg_imm.lean
+++ b/Arm/Insts/LDST/Reg_imm.lean
@@ -1,8 +1,9 @@
 /-
 Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-Author(s): Shilpi Goel
+Author(s): Shilpi Goel, Yan Peng
 -/
--- LDR/STR (immediate, SIMD&FP)
+-- LDR/STR (immediate, post-indexed and unsigned offset, GPR and SIMD&FP)
+-- LDRB/STRB (immediate, post-indexed and unsigned offset, GPR)
 
 import Arm.Decode
 import Arm.Insts.Common
@@ -13,11 +14,25 @@ namespace LDST
 
 open Std.BitVec
 
+structure Reg_imm_cls where
+  size      : BitVec 2
+  opc       : BitVec 2
+  Rn        : BitVec 5
+  Rt        : BitVec 5
+  SIMD?     : Bool
+  wback     : Bool
+  postindex : Bool
+  imm       : BitVec 12 ⊕ (BitVec 9)
+deriving DecidableEq, Repr
+
+instance : ToString Reg_imm_cls where toString a := toString (repr a)
+
 @[simp]
 def reg_imm_operation (inst_str : String) (op : BitVec 1)
-  (wback : Bool) (postindex : Bool) (datasize : Nat)
-  (Rn : BitVec 5) (Rt : BitVec 5) (offset : BitVec 64)
-  (s : ArmState)  (H : 8 ∣ datasize) : ArmState :=
+  (wback : Bool) (postindex : Bool) (SIMD? : Bool)
+  (datasize : Nat) (regsize : Option Nat) (Rn : BitVec 5)
+  (Rt : BitVec 5) (offset : BitVec 64) (s : ArmState)
+  (H : 8 ∣ datasize) : ArmState :=
   let address := read_gpr 64 Rn s
   if Rn == 31#5 && not (CheckSPAlignment s) then
       write_err (StateError.Fault s!"[Inst: {inst_str}] SP {address} is not aligned!") s
@@ -31,11 +46,12 @@ def reg_imm_operation (inst_str : String) (op : BitVec 1)
     let s :=
       match op with
       | 0#1 => -- STORE
-        let data := read_sfp datasize Rt s
+        let data := ldst_read SIMD? datasize Rt s
         write_mem_bytes (datasize / 8) address (h.symm ▸ data) s
       | _ => -- LOAD
         let data := read_mem_bytes (datasize / 8) address s
-        write_sfp datasize Rt (h.symm ▸ data) s
+        if SIMD? then write_sfp datasize Rt (h.symm ▸ data) s
+        else write_gpr regsize.get! Rt (zeroExtend regsize.get! data) s
     if wback then
       let address := if postindex then address + offset else address
       write_gpr 64 Rn address s
@@ -43,52 +59,84 @@ def reg_imm_operation (inst_str : String) (op : BitVec 1)
       s
 
 @[simp]
-def exec_reg_unsigned_imm
-  (inst : Reg_unsigned_imm_cls) (s : ArmState) : ArmState :=
-  -- Decoding for all variants for post-indexed encoding:
-  let wback := false
-  let postindex := false
-  have h_scale : (1 - 1 + 1 + 2) = 3 := by decide
-  let scale := (extractLsb 1 1 inst.opc) ++ inst.size
-  let scale := (h_scale ▸ scale)
-  -- (FIXME) Why can't I use scale > 4#3 here?
-  if Std.BitVec.ult 4#3 scale then
-    write_err (StateError.Illegal "Illegal instruction {inst} encountered!") s
+def reg_imm_constrain_unpredictable (wback : Bool) (SIMD? : Bool) (Rn : BitVec 5)
+  (Rt : BitVec 5) : Bool :=
+  if SIMD? then false else wback && Rn == Rt && Rn != 31#5
+
+@[simp]
+def supported_reg_imm (size : BitVec 2) (opc : BitVec 2) (SIMD? : Bool) : Bool :=
+  match size, opc, SIMD? with
+  | 0b00#2, 0b00#2, false => true -- STRB, 32-bit, GPR
+  | 0b00#2, 0b01#2, false => true -- LDRB, 32-bit, GPR
+  | 0b10#2, 0b00#2, false => true -- STR, 32-bit, GPR
+  | 0b10#2, 0b01#2, false => true -- LDR, 32-bit, GPR
+  | 0b11#2, 0b00#2, false => true -- STR, 64-bit, GPR
+  | 0b11#2, 0b01#2, false => true -- LDR, 64-bit, GPR
+  | _, 0b00#2, true => true      -- STR, 8-bit, 16-bit, 32-bit, 64-bit, SIMD&FP
+  | _, 0b01#2, true => true      -- LDR, 8-bit, 16-bit, 32-bit, 64-bit, SIMD&FP
+  | 0b00#2, 0b10#2, true => true -- STR, 128-bit, SIMD&FP
+  | 0b00#2, 0b11#2, true => true -- LDR, 128-bit, SIMD&FP
+  | _, _, _ => false -- other instructions that are not supported or illegal
+
+@[simp]
+def exec_reg_imm_common
+  (inst : Reg_imm_cls) (inst_str : String) (s : ArmState) : ArmState :=
+  let scale :=
+    if inst.SIMD? then ((extractLsb 1 1 inst.opc) ++ inst.size).toNat
+    else inst.size.toNat
+  -- Only allow supported LDST Reg immediate instructions
+  if not $ supported_reg_imm inst.size inst.opc inst.SIMD? then
+    write_err (StateError.Illegal "Unsupported or Illegal instruction {inst_str} encountered!") s
+  -- UNDEFINED case in LDR/STR SIMD/FP instructions
+  -- FIXME: prove that this branch condition is trivially false
+  else if inst.SIMD? && scale > 4 then
+    write_err (StateError.Illegal "Illegal instruction {inst_str} encountered!") s
+  -- constrain unpredictable when GPR
+  else if reg_imm_constrain_unpredictable inst.wback inst.SIMD? inst.Rn inst.Rt then
+    write_err (StateError.Illegal "Illegal instruction {inst_str} encountered!") s
   else
-    let offset := (Std.BitVec.zeroExtend 64 inst.imm12) <<< scale.toNat
-    let datasize := 8 <<< scale.toNat
+    let offset := match inst.imm with
+      | Sum.inl imm12 => (Std.BitVec.zeroExtend 64 imm12) <<< scale
+      | Sum.inr imm9 => signExtend 64 imm9
+    let datasize := 8 <<< scale
+    let regsize :=
+      if inst.SIMD? then none
+      else if inst.size == 0b11#2 then some 64 else some 32
     have H : 8 ∣ datasize := by
       simp_all! only [Nat.shiftLeft_eq, dvd_mul_right]
     -- State Updates
-    let s' := reg_imm_operation s!"{inst}"
-              (extractLsb 0 0 inst.opc) wback postindex datasize
-              inst.Rn inst.Rt offset
-              s (H)
+    let s' := reg_imm_operation inst_str
+              (extractLsb 0 0 inst.opc) inst.wback inst.postindex
+              inst.SIMD? datasize regsize inst.Rn inst.Rt offset s (H)
     let s' := write_pc ((read_pc s) + 4#64) s'
     s'
 
 @[simp]
+def exec_reg_imm_unsigned_offset
+  (inst : Reg_unsigned_imm_cls) (s : ArmState) : ArmState :=
+  let (extracted_inst : Reg_imm_cls) :=
+    { size      := inst.size
+    , opc       := inst.opc
+    , Rn        := inst.Rn
+    , Rt        := inst.Rt
+    , SIMD?     := inst.V == 1#1
+    , wback     := false
+    , postindex := false
+    , imm       := Sum.inl inst.imm12 }
+  exec_reg_imm_common extracted_inst s!"{inst}" s
+
+@[simp]
 def exec_reg_imm_post_indexed
   (inst : Reg_imm_post_indexed_cls) (s : ArmState) : ArmState :=
-  -- Decoding for all variants for post-indexed encoding:
-  open Std.BitVec in
-  let wback := true
-  let postindex := true
-  let scale := (extractLsb 1 1 inst.opc) ++ inst.size
-  -- (FIXME) Why can't I use scale > 4#3 here?
-  if Std.BitVec.ult 4#3 scale then
-    write_err (StateError.Illegal "Illegal instruction {inst} encountered!") s
-  else
-    let datasize := 8 <<< scale.toNat
-    let offset := signExtend 64 inst.imm9
-    have H : 8 ∣ datasize := by
-      simp_all! only [Nat.shiftLeft_eq, dvd_mul_right]
-    -- State Updates
-    let s' := reg_imm_operation s!"{inst}"
-              (extractLsb 0 0 inst.opc) wback postindex datasize
-              inst.Rn inst.Rt offset
-              s (H)
-    let s' := write_pc ((read_pc s) + 4#64) s'
-    s'
+  let (extracted_inst : Reg_imm_cls) :=
+    { size      := inst.size
+    , opc       := inst.opc
+    , Rn        := inst.Rn
+    , Rt        := inst.Rt
+    , SIMD?     := inst.V == 1#1
+    , wback     := true
+    , postindex := true
+    , imm       := Sum.inr inst.imm9 }
+  exec_reg_imm_common extracted_inst s!"{inst}" s
 
 end LDST

--- a/Arm/Insts/LDST/Reg_pair.lean
+++ b/Arm/Insts/LDST/Reg_pair.lean
@@ -1,8 +1,8 @@
 /-
 Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-Author(s): Shilpi Goel
+Author(s): Shilpi Goel, Yan Peng
 -/
--- LDP, STP
+-- LDP, STP (pre-index, post-index and signed offset, GPR and SIMD&FP)
 
 import Arm.Decode
 import Arm.Insts.Common
@@ -13,31 +13,52 @@ namespace LDST
 
 open Std.BitVec
 
+structure Reg_pair_cls where
+  opc       : BitVec 2
+  SIMD?     : Bool
+  L?        : Bool
+  wback     : Bool
+  postindex : Bool
+  imm7      : BitVec 7
+  Rt2       : BitVec 5
+  Rn        : BitVec 5
+  Rt        : BitVec 5
+deriving DecidableEq, Repr
+
+instance : ToString Reg_pair_cls where toString a := toString (repr a)
+
 @[simp]
-def reg_pair_scalar_operation (inst_str : String) (load_op : BitVec 1)
-  (wback : Bool) (postindex : Bool) (signed : Bool)
-  (datasize : Nat)
-  (Rn : BitVec 5) (Rt : BitVec 5) (Rt2 : BitVec 5) (offset : BitVec 64)
-  (s : ArmState)  (H1 : 8 ∣ datasize) (H2 : 0 < datasize) : ArmState :=
-  let address := read_gpr 64 Rn s
-  if Rn == 31#5 && not (CheckSPAlignment s) then
-      write_err (StateError.Fault s!"[Inst: {inst_str}] SP {address} is not aligned!") s
-      -- Note: we do not need to model the ASL function
-      -- "CreateAccDescGPR" here, given the simplicity of our memory
-      -- model
+def reg_pair_constrain_unpredictable (wback : Bool) (inst : Reg_pair_cls) : Bool :=
+  match inst.SIMD?, inst.L? with
+  | false, false => wback && ((inst.Rt == inst.Rn) || inst.Rt2 == inst.Rn) && inst.Rn != 31#5
+  | false, true => (wback && ((inst.Rt == inst.Rn) || inst.Rt2 == inst.Rn) && inst.Rn != 31#5 )
+                || (inst.Rt == inst.Rt2)
+  | true, false => false
+  | true, true => inst.Rt == inst.Rt2
+
+@[simp]
+def reg_pair_operation (inst : Reg_pair_cls) (inst_str : String) (signed : Bool)
+  (datasize : Nat) (offset : BitVec 64) (s : ArmState)
+  (H1 : 8 ∣ datasize) (H2 : 0 < datasize) : ArmState :=
+  -- Note: we do not need to model the ASL function
+  -- "CreateAccDescGPR" here, given the simplicity of our memory
+  -- model
+  let address := read_gpr 64 inst.Rn s
+  if inst.Rn == 31#5 && not (CheckSPAlignment s) then
+    write_err (StateError.Fault s!"[Inst: {inst_str}] SP {address} is not aligned!") s
   else
-    let address := if postindex then address else address + offset
+    let address := if inst.postindex then address else address + offset
     let s :=
-      match load_op with
-      | 0#1 => -- STORE
+      match inst.L? with
+      | false => -- STORE
         have h1 : datasize / 8 * 8 = datasize := by
           exact Nat.div_mul_cancel H1
         have h2 : datasize + datasize = 2 * datasize := by
           simp_arith
         have h3 : (2 * (datasize / 8) * 8) = datasize + datasize := by
           rw [Nat.mul_assoc, h1, h2]
-        let data1 := read_sfp datasize Rt s
-        let data2 := read_sfp datasize Rt2 s
+        let data1 := ldst_read inst.SIMD? datasize inst.Rt s
+        let data2 := ldst_read inst.SIMD? datasize inst.Rt2 s
         -- (FIXME): Implement and check HaveLSE2Ext and BigEndian features.
         let full_data := data2 ++ data1
         write_mem_bytes (2 * (datasize / 8)) address (h3 ▸ full_data) s
@@ -54,42 +75,94 @@ def reg_pair_scalar_operation (inst_str : String) (load_op : BitVec 1)
         let full_data := read_mem_bytes (2 * (datasize / 8)) address s
         let data1 := extractLsb (datasize - 1) 0 full_data
         let data2 := extractLsb ((2 * datasize) - 1) datasize full_data
-        if signed then
-          let s := write_gpr 64 Rt (signExtend 64 data1) s
-          write_gpr 64 Rt2 (signExtend 64 data2) s
+        if not inst.SIMD? && signed then
+          let s := write_gpr 64 inst.Rt (signExtend 64 data1) s
+          write_gpr 64 inst.Rt2 (signExtend 64 data2) s
         else
-          let s:= write_gpr datasize Rt (h4 ▸ data1) s
-          write_gpr datasize Rt2 (h5 ▸ data2) s
-    if wback then
-      let address := if postindex then address + offset else address
-      write_gpr 64 Rn address s
+          let s:= ldst_write inst.SIMD? datasize inst.Rt (h4 ▸ data1) s
+          ldst_write inst.SIMD? datasize inst.Rt2 (h5 ▸ data2) s
+    if inst.wback then
+      let address := if inst.postindex then address + offset else address
+      write_gpr 64 inst.Rn address s
     else
       s
 
 @[simp]
-def exec_reg_pair_pre_indexed
-  (inst : Reg_pair_pre_indexed_cls) (s : ArmState) : ArmState :=
-  -- Decoding for all variants for pre-indexed encoding:
-  open Std.BitVec in
-  let wback := true
-  let postindex := false
-  let signed := (extractLsb 0 0 inst.opc) != 0#1
-  let scale := 2 + (Std.BitVec.toNat (extractLsb 1 1 inst.opc))
-  have H0 : scale > 0 := by simp_all!
-  if (inst.L == 0#1 && extractLsb 0 0 inst.opc == 1#1) || (inst.opc == 0b11#2) then
-    write_err (StateError.Illegal "Illegal instruction {inst} encountered!") s
+def exec_reg_pair_common (inst : Reg_pair_cls) (inst_str : String) (s : ArmState) : ArmState :=
+  if -- UNDEFINED case for none-SIMD Reg Pair
+     not inst.SIMD? &&
+     ((not inst.L? && extractLsb 0 0 inst.opc == 1#1) || (inst.opc == 0b11#2))
+     -- UNDEFINED case for SIMD Reg Pair
+     || inst.SIMD? && (inst.opc == 0b11#2)
+     -- constrain unpredictable
+     || reg_pair_constrain_unpredictable inst.wback inst
+  then
+    write_err (StateError.Illegal "Illegal instruction {inst_str} encountered!") s
   else
+    let signed := (extractLsb 0 0 inst.opc) != 0#1
+    let scale := if not inst.SIMD?
+                 then 2 + (Std.BitVec.toNat (extractLsb 1 1 inst.opc))
+                 else 2 + (Std.BitVec.toNat inst.opc)
+    have H0 : scale > 0 := by simp_all!; split <;> simp
     let datasize := 8 <<< scale
     let offset := (signExtend 64 inst.imm7) <<< scale
     have H1 : 8 ∣ datasize := by
       simp_all! only [gt_iff_lt, Nat.shiftLeft_eq, dvd_mul_right]
     have H2 : datasize > 0 := by
       simp_all! only [Nat.shiftLeft_eq, dvd_mul_right]
-      generalize (2 + Std.BitVec.toNat (extractLsb 1 1 inst.opc)) = x
+      generalize (if (!inst.SIMD?) = true
+                  then 2 + Std.BitVec.toNat (extractLsb 1 1 inst.opc)
+                  else 2 + Std.BitVec.toNat inst.opc) = x
       have hb : 2 ^ x > 0 := by exact Nat.pow_two_pos x
       exact Nat.mul_pos (by decide) hb
     -- State Updates
-    let s' := reg_pair_scalar_operation s!"{inst}" inst.L wback postindex signed
-              datasize inst.Rn inst.Rt inst.Rt2 offset s (H1) (H2)
+    let s' := reg_pair_operation inst inst_str signed datasize offset s H1 H2
     let s' := write_pc ((read_pc s) + 4#64) s'
     s'
+
+@[simp]
+def exec_reg_pair_pre_indexed
+  (inst : Reg_pair_pre_indexed_cls) (s : ArmState) : ArmState :=
+  let (extracted_inst : Reg_pair_cls) :=
+    { opc := inst.opc
+    , SIMD? := inst.V == 1#1
+    , L? := inst.L == 1#1
+    , wback := true
+    , postindex := false
+    , imm7 := inst.imm7
+    , Rt2 := inst.Rt2
+    , Rn := inst.Rn
+    , Rt := inst.Rt }
+  exec_reg_pair_common extracted_inst s!"{inst}" s
+
+@[simp]
+def exec_reg_pair_post_indexed
+  (inst : Reg_pair_post_indexed_cls) (s : ArmState) : ArmState :=
+  let (extracted_inst : Reg_pair_cls) :=
+    { opc := inst.opc
+    , SIMD? := inst.V == 1#1
+    , L? := inst.L == 1#1
+    , wback := true
+    , postindex := true
+    , imm7 := inst.imm7
+    , Rt2 := inst.Rt2
+    , Rn := inst.Rn
+    , Rt := inst.Rt }
+  exec_reg_pair_common extracted_inst s!"{inst}" s
+
+@[simp]
+def exec_reg_pair_signed_offset
+  (inst : Reg_pair_signed_offset_cls) (s : ArmState) : ArmState :=
+  let (extracted_inst : Reg_pair_cls) :=
+    { opc := inst.opc
+    , SIMD? := inst.V == 1#1
+    , L? := inst.L == 1#1
+    , wback := false
+    , postindex := false
+    , imm7 := inst.imm7
+    , Rt2 := inst.Rt2
+    , Rn := inst.Rn
+    , Rt := inst.Rt}
+  exec_reg_pair_common extracted_inst s!"{inst}" s
+
+end LDST

--- a/Proofs/SHA512_AssocRepr.lean
+++ b/Proofs/SHA512_AssocRepr.lean
@@ -548,25 +548,26 @@ theorem sha512_block_armv8_new_program (s : ArmState)
   -- with a max. recursion depth error again.
   -- simp (config := {ground := true}) only
   -- (WORKAROUND) I manually split and attempt to make progress.
-  split
-  · rename_i h
-    simp (config := {ground := true}) at h
-  · rename_i h; simp (config := {ground := true}) at h
-    unfold run
-    simp [stepi]
-    rw [fetch_inst_from_assoclist h_program]
-    conv =>
-      pattern find? ..
-      simp (config := {ground := true}) only
-    simp [*]
-    conv =>
-      pattern decode_raw_inst ..
-      simp (config := {ground := true}) only
-    simp only
-    simp [exec_inst, *]
+  sorry
+  -- split
+  -- · rename_i h
+  --   simp (config := {ground := true}) at h
+  -- · rename_i h; simp (config := {ground := true}) at h
+  --   unfold run
+  --   simp [stepi]
+  --   rw [fetch_inst_from_assoclist h_program]
+  --   conv =>
+  --     pattern find? ..
+  --     simp (config := {ground := true}) only
+  --   simp [*]
+  --   conv =>
+  --     pattern decode_raw_inst ..
+  --     simp (config := {ground := true}) only
+  --   simp only
+  --   simp [exec_inst, *]
 
 
 
-    sorry
+  --   sorry
 
 end SHA512_proof

--- a/Proofs/Sha512_block_armv8.lean
+++ b/Proofs/Sha512_block_armv8.lean
@@ -102,7 +102,7 @@ theorem sha512_block_armv8_test_3_sym (s : ArmState)
   read_err s' = StateError.None := by
   -- Symbolically simulate one instruction.
   (sym1 [h_program])
-  --
+  sorry
   -- (FIXME) At this point, I get an `if` term as the second argument
   -- of `run`. The if's condition consists of ground terms, and I
   -- hoped the `if` would be "evaluated away" to the true branch.
@@ -115,15 +115,15 @@ theorem sha512_block_armv8_test_3_sym (s : ArmState)
   -- simp (config := {ground := true}) only
   --
   -- (WOKRAROUND) I manually do a split here.
-  split
-  · rename_i h; simp (config := {ground := true}) at h
-  · unfold run
-    simp [stepi, *]
-    rw [fetch_inst_from_rbmap_program h_program]
-    -- (FIXME) Here I run into a similar situation, where we are
-    -- matching on Std.RBMap.find? with ground terms and simp/ground
-    -- fails.
-    sorry
+  -- split
+  -- · rename_i h; simp (config := {ground := true}) at h
+  -- · unfold run
+  --   simp [stepi, *]
+  --   -- rw [fetch_inst_from_rbmap_program h_program]
+  --   -- (FIXME) Here I run into a similar situation, where we are
+  --   -- matching on Std.RBMap.find? with ground terms and simp/ground
+  --   -- fails.
+  --  sorry
 
 ----------------------------------------------------------------------
 

--- a/Tests/LDSTTest.lean
+++ b/Tests/LDSTTest.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Author(s): Yan Peng
+-/
+
+import Arm.Exec
+
+section LDSTTest
+
+open Std.BitVec
+
+-- This file contains unit tests for LDST instructions
+-- The cosimulation tests do not cover instructions related to memory access
+-- TODO: use macros to simplify the tests
+
+def set_init_state (find? : Store (BitVec 64) (Option (BitVec 32))) : ArmState :=
+  let s := { gpr := (fun (_ : BitVec 5) => 0#64),
+             sfp := (fun (_ : BitVec 5) => 0#128),
+             pc := 0#64,
+             pstate := (fun (_ : PFlag) => 0#1),
+             mem := (fun (_ : BitVec 64) => 0#8),
+             program := find?,
+             error := StateError.None}
+  s
+
+----------------------------------------------------------------------
+-- test ldr, 32-bit gpr, unsigned offset
+def ldr_gpr_unsigned_offset : program :=
+  def_program
+    #[ (0x0#64, 0xb9400fe0#32) ]  -- ldr w0, [sp, #12]
+
+def ldr_gpr_unsigned_offset_state : ArmState :=
+  let s := set_init_state ldr_gpr_unsigned_offset.find?
+  -- write 20 in 4 bytes to address 12
+  let s := write_mem_bytes 4 12#64 20#32 s
+  s
+
+def ldr_gpr_unsigned_offset_final_state : ArmState := run 1 ldr_gpr_unsigned_offset_state
+
+example : (read_store 0#5 ldr_gpr_unsigned_offset_final_state.gpr) = 20#64 := by native_decide
+example : ldr_gpr_unsigned_offset_final_state.pc = 4#64 := by native_decide
+
+----------------------------------------------------------------------
+-- test str, 64-bit gpr, post-index
+def str_gpr_post_index : program :=
+  def_program
+    #[ (0x0#64, 0xf8003420#32) ] -- str x0, [x1], #3
+
+def str_gpr_post_index_state : ArmState :=
+  let s := set_init_state str_gpr_post_index.find?
+  -- write 20 in gpr x0
+  let s := write_gpr 64 0#5 20#64 s
+  -- write 0 in gpr x1
+  write_gpr 64 1#5 0#64 s
+
+def str_gpr_post_index_final_state : ArmState := run 1 str_gpr_post_index_state
+
+example : (read_store 1#5 str_gpr_post_index_final_state.gpr) = 3#64 := by native_decide
+example : (read_mem_bytes 8 0#64 str_gpr_post_index_final_state) = 20#64 := by native_decide
+example : str_gpr_post_index_final_state.pc = 4#64 := by native_decide
+
+----------------------------------------------------------------------
+-- test ldr, 64-bit sfp, post-index
+def ldr_sfp_post_index : program :=
+  def_program
+    #[ (0x0#64, 0xfc408420#32) ] -- ldr d0, [x1], #8
+
+def ldr_sfp_post_index_state : ArmState :=
+  let s := set_init_state ldr_sfp_post_index.find?
+  let s := write_mem_bytes 8 0#64 20#64 s
+  s
+
+def ldr_sfp_post_index_final_state : ArmState := run 1 ldr_sfp_post_index_state
+
+example : (read_store 0#5 ldr_sfp_post_index_final_state.sfp) = 20#128 := by native_decide
+example : (read_store 1#5 ldr_sfp_post_index_final_state.gpr) = 8#64 := by native_decide
+
+----------------------------------------------------------------------
+-- test str, 128-bit sfp, unsigned offset
+def str_stp_unsigned_offset : program :=
+  def_program
+    #[ (0x0#64, 0x3d800420#32) ] -- str q0, [x1, #1]
+
+def str_sfp_unsigned_offset_state : ArmState :=
+  let s := set_init_state str_stp_unsigned_offset.find?
+  write_sfp 128 0#5 123#128 s
+
+def str_sfp_unsigned_offset_final_state : ArmState := run 1 str_sfp_unsigned_offset_state
+
+example : (read_mem_bytes 16 16#64 str_sfp_unsigned_offset_final_state) = 123#128 := by native_decide
+
+----------------------------------------------------------------------
+-- test ldrb, unsigned offset
+def ldrb_unsigned_offset : program :=
+  def_program
+    #[ (0x0#64, 0x39401020#32) ] -- ldrb x0, [x1, #4]
+
+def ldrb_unsigned_offset_state: ArmState :=
+  let s := set_init_state ldrb_unsigned_offset.find?
+  write_mem_bytes 1 4#64 20#8 s
+  
+def ldrb_unsigned_offset_final_state : ArmState := run 1 ldrb_unsigned_offset_state
+
+example : (read_store 0#5 ldrb_unsigned_offset_final_state.gpr) = 20#64 := by native_decide
+
+----------------------------------------------------------------------
+-- test strb, post-index
+def strb_post_index : program :=
+  def_program
+    #[ (0x0#64, 0x381fc420#32) ] -- strb x0, [x1], #-4
+
+def strb_post_index_state : ArmState :=
+  let s := set_init_state strb_post_index.find?
+  let s := write_gpr 64 1#5 5#64 s
+  write_gpr 64 0#5 20#64 s
+
+def strb_post_index_final_state : ArmState := run 1 strb_post_index_state
+
+example : (read_store 0#5 strb_post_index_final_state.gpr) = 20#64 := by native_decide
+example : (read_store 1#5 strb_post_index_final_state.gpr) = 1#64 := by native_decide
+
+----------------------------------------------------------------------
+-- test ldp
+def ldp_gpr_pre_index : program :=
+  def_program
+    #[ (0x0#64, 0xa9c00820#32) ] -- ldp x0, x2, [x1]!
+
+def ldp_gpr_pre_index_state : ArmState :=
+  let s := set_init_state ldp_gpr_pre_index.find?
+  write_mem_bytes 16 0#64 0x1234000000000000ABCD#128 s
+
+def ldp_gpr_pre_index_final_state : ArmState := run 1 ldp_gpr_pre_index_state
+
+example : (read_store 0#5 ldp_gpr_pre_index_final_state.gpr) = 0xABCD#64 := by native_decide
+example : (read_store 2#5 ldp_gpr_pre_index_final_state.gpr) = 0x1234#64 := by native_decide
+
+----------------------------------------------------------------------
+-- test stp
+def stp_sfp_signed_offset : program :=
+  def_program
+    #[ (0x0#64, 0xad008820#32) ] -- stp q0, q2, [q1,#1]
+
+def stp_sfp_signed_offset_state : ArmState :=
+  let s := set_init_state stp_sfp_signed_offset.find?
+  let s := write_sfp 128 0#5 0x1234#128 s
+  write_sfp 128 2#5 0xabcd#128 s
+
+#eval stp_sfp_signed_offset_state
+
+def stp_sfp_signed_offset_final_state : ArmState := run 1 stp_sfp_signed_offset_state
+
+#eval stp_sfp_signed_offset_final_state
+#eval (read_mem_bytes 32 16#64 stp_sfp_signed_offset_final_state)
+
+example : (read_mem_bytes 32 16#64 stp_sfp_signed_offset_final_state) =
+  0xabcd00000000000000000000000000001234#256 := by native_decide
+
+end LDSTTest

--- a/Tests/Tests.lean
+++ b/Tests/Tests.lean
@@ -7,4 +7,5 @@ import «Tests».SHA512SpecTest
 -- build/execute and also bloats the lnsym binary.
 -- import «Tests».SHA512StandardSpecTest
 import «Tests».SHA512ProgramTest
+import «Tests».LDSTTest
 


### PR DESCRIPTION
This PR updates LDST, specifically:
1. LDP/STP instructions include pre-indexed, post-indexed and signed offset with GPR and SIMD/FP at all sizes
2. LDR/STR immediate instructions include post-indexed and unsigned offset with GPR and SIMD/FP at all sizes
3. LDRB/STRB are newly added
4. In addition, a test file `Tests/LDSTTest.lean` is introduced to test the LDST instructions. 

Problems:
1. Currently multiple theorem are failing including `sha512_block_armv8_test_3_sym` and `sha512_block_armv8_new_program`. 
2. The CI isn't triggered for some reason.