### PR TITLE
(WIP) Split sym1 into smaller tactics

### DIFF
--- a/Proofs/MultiInsts.lean
+++ b/Proofs/MultiInsts.lean
@@ -30,6 +30,7 @@ theorem one_asm_snippet_sym_helper1 (q0_var : BitVec 128) :
 theorem one_asm_snippet_sym_helper2 (q0_var : BitVec 128) :
   q0_var ||| q0_var = q0_var := by auto
 
+-- Todo: use sym_n to prove this theorem.
 theorem small_asm_snippet_sym (s : ArmState)
   (h_pc : read_pc s = 0x12650c#64)
   (h_program : s.program = test_program.find?)
@@ -45,7 +46,7 @@ theorem small_asm_snippet_sym (s : ArmState)
     -- Wrapping up the result:
     -- generalize (r (StateField.SFP 0#5) s) = q0_var; unfold state_value at q0_var; simp at q0_var
     -- try (simp [one_asm_snippet_sym_helper1])
-    simp only [one_asm_snippet_sym_helper2]    
+    simp only [one_asm_snippet_sym_helper2]
     done
 
 end multi_insts_proofs

--- a/Proofs/Sha512_block_armv8.lean
+++ b/Proofs/Sha512_block_armv8.lean
@@ -94,6 +94,44 @@ def sha512_program_test_3 : program :=
     (0x1264cc#64 , 0x4cdf2034#32)       --  ld1     {v20.16b-v23.16b}, [x1], #64
   ]
 
+def mySym1 (curr_state_number:Int) : Lean.Elab.Tactic.TacticM Unit :=
+  Lean.Elab.Tactic.withMainContext do
+    let n_str := toString curr_state_number
+    let n'_str := toString (curr_state_number+1)
+    let mk_name (s:String): Lean.Name :=
+      Lean.Name.append Lean.Name.anonymous s
+    -- The name of the next state
+    let st' := Lean.mkIdent (mk_name ("s_" ++ n'_str))
+    let h_st_ok := Lean.mkIdent (mk_name ("h_s" ++ n_str ++ "_ok"))
+    let h_st'_ok := Lean.mkIdent (mk_name ("h_s" ++ n'_str ++ "_ok"))
+    let h_st_pc := Lean.mkIdent (mk_name ("h_s" ++ n_str ++ "_pc"))
+    let h_st'_pc := Lean.mkIdent (mk_name ("h_s" ++ n'_str ++ "_pc"))
+    let h_st_program := Lean.mkIdent (mk_name ("h_s" ++ n_str ++ "_program"))
+    let h_st'_program := Lean.mkIdent (mk_name ("h_s" ++ n'_str ++ "_program"))
+    let h_st_sp_aligned := Lean.mkIdent (mk_name ("h_s" ++ n_str ++ "_sp_aligned"))
+    let h_st'_sp_aligned := Lean.mkIdent (mk_name ("h_s" ++ n'_str ++ "_sp_aligned"))
+    -- Temporary hypotheses
+    let h_run := Lean.mkIdent (mk_name "h_run")
+    Lean.Elab.Tactic.evalTactic (←
+      `(tactic|
+         (init_next_step $h_run:ident
+          rename_i $st':ident h_step $h_run:ident
+          -- Simulate one instruction
+          fetch_and_decode_inst h_step $h_st_ok:ident $h_st_pc:ident $h_st_program:ident
+          exec_inst h_step $h_st_sp_aligned:ident $st':ident
+
+          -- Update invariants
+          update_invariants $st':ident sha512_program_test_3
+                            $h_st'_ok:ident
+                            $h_st_pc:ident $h_st'_pc:ident
+                            $h_st_sp_aligned $h_st'_sp_aligned:ident
+                            $h_st'_program h_step 1205444#64
+          clear $h_st_ok:ident $h_st_sp_aligned:ident $h_st_pc:ident h_step $h_run:ident
+                $h_st_program:ident)))
+
+elab "my_sym1" n:num : tactic => do
+  mySym1 n.getNat
+
 theorem sha512_block_armv8_test_3_sym (s0 s_final : ArmState)
   (h_s0_ok : read_err s0 = StateError.None)
   (h_s0_sp_aligned : CheckSPAlignment s0 = true)
@@ -104,6 +142,13 @@ theorem sha512_block_armv8_test_3_sym (s0 s_final : ArmState)
 
   unfold read_pc at h_s0_pc
 
+  my_sym1 0
+  my_sym1 1
+  my_sym1 2
+  my_sym1 3
+
+  sorry
+/-
   -- Unroll one step from 'run (n+1)'
   init_next_step h_run
   rename_i s1 h_step h_run
@@ -155,7 +200,7 @@ theorem sha512_block_armv8_test_3_sym (s0 s_final : ArmState)
   clear h_s3_ok h_s3_sp_aligned h_s3_pc h_step h_s3_program
 
   rw [h_run,h_s4_ok]
-
+-/
 
 ----------------------------------------------------------------------
 

--- a/Proofs/Sha512_block_armv8.lean
+++ b/Proofs/Sha512_block_armv8.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Author(s): Shilpi Goel
 -/
 import Arm.Exec
+import Arm.State
 import Tactics.Sym
 import Tests.SHA512ProgramTest
 
@@ -97,7 +98,7 @@ theorem sha512_block_armv8_test_3_sym (s0 s_final : ArmState)
   (h_s0_ok : read_err s0 = StateError.None)
   (h_s0_sp_aligned : CheckSPAlignment s0 = true)
   (h_s0_pc : read_pc s0 = 0x1264c0#64)
-  (h_program : s0.program = sha512_program_test_3.find?)
+  (h_s0_program : s0.program = sha512_program_test_3.find?)
   (h_run : s_final = run 4 s0) :
   read_err s_final = StateError.None := by
 
@@ -105,14 +106,56 @@ theorem sha512_block_armv8_test_3_sym (s0 s_final : ArmState)
 
   -- Unroll one step from 'run (n+1)'
   init_next_step h_run
-  rename_i s_1 h_step h_run
+  rename_i s1 h_step h_run
   -- Simulate one instruction
-  fetch_and_decode_inst h_step h_s0_ok h_s0_pc h_program
-  exec_inst h_step h_s0_sp_aligned s_1
-  -- Update invariants
-  update_invariants s_1 h_s1_ok h_s1_pc h_s0_sp_aligned h_step
+  fetch_and_decode_inst h_step h_s0_ok h_s0_pc h_s0_program
+  exec_inst h_step h_s0_sp_aligned s1
 
-  sorry
+  -- Update invariants
+  update_invariants s1 sha512_program_test_3
+                    h_s1_ok h_s0_pc h_s1_pc
+                    h_s0_sp_aligned h_s1_sp_aligned
+                    h_s1_program h_step 1205444#64
+  clear h_s0_ok h_s0_sp_aligned h_s0_pc h_step h_s0_program
+
+  init_next_step h_run
+  rename_i s2 h_step h_run
+  -- Simulate one instruction
+  fetch_and_decode_inst h_step h_s1_ok h_s1_pc h_s1_program
+  exec_inst h_step h_s1_sp_aligned s2
+  -- Update invariants
+  update_invariants s2 sha512_program_test_3
+                    h_s2_ok h_s1_pc h_s2_pc
+                    h_s1_sp_aligned h_s2_sp_aligned
+                    h_s2_program h_step 1205448#64
+  clear h_s1_ok h_s1_sp_aligned h_s1_pc h_step h_s1_program
+
+  init_next_step h_run
+  rename_i s3 h_step h_run
+  -- Simulate one instruction
+  fetch_and_decode_inst h_step h_s2_ok h_s2_pc h_s2_program
+  exec_inst h_step h_s2_sp_aligned s3
+  -- Update invariants
+  update_invariants s3 sha512_program_test_3
+                    h_s3_ok h_s2_pc h_s3_pc
+                    h_s2_sp_aligned h_s3_sp_aligned
+                    h_s3_program h_step 1205452#64
+  clear h_s2_ok h_s2_sp_aligned h_s2_pc h_step h_s2_program
+
+  init_next_step h_run
+  rename_i s4 h_step h_run
+  -- Simulate one instruction
+  fetch_and_decode_inst h_step h_s3_ok h_s3_pc h_s3_program
+  exec_inst h_step h_s3_sp_aligned s4
+  -- Update invariants
+  update_invariants s4 sha512_program_test_3
+                    h_s4_ok h_s3_pc h_s4_pc
+                    h_s3_sp_aligned h_s4_sp_aligned
+                    h_s4_program h_step 1205456#64
+  clear h_s3_ok h_s3_sp_aligned h_s3_pc h_step h_s3_program
+
+  rw [h_run,h_s4_ok]
+
 
 ----------------------------------------------------------------------
 

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -33,6 +33,30 @@ theorem run_onestep (s s': ArmState) (n: ℕ) (h_nonneg: 0 < n):
   · rename_i n
     simp [run]
 
+-- TODO: replace this with an upcoming new lemma in Std
+theorem Std.BitVec.foldCtor : { toFin := { val := a, isLt := h } : BitVec n } = BitVec.ofNat n a := by
+  simp [BitVec.ofNat, Fin.ofNat', h, Nat.mod_eq_of_lt]
+
+theorem write_mem_bytes_program {n:ℕ} (addr:BitVec 64) (bytes:BitVec (n * 8)):
+    (write_mem_bytes n addr bytes s).program = s.program := by
+  intros
+  induction n generalizing addr s
+  · simp [write_mem_bytes]
+  · rename_i n h_n
+    simp [write_mem_bytes]
+    rw [h_n]
+    simp [write_mem]
+
+theorem w_program (sf:StateField) (v:state_value sf) (s:ArmState):
+    (w sf v s).program = s.program := by
+  intros
+  cases sf <;> unfold w <;> simp
+  · unfold write_base_gpr; simp
+  · unfold write_base_sfp; simp
+  · unfold write_base_pc; simp
+  · unfold write_base_flag; simp
+  · unfold write_base_error; simp
+
 /--
   An ongoing new version of fine-grained simulation tactics.
 --/
@@ -46,38 +70,60 @@ macro "init_next_step" h_s:ident : tactic =>
      rename_i h_s'
      simp at h_s'))
 
+
 macro "fetch_and_decode_inst" h_step:ident h_s_ok:ident h_pc:ident h_program:ident : tactic =>
   `(tactic|
     (unfold stepi at $h_step:ident
      rw [$h_s_ok:ident] at $h_step:ident
-     dsimp only at $h_step:ident -- reduce let(zeta) and match
-     unfold read_pc at $h_step:ident
+     dsimp at $h_step:ident -- reduce let(zeta) and match
      rw [$h_pc:ident] at $h_step:ident
      rw [fetch_inst_from_rbmap_program $h_program:ident] at $h_step:ident
      simp (config := {ground := true}) at $h_step:ident
+     repeat (rw [Std.BitVec.foldCtor] at $h_step:ident)
     ))
 
 macro "exec_inst" h_step:ident h_sp_aligned:ident st_next:ident: tactic =>
   `(tactic|
     (unfold exec_inst at $h_step:ident
-     simp at $h_step:ident
-     conv at $h_step:ident =>
-       arg 2
-       apply if_true
-       apply $st_next:ident
-     simp [$h_sp_aligned:ident] at $h_step:ident
+     -- A simple case where simp works (e.g., Arm.DPI)
+     try (simp (config := {ground := true, decide := true}) at $h_step:ident)
+     -- A complicated case (e.g., Arm.LDST)
+     try (simp at $h_step:ident; (conv at $h_step:ident =>
+         arg 2
+         apply if_true
+         apply $st_next:ident); simp [$h_sp_aligned:ident] at $h_step:ident)
     ))
 
 -- This tactic is WIP.
-macro "update_invariants" st_next:ident h_s_ok_new:ident h_pc_new:ident
-                          h_sp_aligned_new:ident h_step:ident : tactic =>
+macro "update_invariants" st_next:ident progname:ident
+                          h_s_ok_new:ident
+                          h_pc:ident h_pc_new:ident
+                          h_sp_aligned:ident h_sp_aligned_new:ident
+                          h_program_new:ident
+                          h_step:ident pc_next:term : tactic =>
   `(tactic|
-    (have ($h_s_ok_new:ident): read_err $st_next:ident = StateError.None := by
-      rw [$h_step:ident]; simp_all
-     -- Q: How can we automatically infer the next PC?
-     have ($h_pc_new:ident): r StateField.PC st_next = 1205444#64 := by
-      rw [$h_step:ident,h_s0_pc]; simp; simp (config := {ground := true})
-     -- TODO: how to do this?
-     have ($h_sp_aligned_new:ident): CheckSPAlignment $st_next:ident = true := sorry
-     clear $h_step:ident
+     (have $h_s_ok_new:ident: read_err $st_next:ident = StateError.None := by
+        rw [$h_step:ident]; simp_all
+      -- Q: How can we automatically infer the next PC?
+      have $h_pc_new:ident: r StateField.PC $st_next:ident = $pc_next:term := by
+        rw [$h_step:ident,$h_pc:ident]; simp; simp (config := {ground := true})
+      have $h_sp_aligned_new:ident: CheckSPAlignment $st_next:ident = true := by
+        unfold CheckSPAlignment at *
+        rw [$h_step:ident]
+        simp
+        simp at $h_sp_aligned:ident
+        sorry
+        /-
+          h_s0_sp_aligned: extractLsb 3 0 (r (StateField.GPR 31#5) s0) &&& 15#4 = 0#4
+          ⊢ extractLsb 3 0 (r (StateField.GPR 31#5) s0 +
+            signExtend 64 126#7 <<< (2 + Std.BitVec.toNat (extractLsb 1 1 2#2))) &&&
+              15#4 =
+            0#4
+        -/
+      have $h_program_new:ident : ($st_next:ident).program =
+              Std.RBMap.find? ($progname:ident) := by
+        rw [$h_step:ident]
+        try (repeat rw [w_program])
+        try (rw [write_mem_bytes_program])
+        assumption
     ))

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -5,13 +5,15 @@ Author(s): Shilpi Goel
 import Arm.Exec
 import Arm.MemoryProofs
 
+open Std.BitVec
+
 -- sym1 tactic symbolically simulates a single instruction.
 syntax "sym1" "[" term "]" : tactic
 macro_rules
   | `(tactic| sym1 [$h_program:term]) =>
     `(tactic|
-      (try simp_all (config := {decide := true, ground := true})); 
-      unfold run; 
+      (try simp_all (config := {decide := true, ground := true}));
+      unfold run;
       simp_all [stepi];
       (try rw [fetch_inst_from_rbmap_program $h_program]);
       (try simp (config := {decide := true, ground := true}) only);
@@ -22,3 +24,60 @@ macro_rules
       -- (try simp_all (config := {decide := true, ground := true}) only);
       -- (try simp only [ne_eq, r_of_w_different, r_of_w_same, w_of_w_shadow, w_irrelevant])
       (try simp_all (config := {decide := true, ground := true})))
+
+
+theorem run_onestep (s s': ArmState) (n: ℕ) (h_nonneg: 0 < n):
+  (s' = run n s) ↔ ∃ s'', s'' = stepi s ∧ s' = run (n-1) s'' := by
+  cases n
+  · cases h_nonneg
+  · rename_i n
+    simp [run]
+
+/--
+  An ongoing new version of fine-grained simulation tactics.
+--/
+
+macro "init_next_step" h_s:ident : tactic =>
+  `(tactic|
+    (rw [run_onestep] at $h_s:ident <;> try omega
+     cases $h_s:ident
+     rename_i h_temp
+     cases h_temp
+     rename_i h_s'
+     simp at h_s'))
+
+macro "fetch_and_decode_inst" h_step:ident h_s_ok:ident h_pc:ident h_program:ident : tactic =>
+  `(tactic|
+    (unfold stepi at $h_step:ident
+     rw [$h_s_ok:ident] at $h_step:ident
+     dsimp only at $h_step:ident -- reduce let(zeta) and match
+     unfold read_pc at $h_step:ident
+     rw [$h_pc:ident] at $h_step:ident
+     rw [fetch_inst_from_rbmap_program $h_program:ident] at $h_step:ident
+     simp (config := {ground := true}) at $h_step:ident
+    ))
+
+macro "exec_inst" h_step:ident h_sp_aligned:ident st_next:ident: tactic =>
+  `(tactic|
+    (unfold exec_inst at $h_step:ident
+     simp at $h_step:ident
+     conv at $h_step:ident =>
+       arg 2
+       apply if_true
+       apply $st_next:ident
+     simp [$h_sp_aligned:ident] at $h_step:ident
+    ))
+
+-- This tactic is WIP.
+macro "update_invariants" st_next:ident h_s_ok_new:ident h_pc_new:ident
+                          h_sp_aligned_new:ident h_step:ident : tactic =>
+  `(tactic|
+    (have ($h_s_ok_new:ident): read_err $st_next:ident = StateError.None := by
+      rw [$h_step:ident]; simp_all
+     -- Q: How can we automatically infer the next PC?
+     have ($h_pc_new:ident): r StateField.PC st_next = 1205444#64 := by
+      rw [$h_step:ident,h_s0_pc]; simp; simp (config := {ground := true})
+     -- TODO: how to do this?
+     have ($h_sp_aligned_new:ident): CheckSPAlignment $st_next:ident = true := sorry
+     clear $h_step:ident
+    ))


### PR DESCRIPTION
The work is ongoing.

A macro-style tactic is chosen instead of the monad style so that developers can easily extend the tactics. However, this will change for a small set of tactics if they need more fine-grained manipulations.