### PR TITLE
Use List.replicate instead of List.create

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -149,6 +149,15 @@ abbrev partInstall (hi lo : Nat) (val : BitVec (hi - lo + 1)) (x : BitVec n): Bi
 
 example : (partInstall 3 0 0xC#4 0xAB0D#16 = 0xAB0C#16) := by native_decide
 
+def flattenTR {n : Nat} (xs : List (BitVec n)) (i : Nat)
+  (acc : BitVec len) (H : n > 0) : BitVec len :=
+  match xs with
+  | [] => acc
+  | x :: rest =>
+    have h : n = (i * n + n - 1 - i * n + 1) := by omega
+    let new_acc := (BitVec.partInstall (i * n + n - 1) (i * n) (h ▸ x) acc)
+    flattenTR rest (i + 1) new_acc H
+
 ----------------------------------------------------------------------
 
 attribute [ext] BitVec

--- a/Tests/AES-GCM/AESGCMProgramTests.lean
+++ b/Tests/AES-GCM/AESGCMProgramTests.lean
@@ -205,9 +205,11 @@ def Xi_res : List (BitVec 8) :=
 namespace enc
 
 -- AES_128_GCM encrypt test
-set_option maxRecDepth 2100 in
 def final_state : ArmState :=
-  aes_gcm_enc_kernel_test 1514 (revflat in_blocks) (revflat Xi) (revflat Htable)
+  have h : 8 * in_blocks.length = 4096 := by
+    unfold in_blocks
+    simp only [List.length_replicate]
+  aes_gcm_enc_kernel_test 1514 (h ▸ revflat in_blocks) (revflat Xi) (revflat Htable)
     rounds (revflat key) (revflat ivec)
 
 def final_ciphertext : BitVec 4096 := read_mem_bytes 512 out_address final_state
@@ -304,9 +306,11 @@ def Xi_res : List (BitVec 8) :=
 namespace enc
 
 -- AES_192_GCM encrypt test
-set_option maxRecDepth 2100 in
 def final_state : ArmState :=
-  aes_gcm_enc_kernel_test 1650 (revflat in_blocks) (revflat Xi) (revflat Htable)
+  have h : 8 * in_blocks.length = 4096 := by
+    unfold in_blocks
+    simp only [List.length_replicate]
+  aes_gcm_enc_kernel_test 1650 (h ▸ revflat in_blocks) (revflat Xi) (revflat Htable)
     rounds (revflat key) (revflat ivec)
 
 def final_ciphertext : BitVec 4096 := read_mem_bytes 512 out_address final_state
@@ -406,9 +410,11 @@ def Xi_res : List (BitVec 8) :=
 namespace enc
 
 -- AES_256_GCM encrypt test
-set_option maxRecDepth 2100 in
 def final_state : ArmState :=
-  aes_gcm_enc_kernel_test 1778 (revflat in_blocks) (revflat Xi) (revflat Htable)
+  have h : 8 * in_blocks.length = 4096 := by
+    unfold in_blocks
+    simp only [List.length_replicate]
+  aes_gcm_enc_kernel_test 1778 (h ▸ revflat in_blocks) (revflat Xi) (revflat Htable)
     rounds (revflat key) (revflat ivec)
 
 def final_ciphertext : BitVec 4096 := read_mem_bytes 512 out_address final_state

--- a/Tests/AES-GCM/AESGCMProgramTests.lean
+++ b/Tests/AES-GCM/AESGCMProgramTests.lean
@@ -31,8 +31,6 @@ open BitVec
   now we reply on this comment.
 
 -/
--- TODO: make revflat use tail recursive version of `flatten` might reduce this number
-set_option maxRecDepth 2100
 
 namespace AESGCMEncDecKernelProgramTest
 
@@ -207,6 +205,7 @@ def Xi_res : List (BitVec 8) :=
 namespace enc
 
 -- AES_128_GCM encrypt test
+set_option maxRecDepth 2100 in
 def final_state : ArmState :=
   aes_gcm_enc_kernel_test 1514 (revflat in_blocks) (revflat Xi) (revflat Htable)
     rounds (revflat key) (revflat ivec)
@@ -235,6 +234,7 @@ def final_ivec : BitVec 128 := read_mem_bytes 16 ivec_address final_state
 
 example : final_state.error = StateError.None := by native_decide
 example : final_hash = revflat Xi_res := by native_decide
+set_option maxRecDepth 2100 in
 example : final_ciphertext = revflat in_blocks := by native_decide
 example : final_ivec = revflat ivec_res := by native_decide
 
@@ -304,6 +304,7 @@ def Xi_res : List (BitVec 8) :=
 namespace enc
 
 -- AES_192_GCM encrypt test
+set_option maxRecDepth 2100 in
 def final_state : ArmState :=
   aes_gcm_enc_kernel_test 1650 (revflat in_blocks) (revflat Xi) (revflat Htable)
     rounds (revflat key) (revflat ivec)
@@ -332,6 +333,7 @@ def final_ivec : BitVec 128 := read_mem_bytes 16 ivec_address final_state
 
 example : final_state.error = StateError.None := by native_decide
 example : final_hash = revflat Xi_res := by native_decide
+set_option maxRecDepth 2100 in
 example : final_ciphertext = revflat in_blocks := by native_decide
 example : final_ivec = revflat ivec_res := by native_decide
 
@@ -404,6 +406,7 @@ def Xi_res : List (BitVec 8) :=
 namespace enc
 
 -- AES_256_GCM encrypt test
+set_option maxRecDepth 2100 in
 def final_state : ArmState :=
   aes_gcm_enc_kernel_test 1778 (revflat in_blocks) (revflat Xi) (revflat Htable)
     rounds (revflat key) (revflat ivec)
@@ -432,6 +435,7 @@ def final_ivec : BitVec 128 := read_mem_bytes 16 ivec_address final_state
 
 example : final_state.error = StateError.None := by native_decide
 example : final_hash = revflat Xi_res := by native_decide
+set_option maxRecDepth 2100 in
 example : final_ciphertext = revflat in_blocks := by native_decide
 example : final_ivec = revflat ivec_res := by native_decide
 

--- a/Tests/AES-GCM/AESV8ProgramTests.lean
+++ b/Tests/AES-GCM/AESV8ProgramTests.lean
@@ -52,11 +52,7 @@ namespace AESHWSetEncryptKeyProgramTest
 -- The assembly checks that kKey address cannot be 0, so we add 8 to the address
 def kKey_address : BitVec 64 := 0#64 + 8#64
 
-def kKey : List (BitVec 8) :=
-  List.create 0x00#8 32
-theorem length_of_kKey : kKey.length = 32 := by
-  unfold kKey
-  apply length_of_list_create
+def kKey : List (BitVec 8) := List.replicate 32 0x00#8
 
 -- Start address for the AES_KEY struct
 def key_address : BitVec 64 := 128#64 + 8#64
@@ -88,9 +84,7 @@ def aes_hw_set_encrypt_key_test (n : Nat) (key_bits : BitVec 64) : ArmState :=
              error := StateError.None
           }
   -- write kKey
