### PR TITLE
Add Simple Proofs (EOR)

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -616,6 +616,15 @@ protected theorem truncate_to_lsb_of_append (m n : Nat) (x : BitVec m) (y : BitV
   truncate n (x ++ y) = y := by
   simp only [truncate_append, Nat.le_refl, ↓reduceDIte, zeroExtend_eq]
 
+---------------------------- Shift Lemmas ---------------------------
+
+@[bitvec_rules]
+protected theorem shift_left_zero_eq (n : Nat) (x : BitVec n) : x <<< 0 = x := by
+    refine eq_of_toNat_eq ?_
+    apply Nat.eq_of_testBit_eq
+    intro i
+    simp only [toNat_shiftLeft, Nat.shiftLeft_zero, toNat_mod_cancel]
+
 ----------------------------------------------------------------------
 
 /- Bitvector pattern component syntax category, originally written by

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -96,10 +96,11 @@ def decode_shift (shift : BitVec 2) : ShiftType :=
   | 0b10 => ShiftType.ASR
   | 0b11 => ShiftType.ROR
 
+@[state_simp_rules]
 def shift_reg (bv : BitVec n) (st : ShiftType) (sa : BitVec 6)
   : BitVec n :=
   match st with
-  | ShiftType.LSL => BitVec.shiftLeft bv sa.toNat
+  | ShiftType.LSL => bv <<< sa.toNat -- BitVec.shiftLeft operation
   | ShiftType.LSR => ushiftRight bv sa.toNat
   | ShiftType.ASR => sshiftRight bv sa.toNat
   | ShiftType.ROR => rotateRight bv sa.toNat

--- a/Arm/Insts/DPR/Logical_shifted_reg.lean
+++ b/Arm/Insts/DPR/Logical_shifted_reg.lean
@@ -12,6 +12,7 @@ namespace DPR
 
 open BitVec
 
+@[state_simp_rules]
 def decode_op (opc : BitVec 2) (N : BitVec 1) : LogicalShiftedRegType :=
   match opc, N with
   | 0b00, 0b0 => LogicalShiftedRegType.AND
@@ -31,6 +32,7 @@ def logical_shifted_reg_update_pstate (bv : BitVec n) : PState :=
   let V := 0#1
   (make_pstate N Z C V)
 
+@[state_simp_rules]
 def exec_logical_shifted_reg_op (op : LogicalShiftedRegType) (opd1 : BitVec n) (opd2 : BitVec n)
   : (BitVec n × Option PState) :=
   match op with

--- a/Proofs/Simple.lean
+++ b/Proofs/Simple.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Shilpi Goel
+-/
+import Arm.Exec
+import Arm.Util
+import Tactics.Sym
+
+section simple
+
+open BitVec
+
+def eor_program : Program :=
+  def_program
+  [(0x4005a8#64 , 0xca000000#32)]      --  eor	x0, x0, x0
+
+@[bitvec_rules]
+theorem shift_left_zero_eq (n : Nat) (x : BitVec n) : x <<< 0 = x := by
+    refine eq_of_toNat_eq ?_
+    apply Nat.eq_of_testBit_eq
+    intro i
+    simp only [toNat_shiftLeft, Nat.shiftLeft_zero, toNat_mod_cancel]
+
+theorem small_asm_snippet_sym (s0 s_final : ArmState)
+  (h_s0_pc : read_pc s0 = 0x4005a8#64)
+  (h_s0_program : s0.program = eor_program)
+  (h_s0_err : read_err s0 = StateError.None)
+  (h_run : s_final = run 1 s0) :
+  read_gpr 64 0#5 s_final = 0x0#64 ∧
+  read_err s_final = StateError.None := by
+  -- Prelude
+  simp_all only [state_simp_rules, -h_run]
+  -- Symbolic Simulation
+  sym_n 1
+  -- Wrapping up the result:
+  unfold run at h_run
+  simp_all (config := {decide := true}) only [state_simp_rules, minimal_theory, bitvec_rules]
+  bv_decide
+  done
+
+end simple


### PR DESCRIPTION
### Description:

Added a new proof using symbolic simulation tactic to prove the simple program "EOR x0 x0 x0" results in register x0 being zero.

### Testing:

What tests have been run? Did `make all` succeed for your changes? 
Yes

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
