### PR TITLE
Add support for all DPI.Bitfield instructions

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -338,14 +338,9 @@ instance : Ord (BitVec n) where
 instance : Hashable (BitVec n) where
   hash x := ⟨Fin.ofNat' x.toNat (by decide)⟩
 
+-- Making sure that the following are decidable.
 example : 5#4 = 5#4 := by decide
 example : ¬ 4#4 = 5#4 := by decide
-
-instance BitVec.decLt {n} (a b : BitVec n) : Decidable (LT.lt a b) := Fin.decLt ..
-instance BitVec.decLe {n} (a b : BitVec n) : Decidable (LE.le a b) := Fin.decLe ..
-
--- The following can be discharged by the decide tactic only after
--- creating the instances above.
 example : 3#4 < 4#4 := by decide
 example : 3#4 <= 4#4 := by decide
 example : 4#4 >= 4#4 := by decide

--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -156,6 +156,9 @@ attribute [bitvec_rules] BitVec.rotateLeft_mod_eq_rotateLeft
 attribute [bitvec_rules] BitVec.getLsb_rotateLeft
 attribute [bitvec_rules] BitVec.rotateRight_mod_eq_rotateRight
 attribute [bitvec_rules] BitVec.getLsb_rotateRight
+attribute [bitvec_rules] BitVec.ofBool_true
+attribute [bitvec_rules] BitVec.ofBool_false
+attribute [bitvec_rules] BitVec.ofNat_eq_ofNat
 
 -- BitVec Simproc rules:
 -- See Lean/Meta/Tactic/Simp/BuiltinSimprocs for the built-in
@@ -195,6 +198,8 @@ attribute [bitvec_rules] BitVec.reduceToNat
 attribute [bitvec_rules] BitVec.reduceToInt
 attribute [bitvec_rules] BitVec.reduceOfInt
 attribute [bitvec_rules] BitVec.reduceOfNat
+attribute [bitvec_rules] BitVec.reduceEq
+attribute [bitvec_rules] BitVec.reduceNe
 attribute [bitvec_rules] BitVec.reduceLT
 attribute [bitvec_rules] BitVec.reduceLE
 attribute [bitvec_rules] BitVec.reduceGT

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -89,6 +89,7 @@ deriving DecidableEq, Repr
 
 instance : ToString ShiftType where toString a := toString (repr a)
 
+@[state_simp_rules]
 def decode_shift (shift : BitVec 2) : ShiftType :=
   match shift with
   | 0b00 => ShiftType.LSL
@@ -132,6 +133,8 @@ deriving DecidableEq, Repr
 
 instance : ToString LogicalImmType where toString a := toString (repr a)
 
+-- TODO: Define a simproc -- we expect this function to be called on concrete
+-- values only.
 def highest_set_bit (bv : BitVec n) : Option Nat := Id.run do
   let mut acc := none
   for i in List.reverse $ List.range n do
@@ -140,6 +143,8 @@ def highest_set_bit (bv : BitVec n) : Option Nat := Id.run do
          break
   return acc
 
+-- TODO: Define a simproc -- we expect this function to be called on concrete
+-- values only.
 def lowest_set_bit (bv : BitVec n) : Nat := Id.run do
   let mut acc := n
   for i in List.range n do
@@ -148,6 +153,8 @@ def lowest_set_bit (bv : BitVec n) : Nat := Id.run do
          break
   return acc
 
+-- TODO: Define a simproc -- we expect this function to be called on concrete
+-- values only.
 def invalid_bit_masks (immN : BitVec 1) (imms : BitVec 6) (immediate : Bool)
   (M : Nat) : Bool :=
   let len := highest_set_bit $ immN ++ ~~~imms