-  have h : 8 * kKey.length = 32 * 8 := by
-    simp only [List.length_reverse, Nat.reduceMul, length_of_kKey]
-  let s := write_mem_bytes 32 kKey_address (h ▸ revflat kKey) s
+  let s := write_mem_bytes 32 kKey_address (revflat kKey) s
   -- write rcon
   let s := write_mem_bytes 48 rcon_address (revflat rcon) s
   let final_state := run n s
@@ -223,11 +217,7 @@ def aes_hw_encrypt_test (n : Nat) (in_block : BitVec 128)
 
 namespace AES128
 
-def in_block : List (BitVec 8) :=
-  List.create 0x00#8 16
-theorem length_of_in_block : in_block.length = 16 := by
-  unfold in_block
-  apply length_of_list_create
+def in_block : List (BitVec 8) := List.replicate 16 0x00#8
 
 def key_schedule : List (BitVec 32) := AESHWSetEncryptKeyProgramTest.AES128.rd_key
 def rounds : BitVec 64 := 10
@@ -238,9 +228,7 @@ def out_block : List (BitVec 8) :=
   ]
 
 def final_state : ArmState :=
-  have h : 8 * in_block.length = 128 := by
-    simp only [List.length_reverse, Nat.reduceMul, length_of_in_block]
-  aes_hw_encrypt_test 44 (h ▸ revflat in_block) rounds (revflat key_schedule)
+  aes_hw_encrypt_test 44 (revflat in_block) rounds (revflat key_schedule)
 def final_ciphertext : BitVec 128 := read_mem_bytes 16 out_address final_state
 
 example : final_state.error = StateError.None := by native_decide
