### PR TITLE
Change the program type in `ArmState` to `Map` 

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -20,6 +20,10 @@ attribute [bitvec_rules] BitVec.extractLsb_ofFin
 attribute [bitvec_rules] BitVec.zeroExtend_eq
 attribute [bitvec_rules] BitVec.ofFin.injEq
 attribute [bitvec_rules] BitVec.extractLsb_toNat
+attribute [bitvec_rules] BitVec.truncate_or
+attribute [bitvec_rules] BitVec.zeroExtend_zeroExtend_of_le
+attribute [bitvec_rules] BitVec.zeroExtend_eq
+
 -- attribute [bitvec_rules] add_ofFin
 
 ----------------------------------------------------------------------

--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -16,7 +16,7 @@ def init_cosim_state : ArmState :=
     pc  := 0#64,
     pstate := zero_pstate,
     mem := (fun (_ : BitVec 64) => 0#8),
-    program := (fun (_ : BitVec 64) => none),
+    program := Map.empty,
     error := StateError.None }
 
 /-- A structure to hold both the input and output values for a
@@ -73,8 +73,7 @@ def init_flags (flags : BitVec 4) (s : ArmState) : ArmState := Id.run do
 /-- Initialize an ArmState for cosimulation from a given regState. -/
 def regState_to_armState (r : regState) : ArmState :=
   let s := init_gprs r.gpr (init_flags r.nzcv (init_sfps r.sfp init_cosim_state))
