### PR TITLE
Define `dsimproc`s for `decode_bit_masks` and `invalid_bit_masks`

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -327,6 +327,9 @@ def split (x : BitVec n) (e : Nat) (h : 0 < e): List (BitVec e) :=
 example : split 0xabcd1234#32 8 (by omega) = [0xab#8, 0xcd#8, 0x12#8, 0x34#8] :=
   by rfl
 
+/-- Get the width of a bitvector. -/
+protected def width (_ : BitVec n) : Nat := n
+
 ----------------------------------------------------------------------
 
 attribute [ext] BitVec

--- a/Arm/Insts/DPSFP/Advanced_simd_shift_by_immediate.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_shift_by_immediate.lean
@@ -17,7 +17,16 @@ open BitVec
 @[state_simp_rules]
 def exec_shift_right_vector
   (inst : Advanced_simd_shift_by_immediate_cls) (s : ArmState) : ArmState :=
-  if (lsb inst.immh 3) ++ inst.Q = 0b10#2 then
+  if inst.immh = 0b0000#4 then
+    -- Derived from the ASL line:
+    -- if immh == '0000' then SEE(asimdimm);
+    write_err
+     (StateError.Other
+       s!"Implementation Error: inst.immh is 0, which indicates \
+          an Advanced SIMD modified immediate class instruction! \
+          inst: {inst}")
+    s
+  else if ((lsb inst.immh 3) ++ inst.Q) = 0b10#2 then
     write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
   else
     let l := highest_set_bit inst.immh

--- a/Tactics/ExplodeStep.lean
+++ b/Tactics/ExplodeStep.lean
@@ -1,4 +1,5 @@
 import Arm.Exec
+import Tactics.Common
 import Lean
 
 /-
@@ -34,34 +35,6 @@ conclusion
 
 open Lean Elab Tactic Expr Meta
 open BitVec
-
-/- Get the string representation of `e` if it denotes a bitvector
-literal. The bitvector's width is not represented in the resulting
-string. -/
-def getBitVecString? (e : Expr) : MetaM (Option String) := do
-  let maybe_e_literal ← getBitVecValue? e
-  match maybe_e_literal with
-  | some ⟨_, value⟩ => return some (ToString.toString value.toNat)
-  | none => return none
-
-/- Get the string representation of `e` if it denotes a `PFlag`. -/
-def getPFlagString? (e : Expr) : MetaM (Option String) := OptionT.run do
-  match_expr e with
-  | PFlag.N => return "n_flag"
-  | PFlag.Z => return "z_flag"
-  | PFlag.C => return "c_flag"
-  | PFlag.V => return "v_flag"
-  | _       => panic! s!"[getPFlagString?] Unexpected expression: {e}"
-
-/- Get the string representation of `e` if it denotes a `StateField`. -/
-def getStateFieldString? (e : Expr) : MetaM (Option String) := OptionT.run do
-  match_expr e with
-  | StateField.GPR iExpr  => return ("x" ++ (← getBitVecString? iExpr))
-  | StateField.SFP iExpr  => return ("q" ++ (← getBitVecString? iExpr))
-  | StateField.PC         => return "pc"
-  | StateField.FLAG pExpr => getPFlagString? pExpr
-  | StateField.ERR        => return "err"
-  | _                     => panic! s!"[getStateFieldName?] Unexpected expression: {e}"
 
 partial def explodeWriteNest (goal : MVarId)
   (st_var : Expr) (e : Expr) (seen_fields : List String)


### PR DESCRIPTION
### Description:

Define `dsimproc`s for `decode_bit_masks` and `invalid_bit_masks`, both of which are functions we expect will be called with concrete arguments because they aid instruction decoding.

### Testing:

`make all` succeeded.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