@@ -252,11 +240,7 @@ end AES128
 
 namespace AES192
 
-def in_block : List (BitVec 8) :=
-  List.create 0x00#8 16
-theorem length_of_in_block : in_block.length = 16 := by
-  unfold in_block
-  apply length_of_list_create
+def in_block : List (BitVec 8) := List.replicate 16 0x00#8
 
 def key_schedule : List (BitVec 32) := AESHWSetEncryptKeyProgramTest.AES192.rd_key
 def rounds : BitVec 64 := 12
@@ -267,9 +251,7 @@ def out_block : List (BitVec 8) :=
   ]
 
 def final_state : ArmState :=
-  have h : 8 * in_block.length = 128 := by
-    simp only [List.length_reverse, Nat.reduceMul, length_of_in_block]
-  aes_hw_encrypt_test 52 (h ▸ revflat in_block) rounds (revflat key_schedule)
+  aes_hw_encrypt_test 52 (revflat in_block) rounds (revflat key_schedule)
 def final_ciphertext : BitVec 128 := read_mem_bytes 16 out_address final_state
 
 example : final_state.error = StateError.None := by native_decide
@@ -280,11 +262,7 @@ end AES192
 
 namespace AES256
 
-def in_block : List (BitVec 8) :=
-  List.create 0x00#8 16
-theorem length_of_in_block : in_block.length = 16 := by
-  unfold in_block
-  apply length_of_list_create
+def in_block : List (BitVec 8) := List.replicate 16 0x00#8
 
 def key_schedule : List (BitVec 32) := AESHWSetEncryptKeyProgramTest.AES256.rd_key
 def rounds : BitVec 64 := 14
@@ -295,9 +273,7 @@ def out_block : List (BitVec 8) :=
   ]
 
 def final_state : ArmState :=
-  have h : 8 * in_block.length = 128 := by
-    simp only [List.length_reverse, Nat.reduceMul, length_of_in_block]
-  aes_hw_encrypt_test 60 (h ▸ revflat in_block) rounds (revflat key_schedule)
+  aes_hw_encrypt_test 60 (revflat in_block) rounds (revflat key_schedule)
 def final_ciphertext : BitVec 128 := read_mem_bytes 16 out_address final_state
 
 example : final_state.error = StateError.None := by native_decide
@@ -351,7 +327,7 @@ def aes_hw_ctr32_encrypt_blocks_test (n : Nat)
   let final_state := run n s
   final_state
 
-def in_block : List (BitVec 8) := List.create 0x00#8 80
+def in_block : List (BitVec 8) := List.replicate 80 0x00#8
 
 def ivec : BitVec 128 := 0x0#128
 