@@ -185,6 +192,8 @@ theorem M_divisible_by_esize_of_valid_bit_masks (immN : BitVec 1) (imms : BitVec
         . simp only [Decidable.not_not, imp_self]
     done
 
+-- TODO: Define a simproc -- we expect this function to be called on concrete
+-- values only.
 -- Resources on Arm bitmask immediate:
 --   https://developer.arm.com/documentation/dui0802/b/A64-General-Instructions/MOV--bitmask-immediate-
 --   https://kddnewton.com/2022/08/11/aarch64-bitmask-immediates.html

--- a/Arm/Insts/DPI/Bitfield.lean
+++ b/Arm/Insts/DPI/Bitfield.lean
@@ -3,8 +3,13 @@ Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author(s): Shilpi Goel, Nevine
 -/
--- For now, support only UBFM (immediate) 32- and 64-bit versions
--- (aliased as LSR and LSL (immediate) among other aliases)
+
+--   UBFM (immediate) 32- and 64-bit versions
+--        (aliased as LSL (immediate), LSR (immediate), UBFIZ, UBFX, UXTB, and UXTH)
+--   SBFM (immediate) 32- and 64-bit versions
+--        (aliased as ASR (immediate), SBFIZ, SBFX, SXTB, SXTH, and SXTW)
+--   BFM (immediate) 32- and 64-bit versions
+--        (aliased as BFC, BFI, and BFXIL)
 
 import Arm.Decode
 import Arm.Insts.Common
@@ -15,13 +20,19 @@ open BitVec
 
 @[state_simp_rules]
 def exec_bitfield (inst: Bitfield_cls) (s : ArmState) : ArmState :=
-  if inst.opc != 0b10#2 then
-    write_err (StateError.Unimplemented s!"Unsupported {inst} encountered!") s
+  let (err, inzero, extend) :=
+    match inst.opc with
+    | 0b00#2 => (false, true, true)   -- SBFM
+    | 0b01#2 => (false, false, false) -- BFM
+    | 0b10#2 => (false, true, false)  -- UBFM
+    | 0b11#2 => (true,  false, false) -- Undefined
+  if err then
+    write_err (StateError.Unimplemented s!"Illegal {inst} encountered!") s
   else
-    let immr5 := inst.immr >>> 5
-    let imms5 := inst.imms >>> 5
-    if (inst.sf = 1 ∧ inst.N ≠ 1) ∨
-      (inst.sf = 0 ∧ (inst.N ≠ 0 ∨ immr5 ≠ 0 ∨ imms5 ≠ 0)) then
+    let immr5 := lsb inst.immr 5
+    let imms5 := lsb inst.imms 5
+    if (inst.sf = 1#1 ∧ inst.N ≠ 1#1) ∨
+      (inst.sf = 0#1 ∧ (inst.N ≠ 0#1 ∨ immr5 ≠ 0#1 ∨ imms5 ≠ 0#1)) then
       write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
     else
       let datasize  := if inst.sf = 1#1 then 64 else 32
@@ -29,63 +40,52 @@ def exec_bitfield (inst: Bitfield_cls) (s : ArmState) : ArmState :=
       match wtmask with
       | none => write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
       | some (wmask, tmask) =>
+        let dst := if inzero then (BitVec.zero datasize) else (read_gpr_zr datasize inst.Rd s)
         let src := read_gpr_zr datasize inst.Rn s
-        let bot := (BitVec.ror src inst.immr.toNat) &&& wmask
-        let result := bot &&& tmask
+        -- Perform bitfield move on low bits
+        let bot := (dst &&& ~~~wmask) ||| ((BitVec.ror src inst.immr.toNat) &&& wmask)
+        -- Determine extension bits (sign, zero or dest register)
+        have h : 1 * datasize = datasize := by simp only [Nat.one_mul]
+        let src_s := BitVec.lsb src inst.imms.toNat
+        let top := if extend then
+                      h ▸ (BitVec.replicate datasize src_s)
+                   else
+                    dst
+        -- Combine extension bits and result bits
+        let result := (top &&& ~~~tmask) ||| (bot &&& tmask)
         let s := write_gpr_zr datasize inst.Rd result s
         let s := write_pc ((read_pc s) + 4#64) s
         s
 
-
 ----------------------------------------------------------------------
 
 /-- Generate random instructions of the DPI.Bitfield class. -/
-partial def Bitfield_cls.ubfm.rand : IO (Option (BitVec 32)) := do
+partial def Bitfield_cls.all.rand : IO (Option (BitVec 32)) := do
   -- Choose assignments based on sf that will not result in illegal instructions
   let sf := ← BitVec.rand 1
+  -- All legal instructions have the same values for sf and N fields.
   let N := sf
+  let opc ← pick_legal_bitfield_opc
   let immr := sf ++ (← BitVec.rand 5)
   let imms := sf ++ (← BitVec.rand 5)
   let (inst : Bitfield_cls) :=
     { sf    := sf,
-      opc   := ← pure 0b10#2,
+      opc   := opc
       N     := N,
       immr  := immr,
       imms  := imms,
-       -- TODO: Do we need to limit Rn and Rd to be up to 30 as in
-       -- Add_sub_imm?
       Rn    := ← BitVec.rand 5,
       Rd    := ← BitVec.rand 5 }
   pure (some (inst.toBitVec32))
-
--- (FIXME) We have a separate function to test LSR specifically
--- because we want to make sure it is hit during conformance testing,
--- which may not be the case when `Bitfield_cls.ubfm.rand` is used to
--- generate a small number of test cases.  Once we have conformance
--- testing running in CI, the volume of tests we'd be running will
--- eliminate the need to have alias-specific instruction generators.
-partial def Bitfield_cls.lsr.rand : IO (Option (BitVec 32)) := do
-  -- Specifically test the assignment that results in LSR
-  let sf := ← BitVec.rand 1
-  let N := sf
-  let immr := sf ++ (← BitVec.rand 5)
-  let imms := sf ++ 0b11111#5
-  let (inst : Bitfield_cls) :=
-    { sf    := sf,
-      opc   := ← pure 0b10#2,
-      N     := N,
-      immr  := immr,
-      imms  := imms,
-       -- TODO: Do we need to limit Rn and Rd to be up to 30 as in
-       -- Add_sub_imm?
-      Rn    := ← BitVec.rand 5,
-      Rd    := ← BitVec.rand 5 }
-  pure (some (inst.toBitVec32))
-
+ where pick_legal_bitfield_opc : IO (BitVec 2) := do
+  let opc ← BitVec.rand 2
+  if opc = 0b11#2 then
+    pick_legal_bitfield_opc
+  else
+    pure opc
 
 def Bitfield_cls.rand : List (IO (Option (BitVec 32))) :=
-  [ Bitfield_cls.lsr.rand,
-    Bitfield_cls.ubfm.rand ]
+  [ Bitfield_cls.all.rand ]
 
 ----------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ tests:
 
 .PHONY: cosim
 cosim:
-	time -p lake exe lnsym $(VERBOSE) --num_tests $(NUM_TESTS)
+	time -p lake exe lnsym $(VERBOSE) --num-tests $(NUM_TESTS)
 
 .PHONY: clean clean_all
 clean: 


### PR DESCRIPTION
### Description:

Add support for all `DPI.Bitfield` instructions. Also fix a typo in the Makefile re. cosimulation invocation.

### Testing:

`make all` and conformance testing succeeded.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