-  let s := { s with program :=
-             (fun (a : BitVec 64) => if a == some 0#64 then r.inst else none) }
+  let s := { s with program := def_program [(0x0#64, r.inst)] }
   s
 
 def bitvec_to_hex (x : BitVec n) : String :=

--- a/Arm/Map.lean
+++ b/Arm/Map.lean
@@ -10,6 +10,9 @@ A simple Map-like type based on lists
 
 def Map (α : Type u) (β : Type v) := List (α × β)
 
+instance [x : Repr (List (α × β))] : Repr (Map α β) where
+  reprPrec := x.reprPrec
+
 def Map.empty : Map α β := []
 
 def Map.find? [DecidableEq α] (m : Map α β) (a' : α) : Option β :=

--- a/Arm/MinTheory.lean
+++ b/Arm/MinTheory.lean
@@ -83,13 +83,15 @@ attribute [minimal_theory] bne_self_eq_false'
 attribute [minimal_theory] decide_False
 attribute [minimal_theory] decide_True
 attribute [minimal_theory] bne_iff_ne
-attribute [minimal_theory] Nat.le_zero_eq
 
+attribute [minimal_theory] Nat.le_zero_eq
 attribute [minimal_theory] Nat.zero_add
 attribute [minimal_theory] Nat.zero_eq
 attribute [minimal_theory] Nat.succ.injEq
 attribute [minimal_theory] Nat.succ_ne_zero
 attribute [minimal_theory] Nat.sub_zero
+
+attribute [minimal_theory] Nat.le_refl
 
 @[minimal_theory]
 theorem option_get_bang_of_some [Inhabited α] (v : α) :

--- a/Arm/State.lean
+++ b/Arm/State.lean
@@ -258,8 +258,7 @@ def w (fld : StateField) (v : (state_value fld)) (s : ArmState) : ArmState :=
   | ERR    => write_base_error v s
 
 @[state_simp_rules]
-theorem r_of_w_same (fld : StateField) (v : (state_value fld)) (s : ArmState) :
-  r fld (w fld v s) = v := by
+theorem r_of_w_same : r fld (w fld v s) = v := by
   unfold r w
   unfold read_base_gpr write_base_gpr
   unfold read_base_sfp write_base_sfp
@@ -269,8 +268,7 @@ theorem r_of_w_same (fld : StateField) (v : (state_value fld)) (s : ArmState) :
   split <;> (repeat (split <;> simp_all!))
 
 @[state_simp_rules]
-theorem r_of_w_different (fld1 fld2 : StateField) (v : (state_value fld2)) (s : ArmState)
-  (h : fld1 ≠ fld2) :
+theorem r_of_w_different (h : fld1 ≠ fld2) :
   r fld1 (w fld2 v s) = r fld1 s := by
   unfold r w
   unfold read_base_gpr write_base_gpr
@@ -282,8 +280,7 @@ theorem r_of_w_different (fld1 fld2 : StateField) (v : (state_value fld2)) (s : 
   split <;> (repeat (split <;> simp_all!))
 
 @[state_simp_rules]
-theorem w_of_w_shadow (fld : StateField) (v1 v2 : (state_value fld)) (s : ArmState) :
-  w fld v2 (w fld v1 s) = w fld v2 s := by
+theorem w_of_w_shadow : w fld v2 (w fld v1 s) = w fld v2 s := by
   unfold w
   unfold write_base_gpr
   unfold write_base_sfp
@@ -293,8 +290,7 @@ theorem w_of_w_shadow (fld : StateField) (v1 v2 : (state_value fld)) (s : ArmSta
   (repeat (split <;> simp_all!))
 
 @[state_simp_rules]
-theorem w_irrelevant (fld : StateField) (v1 v2 : (state_value fld)) (s : ArmState) :
-  w fld (r fld s) s = s := by
+theorem w_irrelevant : w fld (r fld s) s = s := by
   unfold r w
   unfold read_base_gpr write_base_gpr
   unfold read_base_sfp write_base_sfp
@@ -304,8 +300,7 @@ theorem w_irrelevant (fld : StateField) (v1 v2 : (state_value fld)) (s : ArmStat
   repeat (split <;> simp_all)
 
 @[state_simp_rules]
-theorem fetch_inst_of_w (addr : BitVec 64) (fld : StateField) (val : (state_value fld)) (s : ArmState) :
-  fetch_inst addr (w fld val s) = fetch_inst addr s := by
+theorem fetch_inst_of_w : fetch_inst addr (w fld val s) = fetch_inst addr s := by
   unfold fetch_inst w
   unfold write_base_gpr
   unfold write_base_sfp
@@ -316,10 +311,9 @@ theorem fetch_inst_of_w (addr : BitVec 64) (fld : StateField) (val : (state_valu
 
 -- There is no StateField that overwrites the program.
 @[state_simp_rules]
-theorem w_program (sf : StateField) (v : state_value sf) (s : ArmState):
-    (w sf v s).program = s.program := by
+theorem w_program : (w fld v s).program = s.program := by
   intros
-  cases sf <;> unfold w <;> simp
+  cases fld <;> unfold w <;> simp
   · unfold write_base_gpr; simp
   · unfold write_base_sfp; simp
   · unfold write_base_pc; simp
@@ -463,7 +457,7 @@ where
     | (addr, _) :: p, some max => if addr > max then loop p (some addr) else loop p (some max)
 
 theorem fetch_inst_from_program
-  {address: BitVec 64} {program : program} :
+  {address: BitVec 64} :
   fetch_inst address s = s.program.find? address := by
     unfold fetch_inst
     simp_all!

--- a/Proofs/MultiInsts.lean
+++ b/Proofs/MultiInsts.lean
@@ -25,31 +25,31 @@ def test_program : program :=
     (0x126514#64 , 0x4ea21c5c#32),      --  mov     v28.16b, v2.16b
     (0x126518#64 , 0x4ea31c7d#32)]      --  mov     v29.16b, v3.16b
 
-theorem one_asm_snippet_sym_helper1 (q0_var : BitVec 128) :
-  zeroExtend 128 (zeroExtend 128 (zeroExtend 128 q0_var ||| zeroExtend 128 q0_var)) = zeroExtend 128 q0_var := by
-  sorry -- auto
-
 theorem one_asm_snippet_sym_helper2 (q0_var : BitVec 128) :
   q0_var ||| q0_var = q0_var := by sorry -- auto
 
--- Todo: use sym_n to prove this theorem.
-theorem small_asm_snippet_sym (s : ArmState)
-  (h_pc : read_pc s = 0x12650c#64)
-  (h_program : s.program = test_program)
-  (h_s_ok : read_err s = StateError.None)
-  (h_s' : s' = run 4 s) :
-  read_sfp 128 26#5 s' = read_sfp 128 0#5 s ∧
-  read_err s' = StateError.None := by
-    FIXME
-    -- iterate 4 (sym1 [h_program])
-    sym1 [h_program]
-    sym1 [h_program]
-    sym1 [h_program]
-    sym1 [h_program]
-    -- Wrapping up the result:
-    -- generalize (r (StateField.SFP 0#5) s) = q0_var; unfold state_value at q0_var; simp at q0_var
-    -- try (simp [one_asm_snippet_sym_helper1])
+theorem small_asm_snippet_sym (s0 s_final : ArmState)
+  (h_s0_pc : read_pc s0 = 0x12650c#64)
+  (h_s0_program : s0.program = test_program)
+  (h_s0_ok : read_err s0 = StateError.None)
+  (h_run : s_final = run 4 s0) :
+  read_sfp 128 26#5 s_final = read_sfp 128 0#5 s0 ∧
+  read_err s_final = StateError.None := by
+  -- Prelude
+  simp_all only [state_simp_rules, -h_run]
+  -- Symbolic Simulation
+  sym_n 4 h_s0_program
+  -- Wrapping up the result:
+  unfold run at h_run
+  subst s_final s_4
+  apply And.intro
+  · simp_all only [state_simp_rules, minimal_theory, bitvec_rules]
     simp only [one_asm_snippet_sym_helper2]
-    done
+    -- FIXME: Why does state_simp_rules not work here? Why do we need
+    -- an explicit rw?
+    (try (repeat (rw [r_of_w_different (by decide)])))
+    (try (rw [r_of_w_same]))
+  · simp_all only [state_simp_rules, minimal_theory, bitvec_rules]
+  done
 
 end multi_insts_proofs

--- a/Proofs/MultiInsts.lean
+++ b/Proofs/MultiInsts.lean
@@ -35,7 +35,7 @@ theorem one_asm_snippet_sym_helper2 (q0_var : BitVec 128) :
 -- Todo: use sym_n to prove this theorem.
 theorem small_asm_snippet_sym (s : ArmState)
   (h_pc : read_pc s = 0x12650c#64)
-  (h_program : s.program = test_program.find?)
+  (h_program : s.program = test_program)
   (h_s_ok : read_err s = StateError.None)
   (h_s' : s' = run 4 s) :
   read_sfp 128 26#5 s' = read_sfp 128 0#5 s ∧

--- a/Proofs/Sha512_block_armv8.lean
+++ b/Proofs/Sha512_block_armv8.lean
@@ -37,7 +37,7 @@ theorem sha512_program_test_1_sym (s0 s_final : ArmState)
   -- Prelude
   simp_all only [state_simp_rules, -h_run]
   -- Symbolic simulation
-  sym_n 4 --h_s0_program
+  sym_n 4 h_s0_program
   -- Final steps
   unfold run at h_run
   subst s_final s_4
@@ -61,7 +61,7 @@ def sha512_program_test_2 : program :=
 -- set_option profiler true in
 theorem sha512_program_test_2_sym (s0 s_final : ArmState)
   (h_s0_pc : read_pc s0 = 0x126538#64)
-  (h_s0_program : s0.program = sha512_program_test_2.find?)
+  (h_s0_program : s0.program = sha512_program_test_2)
   (h_s0_ok : read_err s0 = StateError.None)
   (h_run : s_final = run 6 s0) :
   read_err s_final = StateError.None := by
@@ -79,16 +79,6 @@ theorem sha512_program_test_2_sym (s0 s_final : ArmState)
 
 -- Test 3:
 
-variable (write : (n : Nat) → BitVec 64 → BitVec (n * 8) → Type → Type)
-
-theorem write_simplify_test_0 (a x y : BitVec 64)
-  (h : ((8 * 8) + 8 * 8) = 2 * ((8 * 8) / 8) * 8) :
-  write (2 * ((8 * 8) / 8)) a (BitVec.cast h (zeroExtend (8 * 8) x ++ (zeroExtend (8 * 8) y))) s
-  =
-  write 16 a (x ++ y) s := by
-  simp only [zeroExtend_eq, BitVec.cast_eq]
-
-
 def sha512_program_test_3 : program :=
   def_program
    [(0x1264c0#64 , 0xa9bf7bfd#32),      --  stp     x29, x30, [sp, #-16]!
@@ -105,7 +95,7 @@ theorem sha512_block_armv8_test_3_sym (s0 s_final : ArmState)
   (h_s0_ok : read_err s0 = StateError.None)
   (h_s0_sp_aligned : CheckSPAlignment s0 = true)
   (h_s0_pc : read_pc s0 = 0x1264c0#64)
-  (h_s0_program : s0.program = sha512_program_test_3.find?)
+  (h_s0_program : s0.program = sha512_program_test_3)
   (h_run : s_final = run 4 s0) :
   read_err s_final = StateError.None := by
   -- Prelude
@@ -157,7 +147,7 @@ theorem sha512_block_armv8_test_4_sym (s0 s_final : ArmState)
   (h_s0_ok : read_err s0 = StateError.None)
   (h_s0_sp_aligned : CheckSPAlignment s0 = true)
   (h_s0_pc : read_pc s0 = 0x1264c0#64)
-  (h_s0_program : s0.program = sha512_program_map.find?)
+  (h_s0_program : s0.program = sha512_program_map)
   (h_run : s_final = run 32 s0) :
   read_err s_final = StateError.None := by
   -- Prelude

--- a/Proofs/Sha512_block_armv8.lean
+++ b/Proofs/Sha512_block_armv8.lean
@@ -30,14 +30,14 @@ def sha512_program_test_1 : program :=
 theorem sha512_program_test_1_sym (s0 s_final : ArmState)
   (h_s0_pc : read_pc s0 = 0x126538#64)
   (h_s0_sp_aligned : CheckSPAlignment s0 = true)
-  (h_s0_program : s0.program = sha512_program_test_1.find?)
+  (h_s0_program : s0.program = sha512_program_test_1)
   (h_s0_ok : read_err s0 = StateError.None)
   (h_run : s_final = run 4 s0) :
   read_err s_final = StateError.None := by
   -- Prelude
   simp_all only [state_simp_rules, -h_run]
   -- Symbolic simulation
-  sym_n 4 h_s0_program
+  sym_n 4 --h_s0_program
   -- Final steps
   unfold run at h_run
   subst s_final s_4

--- a/Proofs/Test.lean
+++ b/Proofs/Test.lean
@@ -16,7 +16,7 @@ def test_s (inst : BitVec 32): ArmState :=
     pstate := zero_pstate,
     mem := (fun (_ : BitVec 64) => 0#8),
     -- Program: BitVec 64 → Option (BitVec 32)
-    program := (fun (a : BitVec 64) => if a == some 0#64 then inst else none),
+    program := [(0#64, inst)],
     error := StateError.None }
 
 -- 0x91000421#32: add x1, x1, 1

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -41,7 +41,7 @@ macro "init_next_step" h_s:ident : tactic =>
 
 -- Given 'h_step: s_next = stepi s', fetch_and_decode_inst unfolds stepi,
 -- simplifies fetch_inst and decode_raw_inst.
-macro "fetch_and_decode_inst" h_step:ident h_program:ident : tactic =>
+macro "fetch_and_decode_inst" h_step:ident /-h_program:ident-/ : tactic =>
   `(tactic|
     (-- unfold stepi at $h_step:ident
      -- rw [$h_s_ok:ident] at $h_step:ident
@@ -54,7 +54,7 @@ macro "fetch_and_decode_inst" h_step:ident h_program:ident : tactic =>
      -- simp (config := {ground := true}) at $h_step:ident
      -- repeat (rw [BitVec.ofFin_eq_ofNat] at $h_step:ident)
     simp only [*, stepi, state_simp_rules, minimal_theory, bitvec_rules] at $h_step:ident
-    rw [fetch_inst_from_program $h_program:ident] at $h_step:ident
+    rw [fetch_inst_from_program/- $h_program:ident-/] at $h_step:ident
     conv at $h_step:ident =>
       pattern Map.find? _ _
       simp (config := {ground := true}) only
@@ -128,7 +128,7 @@ macro "update_invariants" st_next:ident progname:ident
         try (rw [write_mem_bytes_program])
         assumption))
 
-def sym_one (curr_state_number : Nat) (prog : Lean.Ident) :
+def sym_one (curr_state_number : Nat) /-(prog : Lean.Ident)-/ :
     Lean.Elab.Tactic.TacticM Unit :=
   Lean.Elab.Tactic.withMainContext do
     let n_str := toString curr_state_number
@@ -161,7 +161,7 @@ def sym_one (curr_state_number : Nat) (prog : Lean.Ident) :
          (init_next_step $h_run:ident
           rename_i $st':ident $h_step_n':ident $h_run:ident
           -- Simulate one instruction
-          fetch_and_decode_inst $h_step_n':ident $prog:ident
+          fetch_and_decode_inst $h_step_n':ident /-$prog:ident-/
           (try clear $h_step_n:ident)
           exec_inst $h_step_n':ident
           -- Update invariants
@@ -175,12 +175,12 @@ def sym_one (curr_state_number : Nat) (prog : Lean.Ident) :
                 )))
 
 -- sym_n tactic symbolically simulates n instructions.
-elab "sym_n" n:num prog:ident : tactic => do
+elab "sym_n" n:num /-prog:ident-/ : tactic => do
   for i in List.range n.getNat do
-    sym_one i prog
+    sym_one i --prog
 
 -- sym_n tactic symbolically simulates n instructions from
 -- state number i.
-elab "sym_i_n" i:num n:num prog:ident : tactic => do
+elab "sym_i_n" i:num n:num /-prog:ident-/ : tactic => do
   for j in List.range n.getNat do
-    sym_one (i.getNat + j) prog
+    sym_one (i.getNat + j) --prog

--- a/Tests/LDSTTest.lean
+++ b/Tests/LDSTTest.lean
@@ -14,13 +14,13 @@ open BitVec
 -- The cosimulation tests do not cover instructions related to memory access
 -- TODO: use macros to simplify the tests
 
-def set_init_state (find? : Store (BitVec 64) (Option (BitVec 32))) : ArmState :=
+def set_init_state (program : Map (BitVec 64) (BitVec 32)) : ArmState :=
   let s := { gpr := (fun (_ : BitVec 5) => 0#64),
              sfp := (fun (_ : BitVec 5) => 0#128),
              pc := 0#64,
              pstate := zero_pstate,
              mem := (fun (_ : BitVec 64) => 0#8),
-             program := find?,
+             program := program,
              error := StateError.None}
   s
 
@@ -30,7 +30,7 @@ def ldr_gpr_unsigned_offset : program :=
   def_program [ (0x0#64, 0xb9400fe0#32) ]  -- ldr w0, [sp, #12]
 
 def ldr_gpr_unsigned_offset_state : ArmState :=
-  let s := set_init_state ldr_gpr_unsigned_offset.find?
+  let s := set_init_state ldr_gpr_unsigned_offset
   -- write 20 in 4 bytes to address 12
   let s := write_mem_bytes 4 12#64 20#32 s
   s
@@ -46,7 +46,7 @@ def str_gpr_post_index : program :=
   def_program [ (0x0#64, 0xf8003420#32) ] -- str x0, [x1], #3
 
 def str_gpr_post_index_state : ArmState :=
-  let s := set_init_state str_gpr_post_index.find?
+  let s := set_init_state str_gpr_post_index
   -- write 20 in gpr x0
   let s := write_gpr 64 0#5 20#64 s
   -- write 0 in gpr x1
@@ -64,7 +64,7 @@ def ldr_sfp_post_index : program :=
   def_program [ (0x0#64, 0xfc408420#32) ] -- ldr d0, [x1], #8
 
 def ldr_sfp_post_index_state : ArmState :=
-  let s := set_init_state ldr_sfp_post_index.find?
+  let s := set_init_state ldr_sfp_post_index
   let s := write_mem_bytes 8 0#64 20#64 s
   s
 
@@ -79,7 +79,7 @@ def str_stp_unsigned_offset : program :=
   def_program [ (0x0#64, 0x3d800420#32) ] -- str q0, [x1, #1]
 
 def str_sfp_unsigned_offset_state : ArmState :=
-  let s := set_init_state str_stp_unsigned_offset.find?
+  let s := set_init_state str_stp_unsigned_offset
   write_sfp 128 0#5 123#128 s
 
 def str_sfp_unsigned_offset_final_state : ArmState := run 1 str_sfp_unsigned_offset_state
@@ -92,7 +92,7 @@ def ldrb_unsigned_offset : program :=
   def_program [ (0x0#64, 0x39401020#32) ] -- ldrb x0, [x1, #4]
 
 def ldrb_unsigned_offset_state: ArmState :=
-  let s := set_init_state ldrb_unsigned_offset.find?
+  let s := set_init_state ldrb_unsigned_offset
   write_mem_bytes 1 4#64 20#8 s
   
 def ldrb_unsigned_offset_final_state : ArmState := run 1 ldrb_unsigned_offset_state
@@ -105,7 +105,7 @@ def strb_post_index : program :=
   def_program [ (0x0#64, 0x381fc420#32) ] -- strb x0, [x1], #-4
 
 def strb_post_index_state : ArmState :=
-  let s := set_init_state strb_post_index.find?
+  let s := set_init_state strb_post_index
   let s := write_gpr 64 1#5 5#64 s
   write_gpr 64 0#5 20#64 s
 
@@ -120,7 +120,7 @@ def ldp_gpr_pre_index : program :=
   def_program [ (0x0#64, 0xa9c00820#32) ] -- ldp x0, x2, [x1]!
 
 def ldp_gpr_pre_index_state : ArmState :=
-  let s := set_init_state ldp_gpr_pre_index.find?
+  let s := set_init_state ldp_gpr_pre_index
   write_mem_bytes 16 0#64 0x1234000000000000ABCD#128 s
 
 def ldp_gpr_pre_index_final_state : ArmState := run 1 ldp_gpr_pre_index_state
@@ -134,7 +134,7 @@ def stp_sfp_signed_offset : program :=
   def_program [ (0x0#64, 0xad008820#32) ] -- stp q0, q2, [q1,#1]
 
 def stp_sfp_signed_offset_state : ArmState :=
-  let s := set_init_state stp_sfp_signed_offset.find?
+  let s := set_init_state stp_sfp_signed_offset
   let s := write_sfp 128 0#5 0x1234#128 s
   write_sfp 128 2#5 0xabcd#128 s
 

--- a/Tests/SHA512ProgramTest.lean
+++ b/Tests/SHA512ProgramTest.lean
@@ -587,7 +587,7 @@ def init_sha512_test : ArmState :=
              pc  := 0x1264c0#64,
              pstate := zero_pstate,
              mem := (fun (_ : BitVec 64) => 0#8),
-             program := sha512_program_map.find?,
+             program := sha512_program_map,
              error := StateError.None }
   have h_input : 1024 = 1024 / 8 * 8 := by decide
   let s := write_mem_bytes (1024 / 8) input_address (h_input ▸ asm_input) s


### PR DESCRIPTION
### Description:

Change the program type to `Map` (courtesy @aqjune-aws).

Before this change, the `program` field in `ArmState` had the following type:
`Store (BitVec 64) (Option (BitVec 32))`
Now its type is:
`Map (BitVec 64) (BitVec 32)`

An immediate fallout is that the precondition for symbolic simulation/code reasoning will now become:
`s0.program = <program_map>`
instead of
`s0.program = <program_map>.find?`

### Testing:

`make all` succeeded.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