--- a/Tests/AES-GCM/GCMProgramTests.lean
+++ b/Tests/AES-GCM/GCMProgramTests.lean
@@ -56,11 +56,7 @@ def In_address := 0x120#64
 def H : List (BitVec 64) :=
   [ 0x66e94bd4ef8a2c3b#64, 0x884cfa59ca342b2e#64 ]
 
-def Htable_before_init : List (BitVec 64) :=
-  List.create 0x0#64 32
-theorem length_of_Htable_before_init : Htable_before_init.length = 32 := by
-  unfold Htable_before_init
-  apply length_of_list_create
+def Htable_before_init : List (BitVec 64) := List.replicate 32 0x0#64
 
 def Htable : List (BitVec 64) :=
   [ 0x1099f4b39468565c#64, 0xcdd297a9df145877#64,
@@ -81,11 +77,7 @@ def Htable : List (BitVec 64) :=
     0x0#64, 0x0#64 ]
 
 def buf : List (BitVec 64) :=
-  List.create 0x2a2a2a2a2a2a2a2a#64 14
-
-theorem length_of_buf : buf.length = 14 := by
-  unfold buf
-  apply length_of_list_create
+  List.replicate 14 0x2a2a2a2a2a2a2a2a#64
 
 def X : List (List (BitVec 8)) :=
   [ [ 0x10#8, 0x54#8, 0x43#8, 0xb0#8, 0x2c#8, 0x4b#8, 0x1f#8, 0x24#8,
@@ -134,9 +126,7 @@ def init_gcm_init_test : ArmState :=
              error := StateError.None
            }
   let s := write_mem_bytes 16 H_address (revflat H) s
-  have h : 64 * Htable_before_init.length = 256 * 8 := by
-    simp only [List.length_reverse, Nat.reduceMul, length_of_Htable_before_init]
-  let s := write_mem_bytes 256 Htable_address (h ▸ revflat Htable_before_init) s
+  let s := write_mem_bytes 256 Htable_address (revflat Htable_before_init) s
   s
 
 def final_state : ArmState := run GCMInitV8Program.gcm_init_v8_program.length init_gcm_init_test
@@ -224,9 +214,7 @@ def X_before : List (BitVec 8) := List.get! X 2
 def X_after : List (BitVec 8) := List.get! X 3
 
 def final_state : ArmState :=
-  have h : 64 * buf.length = 896 := by
-    simp only [List.length_reverse, Nat.reduceMul, length_of_buf]
-  gcm_ghash_test 68 len (h ▸ revflat buf) (revflat X_before)
+  gcm_ghash_test 68 len (revflat buf) (revflat X_before)
 def final_hash : BitVec 128 := read_mem_bytes 16 x_address final_state
 
 example : final_hash = revflat X_after := by native_decide
@@ -242,9 +230,7 @@ def X_before : List (BitVec 8) := List.get! X 4
 def X_after : List (BitVec 8) := List.get! X 5
 
 def final_state : ArmState :=
-  have h : 64 * buf.length = 896 := by
-    simp only [List.length_reverse, Nat.reduceMul, length_of_buf]
-  gcm_ghash_test 63 len (h ▸ revflat buf) (revflat X_before)
+  gcm_ghash_test 63 len (revflat buf) (revflat X_before)
 def final_hash : BitVec 128 := read_mem_bytes 16 x_address final_state
 
 example : final_hash = revflat X_after := by native_decide
@@ -260,9 +246,7 @@ def X_before : List (BitVec 8) := List.get! X 5
 def X_after : List (BitVec 8) := List.get! X 6
 
 def final_state : ArmState :=
-  have h : 64 * buf.length = 896 := by
-    simp only [List.length_reverse, Nat.reduceMul, length_of_buf]
-  gcm_ghash_test 86 len (h ▸ revflat buf) (revflat X_before)
+  gcm_ghash_test 86 len (revflat buf) (revflat X_before)
 def final_hash : BitVec 128 := read_mem_bytes 16 x_address final_state
 
 example : final_hash = revflat X_after := by native_decide
@@ -278,9 +262,7 @@ def X_before : List (BitVec 8) := List.get! X 6
 def X_after : List (BitVec 8) := List.get! X 7
 
 def final_state : ArmState :=
-  have h : 64 * buf.length = 896 := by
-    simp only [List.length_reverse, Nat.reduceMul, length_of_buf]
-  gcm_ghash_test 97 len (h ▸ revflat buf) (revflat X_before)
+  gcm_ghash_test 97 len (revflat buf) (revflat X_before)
 def final_hash : BitVec 128 := read_mem_bytes 16 x_address final_state
 
 example : final_hash = revflat X_after := by native_decide
@@ -296,9 +278,7 @@ def X_before : List (BitVec 8) := List.get! X 7
 def X_after : List (BitVec 8) := List.get! X 8
 
 def final_state : ArmState :=
-  have h : 64 * buf.length = 896 := by
-    simp only [List.length_reverse, Nat.reduceMul, length_of_buf]
-  gcm_ghash_test 106 len (h ▸ revflat buf) (revflat X_before)
+  gcm_ghash_test 106 len (revflat buf) (revflat X_before)
 def final_hash : BitVec 128 := read_mem_bytes 16 x_address final_state
 
 example : final_hash = revflat X_after := by native_decide

--- a/Tests/Common.lean
+++ b/Tests/Common.lean
@@ -4,33 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author(s): Yan Peng
 -/
 import Arm.BitVec
-import Arm.FromMathlib
 
+-- TODO: BitVec.flatten could be optimized by tail recursion
 def revflat (x : List (BitVec n)) : BitVec (n * x.length) := 
   have h : x.reverse.length = x.length := by simp only [List.length_reverse]
   h ▸ BitVec.flatten (List.reverse x)
-
-def list_create_helper (x : BitVec n) (len : Nat) (acc : List (BitVec n)) : List (BitVec n) :=
-  if len <= 0 then acc
-  else list_create_helper x (len - 1) (List.cons x acc)
-
-def List.create (x : BitVec n) (len : Nat) : List (BitVec n) :=
-  list_create_helper x len []
-
--- Functional induction: https://lean-lang.org/blog/2024-5-17-functional-induction/
-theorem length_of_list_create_helper (x : BitVec n) : (list_create_helper x len acc).length = len + acc.length := by
-  -- induction len, acc using list_create_helper.induct x <;> (unfold list_create_helper; simp [*]; omega)
-  induction len, acc using list_create_helper.induct x
-  case case1 len acc hlen =>
-    unfold list_create_helper
-    simp only [Nat.le_zero_eq] at *
-    simp only [hlen, ↓reduceIte, Nat.zero_add]
-  case case2 len acc hlen ih =>
-    unfold list_create_helper
-    simp only [Nat.le_zero_eq, hlen, ↓reduceIte, ih, List.length_cons]
-    omega
-
-theorem length_of_list_create (x : BitVec n) : (List.create x len).length = len := by
-  unfold List.create
-  apply length_of_list_create_helper
-

--- a/Tests/Common.lean
+++ b/Tests/Common.lean
@@ -5,7 +5,6 @@ Author(s): Yan Peng
 -/
 import Arm.BitVec
 
--- TODO: BitVec.flatten could be optimized by tail recursion
 def revflat (x : List (BitVec n)) : BitVec (n * x.length) := 
   have h : x.reverse.length = x.length := by simp only [List.length_reverse]
   h ▸ BitVec.flatten (List.reverse x)


### PR DESCRIPTION
### Description:

This PR removes the definition of List.create:

`List.create (x : BitVec n) (len: Nat) : List (BitVec n)`

and instead uses `List.replicate` from the Lean library.

Due to better support in Lean for the length of the return value from `List.replicate`, a lot of the `have` lemmas for reasoning about length of `List.create` results are no longer needed. Therefore the code is simplified.

Some of the test vectors in Tests/AES-GCM/AESGCMProgramTests.lean are large and we are hitting default `maxRecDepth`, so it is set to higher (512->2100) in that file. 

### Testing:

`make all` and conformance testing was successful

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
