### PR TITLE
Use BitVec.cast instead of \t

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -294,7 +294,7 @@ def flattenTR {n : Nat} (xs : List (BitVec n)) (i : Nat)
   | [] => acc
   | x :: rest =>
     have h : n = (i * n + n - 1 - i * n + 1) := by omega
-    let new_acc := (BitVec.partInstall (i * n + n - 1) (i * n) (h ▸ x) acc)
+    let new_acc := (BitVec.partInstall (i * n + n - 1) (i * n) (BitVec.cast h x) acc)
     flattenTR rest (i + 1) new_acc H
 
 /-- Reverse bits of a bit-vector. -/
@@ -303,7 +303,7 @@ def reverse (x : BitVec n) : BitVec n :=
     if i < n then
       let xi := extractLsb i i x
       have h : i - i + 1 = (n - i - 1) - (n - i - 1) + 1 := by omega
-      let acc := BitVec.partInstall (n - i - 1) (n - i - 1) (h ▸ xi) acc
+      let acc := BitVec.partInstall (n - i - 1) (n - i - 1) (BitVec.cast h xi) acc
       reverseTR x (i + 1) acc
     else acc
   reverseTR x 0 $ BitVec.zero n
@@ -317,8 +317,8 @@ def split (x : BitVec n) (e : Nat) (h : 0 < e): List (BitVec e) :=
     if i < n/e then
       let lo := i * e
       let hi := lo + e - 1
-      have h₀ : e = hi - lo + 1 := by simp only [hi, lo]; omega
-      let part : BitVec e := h₀ ▸ extractLsb hi lo x
+      have h₀ : hi - lo + 1 = e := by simp only [hi, lo]; omega
+      let part : BitVec e := BitVec.cast h₀ (extractLsb hi lo x)
       let newacc := part :: acc
       splitTR x e h (i + 1) newacc
     else acc

--- a/Arm/Insts/DPI/Bitfield.lean
+++ b/Arm/Insts/DPI/Bitfield.lean
@@ -47,10 +47,11 @@ def exec_bitfield (inst: Bitfield_cls) (s : ArmState) : ArmState :=
         -- Determine extension bits (sign, zero or dest register)
         have h : 1 * datasize = datasize := by simp only [Nat.one_mul]
         let src_s := BitVec.lsb src inst.imms.toNat
-        let top := if extend then
-                      h ▸ (BitVec.replicate datasize src_s)
-                   else
-                    dst
+        let top : BitVec datasize :=
+          if extend then
+            BitVec.cast h $ BitVec.replicate datasize src_s
+          else
+            dst
         -- Combine extension bits and result bits
         let result := (top &&& ~~~tmask) ||| (bot &&& tmask)
         let s := write_gpr_zr datasize inst.Rd result s

--- a/Arm/Insts/DPI/Logical_imm.lean
+++ b/Arm/Insts/DPI/Logical_imm.lean
@@ -20,8 +20,7 @@ def decode_op (opc : BitVec 2) : LogicalImmType :=
   | 11#2 => LogicalImmType.ANDS
 
 def update_logical_imm_pstate (bv : BitVec n) : PState :=
-  have h: n - 1 - (n - 1) + 1 = 1 := by simp
-  let N := h ▸ (BitVec.lsb bv (n-1))
+  let N : BitVec 1 := BitVec.lsb bv (n-1)
   let Z := zero_flag_spec bv
   let C := 0#1
   let V := 0#1

--- a/Arm/Insts/DPI/Move_wide_imm.lean
+++ b/Arm/Insts/DPI/Move_wide_imm.lean
@@ -24,8 +24,8 @@ def exec_move_wide_imm (inst : Move_wide_imm_cls) (s : ArmState) : ArmState :=
     let result := if inst.opc = 0b11#2
                   then read_gpr datasize inst.Rd s
                   else BitVec.zero datasize
-    have h : pos + 15 - pos + 1 = 16 := by omega
-    let result := partInstall (pos + 15) pos (h ▸ inst.imm16) result
+    have h : 16 = pos + 15 - pos + 1 := by omega
+    let result := partInstall (pos + 15) pos (BitVec.cast h inst.imm16) result
     let result := if inst.opc = 0b00#2 then ~~~result else result
     -- State Update
     let s := write_gpr datasize inst.Rd result s

--- a/Arm/Insts/DPR/Data_processing_one_source.lean
+++ b/Arm/Insts/DPR/Data_processing_one_source.lean
@@ -54,8 +54,7 @@ private theorem opc_and_sf_constraint (x : BitVec 2) (y : BitVec 1)
 @[state_simp_rules]
 def exec_data_processing_rev
   (inst : Data_processing_one_source_cls) (s : ArmState) : ArmState :=
-  have H₀: 1 - 0 + 1 = 2 := by decide
-  let opc := H₀ ▸ extractLsb 1 0 inst.opcode
+  let opc : BitVec 2 := extractLsb 1 0 inst.opcode
   if H₁ : opc = 0b11#2 ∧ inst.sf = 0b0#1 then
     write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
   else

--- a/Arm/Insts/DPR/Logical_shifted_reg.lean
+++ b/Arm/Insts/DPR/Logical_shifted_reg.lean
@@ -25,8 +25,7 @@ def decode_op (opc : BitVec 2) (N : BitVec 1) : LogicalShiftedRegType :=
   | 0b11, 0b1 => LogicalShiftedRegType.BICS
 
 def logical_shifted_reg_update_pstate (bv : BitVec n) : PState :=
-  have h: n - 1 - (n - 1) + 1 = 1 := by simp
-  let N := h ▸ (BitVec.lsb bv (n-1))
+  let N : BitVec 1 := BitVec.lsb bv (n-1)
   let Z := zero_flag_spec bv
   let C := 0#1
   let V := 0#1

--- a/Arm/Insts/DPSFP/Advanced_simd_extract.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_extract.lean
@@ -35,7 +35,7 @@ def exec_advanced_simd_extract
     have h : (position + datasize - 1 - position + 1) = datasize := by
       rw [Nat.add_sub_assoc, Nat.add_sub_self_left]
       exact Nat.sub_add_cancel h_datasize; trivial
-    let s := write_sfp datasize inst.Rd (h ▸ result) s
+    let s := write_sfp datasize inst.Rd (BitVec.cast h result) s
     let s := write_pc ((read_pc s) + 4#64) s
     s
 

--- a/Arm/Insts/DPSFP/Advanced_simd_table_lookup.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_table_lookup.lean
@@ -21,7 +21,7 @@ def create_table (i : Nat) (regs : Nat) (Rn : BitVec 5) (table : BitVec (128 * r
   else
     let val := read_sfp 128 Rn s
     have h₁ : 128 = 128 * i + 127 - 128 * i + 1 := by omega
-    let table := BitVec.partInstall (128 * i + 127) (128 * i) (h₁ ▸ val) table
+    let table := BitVec.partInstall (128 * i + 127) (128 * i) (BitVec.cast h₁ val) table
     let Rn := (Rn + 1) % 32
     have h₂ : regs - (i + 1) < regs - i := by omega
     create_table (i + 1) regs Rn table s

--- a/Arm/Insts/DPSFP/Advanced_simd_three_different.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_three_different.lean
@@ -41,7 +41,7 @@ def pmull_op (e : Nat) (esize : Nat) (elements : Nat) (x : BitVec n)
     let elem_result := polynomial_mult element1 element2
     have h₁ : esize + esize = 2 * esize := by omega
     have h₂ : 2 * esize > 0 := by omega
-    let result := elem_set result e (2 * esize) (h₁ ▸ elem_result) h₂
+    let result := elem_set result e (2 * esize) (BitVec.cast h₁ elem_result) h₂
     have _ : elements - (e + 1) < elements - e := by omega
     pmull_op (e + 1) esize elements x y result H
   termination_by (elements - e)

--- a/Arm/Insts/DPSFP/Conversion_between_FP_and_Int.lean
+++ b/Arm/Insts/DPSFP/Conversion_between_FP_and_Int.lean
@@ -34,7 +34,7 @@ def fmov_general_aux (intsize : Nat) (fltsize : Nat) (op : FPConvOp)
     let fltval := extractLsb (fltsize - 1) 0 intval
     -- State Update
     have h₀ : fltsize - 1 - 0 + 1 = fltsize := by omega
-    let s := Vpart_write inst.Rd part fltsize (h₀ ▸ fltval) s
+    let s := Vpart_write inst.Rd part fltsize (BitVec.cast h₀ fltval) s
     let s := write_pc ((read_pc s) + 4#64) s
     s
   | _ => write_err (StateError.Other s!"fmov_general_aux called with non-FMOV op!") s

--- a/Arm/Insts/LDST/Advanced_simd_multiple_struct.lean
+++ b/Arm/Insts/LDST/Advanced_simd_multiple_struct.lean
@@ -60,59 +60,59 @@ def ld1_st1_operation (wback : Bool) (inst : Multiple_struct_inst_fields)
       match (rpt, selem) with
         | (1, 1) => -- one register
           if inst.L = 1#1 then -- LD1
-            let data := h ▸ read_mem_bytes datasize_bytes address s
+            let data := BitVec.cast h $ read_mem_bytes datasize_bytes address s
             let s := write_sfp datasize t data s
             (datasize_bytes, s)
           else -- ST1
-            let data := h.symm ▸ read_sfp datasize t s
+            let data := BitVec.cast h.symm $ read_sfp datasize t s
             let s := write_mem_bytes datasize_bytes address data s
             (datasize_bytes, s)
         | (2, 1) => -- two registers
           if inst.L = 1#1 then -- LD1
-            let data1 := h ▸ read_mem_bytes datasize_bytes address s
-            let data2 := h ▸ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 datasize_bytes)) s
+            let data1 := BitVec.cast h $ read_mem_bytes datasize_bytes address s
+            let data2 := BitVec.cast h $ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 datasize_bytes)) s
             let s := write_sfp datasize t data1 s
             let s := write_sfp datasize t2 data2 s
             (2 * datasize_bytes, s)
           else -- ST1
-            let data1 := h.symm ▸ read_sfp datasize t s
-            let data2 := h.symm ▸ read_sfp datasize t2 s
+            let data1 := BitVec.cast h.symm $ read_sfp datasize t s
+            let data2 := BitVec.cast h.symm $ read_sfp datasize t2 s
             let s := write_mem_bytes datasize_bytes address data1 s
             let s := write_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 datasize_bytes)) data2 s
             (2 * datasize_bytes, s)
         | (3, 1) => -- three registers
           if inst.L = 1#1 then -- LD1
-            let data1 := h ▸ read_mem_bytes datasize_bytes address s
-            let data2 := h ▸ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 datasize_bytes)) s
-            let data3 := h ▸ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 (2 * datasize_bytes))) s
+            let data1 := BitVec.cast h $ read_mem_bytes datasize_bytes address s
+            let data2 := BitVec.cast h $ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 datasize_bytes)) s
+            let data3 := BitVec.cast h $ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 (2 * datasize_bytes))) s
             let s := write_sfp datasize t data1 s
             let s := write_sfp datasize t2 data2 s
             let s := write_sfp datasize t3 data3 s
             (3 * datasize_bytes, s)
           else -- ST1
-            let data1 := h.symm ▸ read_sfp datasize t s
-            let data2 := h.symm ▸ read_sfp datasize t2 s
-            let data3 := h.symm ▸ read_sfp datasize t3 s
+            let data1 := BitVec.cast h.symm $ read_sfp datasize t s
+            let data2 := BitVec.cast h.symm $ read_sfp datasize t2 s
+            let data3 := BitVec.cast h.symm $ read_sfp datasize t3 s
             let s := write_mem_bytes datasize_bytes address data1 s
             let s := write_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 datasize_bytes)) data2 s
             let s := write_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 (2 * datasize_bytes))) data3 s
             (3 * datasize_bytes, s)
         | _ => -- four registers
           if inst.L = 1#1 then -- LD1
-            let data1 := h ▸ read_mem_bytes datasize_bytes address s
-            let data2 := h ▸ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 datasize_bytes)) s
-            let data3 := h ▸ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 (2 * datasize_bytes))) s
-            let data4 := h ▸ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 (3 * datasize_bytes))) s
+            let data1 := BitVec.cast h $ read_mem_bytes datasize_bytes address s
+            let data2 := BitVec.cast h $ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 datasize_bytes)) s
+            let data3 := BitVec.cast h $ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 (2 * datasize_bytes))) s
+            let data4 := BitVec.cast h $ read_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 (3 * datasize_bytes))) s
             let s := write_sfp datasize t data1 s
             let s := write_sfp datasize t2 data2 s
             let s := write_sfp datasize t3 data3 s
             let s := write_sfp datasize t4 data4 s
             (4 * datasize_bytes, s)
           else -- ST1
-            let data1 := h.symm ▸ read_sfp datasize t s
-            let data2 := h.symm ▸ read_sfp datasize t2 s
-            let data3 := h.symm ▸ read_sfp datasize t3 s
-            let data4 := h.symm ▸ read_sfp datasize t4 s
+            let data1 := BitVec.cast h.symm $ read_sfp datasize t s
+            let data2 := BitVec.cast h.symm $ read_sfp datasize t2 s
+            let data3 := BitVec.cast h.symm $ read_sfp datasize t3 s
+            let data4 := BitVec.cast h.symm $ read_sfp datasize t4 s
             let s := write_mem_bytes datasize_bytes address data1 s
             let s := write_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 datasize_bytes)) data2 s
             let s := write_mem_bytes datasize_bytes (address + (BitVec.ofNat 64 (2 * datasize_bytes))) data3 s

--- a/Arm/Insts/LDST/Reg_imm.lean
+++ b/Arm/Insts/LDST/Reg_imm.lean
@@ -48,10 +48,10 @@ def reg_imm_operation (inst_str : String) (op : BitVec 1)
       match op with
       | 0#1 => -- STORE
         let data := ldst_read SIMD? datasize Rt s
-        write_mem_bytes (datasize / 8) address (h.symm ▸ data) s
+        write_mem_bytes (datasize / 8) address (BitVec.cast h.symm data) s
       | _ => -- LOAD
         let data := read_mem_bytes (datasize / 8) address s
-        if SIMD? then write_sfp datasize Rt (h.symm ▸ data) s
+        if SIMD? then write_sfp datasize Rt (BitVec.cast h data) s
         else write_gpr regsize.get! Rt (zeroExtend regsize.get! data) s
     if wback then
       let address := if postindex then address + offset else address

--- a/Arm/Insts/LDST/Reg_pair.lean
+++ b/Arm/Insts/LDST/Reg_pair.lean
@@ -56,13 +56,13 @@ def reg_pair_operation (inst : Reg_pair_cls) (inst_str : String) (signed : Bool)
           exact Nat.div_mul_cancel H1
         have h2 : datasize + datasize = 2 * datasize := by
           simp_arith
-        have h3 : (2 * (datasize / 8) * 8) = datasize + datasize := by
+        have h3 : datasize + datasize = 2 * (datasize / 8) * 8 := by
           rw [Nat.mul_assoc, h1, h2]
         let data1 := ldst_read inst.SIMD? datasize inst.Rt s
         let data2 := ldst_read inst.SIMD? datasize inst.Rt2 s
         -- (FIXME): Implement and check HaveLSE2Ext and BigEndian features.
         let full_data := data2 ++ data1
-        write_mem_bytes (2 * (datasize / 8)) address (h3 ▸ full_data) s
+        write_mem_bytes (2 * (datasize / 8)) address (BitVec.cast h3 full_data) s
       | _ => -- LOAD
         have h4 : datasize - 1 - 0 + 1 = datasize := by
           simp; apply Nat.sub_add_cancel H2
@@ -74,8 +74,8 @@ def reg_pair_operation (inst : Reg_pair_cls) (inst_str : String) (signed : Bool)
           let s := write_gpr 64 inst.Rt (signExtend 64 data1) s
           write_gpr 64 inst.Rt2 (signExtend 64 data2) s
         else
-          let s:= ldst_write inst.SIMD? datasize inst.Rt (h4 ▸ data1) s
-          ldst_write inst.SIMD? datasize inst.Rt2 (h5 ▸ data2) s
+          let s:= ldst_write inst.SIMD? datasize inst.Rt (BitVec.cast h4 data1) s
+          ldst_write inst.SIMD? datasize inst.Rt2 (BitVec.cast h5 data2) s
     if inst.wback then
       let address := if inst.postindex then address + offset else address
       write_gpr 64 inst.Rn address s

--- a/Arm/Insts/LDST/Reg_unscaled_imm.lean
+++ b/Arm/Insts/LDST/Reg_unscaled_imm.lean
@@ -33,11 +33,11 @@ def exec_ldstur
       let s := if memop = MemOp.MemOp_STORE then
                  have h : datasize = datasize / 8 * 8 := by omega
                  let data := read_sfp datasize inst.Rt s
-                 write_mem_bytes (datasize / 8) address (h ▸ data) s
+                 write_mem_bytes (datasize / 8) address (BitVec.cast h data) s
                else
                  have h : datasize / 8 * 8 = datasize := by omega
                  let data := read_mem_bytes (datasize / 8) address s
-                 write_sfp datasize inst.Rt (h ▸ data) s
+                 write_sfp datasize inst.Rt (BitVec.cast h data) s
       let s := write_pc ((read_pc s) + 4#64) s
       s
 

--- a/Proofs/SHA512/Sha512_block_armv8_rules.lean
+++ b/Proofs/SHA512/Sha512_block_armv8_rules.lean
@@ -157,7 +157,8 @@ theorem sha512h_rule_2 (a b c d e : BitVec 128) :
   repeat (unfold BitVec.partInstall; simp)
   unfold sha512h compression_update_t1 elem_set elem_get partInstall sigma_big_1 ch ror
   simp only [Nat.reduceAdd, Nat.reduceSub, Nat.reduceMul, Nat.sub_zero, reduceAllOnes,
-    reduceZeroExtend, Nat.zero_mul, reduceHShiftLeft, reduceNot, reduceAnd, Nat.one_mul]
+    reduceZeroExtend, Nat.zero_mul, reduceHShiftLeft, reduceNot, reduceAnd, Nat.one_mul,
+    BitVec.cast_eq]
   bv_decide
 
 end sha512_block_armv8_rules

--- a/Specs/AESCommon.lean
+++ b/Specs/AESCommon.lean
@@ -49,8 +49,8 @@ def SubBytes_aux (i : Nat) (op : BitVec 128) (out : BitVec 128)
   else
     let idx := (extractLsb (i * 8 + 7) (i * 8) op).toNat
     let val := extractLsb (idx * 8 + 7) (idx * 8) $ BitVec.flatten SBOX
-    have h₁ : idx * 8 + 7 - idx * 8 = i * 8 + 7 - i * 8 := by omega
-    let out := BitVec.partInstall (i * 8 + 7) (i * 8) (h₁ ▸ val) out
+    have h₁ : idx * 8 + 7 - idx * 8 + 1 = i * 8 + 7 - i * 8 + 1 := by omega
+    let out := BitVec.partInstall (i * 8 + 7) (i * 8) (BitVec.cast h₁ val) out
     have _ : 15 - i < 16 - i := by omega
     SubBytes_aux (i + 1) op out
   termination_by (16 - i)
@@ -69,17 +69,17 @@ def MixColumns_aux (c : Nat)
     let lo := c * 8
     let hi := lo + 7
     have h₁ : hi - lo + 1 = 8 := by omega
-    let in0_byte := h₁ ▸ extractLsb hi lo in0
-    let in1_byte := h₁ ▸ extractLsb hi lo in1
-    let in2_byte := h₁ ▸ extractLsb hi lo in2
-    let in3_byte := h₁ ▸ extractLsb hi lo in3
-    let val0 := h₁.symm ▸ (FFmul02 in0_byte ^^^ FFmul03 in1_byte ^^^ in2_byte ^^^ in3_byte)
+    let in0_byte := BitVec.cast h₁ $ extractLsb hi lo in0
+    let in1_byte := BitVec.cast h₁ $ extractLsb hi lo in1
+    let in2_byte := BitVec.cast h₁ $ extractLsb hi lo in2
+    let in3_byte := BitVec.cast h₁ $ extractLsb hi lo in3
+    let val0 := BitVec.cast h₁.symm $ (FFmul02 in0_byte ^^^ FFmul03 in1_byte ^^^ in2_byte ^^^ in3_byte)
     let out0 := BitVec.partInstall hi lo val0 out0
-    let val1 := h₁.symm ▸ (FFmul02 in1_byte ^^^ FFmul03 in2_byte ^^^ in3_byte ^^^ in0_byte)
+    let val1 := BitVec.cast h₁.symm $ (FFmul02 in1_byte ^^^ FFmul03 in2_byte ^^^ in3_byte ^^^ in0_byte)
     let out1 := BitVec.partInstall hi lo val1 out1
-    let val2 := h₁.symm ▸ (FFmul02 in2_byte ^^^ FFmul03 in3_byte ^^^ in0_byte ^^^ in1_byte)
+    let val2 := BitVec.cast h₁.symm $ (FFmul02 in2_byte ^^^ FFmul03 in3_byte ^^^ in0_byte ^^^ in1_byte)
     let out2 := BitVec.partInstall hi lo val2 out2
-    let val3 := h₁.symm ▸ (FFmul02 in3_byte ^^^ FFmul03 in0_byte ^^^ in1_byte ^^^ in2_byte)
+    let val3 := BitVec.cast h₁.symm $ (FFmul02 in3_byte ^^^ FFmul03 in0_byte ^^^ in1_byte ^^^ in2_byte)
     let out3 := BitVec.partInstall hi lo val3 out3
     have _ : 3 - c < 4 - c := by omega
     MixColumns_aux (c + 1) in0 in1 in2 in3 out0 out1 out2 out3 FFmul02 FFmul03

--- a/Specs/GCMV8.lean
+++ b/Specs/GCMV8.lean
@@ -39,10 +39,12 @@ def pmult (x: BitVec (m + 1)) (y : BitVec (n + 1)) : BitVec (m + n + 1) :=
     (acc : BitVec (m + n + 1)) : BitVec (m + n + 1) :=
     if i < n + 1 then
       let acc := acc <<< 1
-      have h : n + (m + 1) = m + n + 1 := by omega
-      let tmp := if getMsb y i then (BitVec.zero n) ++ x else h ▸ BitVec.zero (m + n + 1)
-      let acc := h ▸ acc ^^^ tmp
-      pmultTR x y (i + 1) (h ▸ acc)
+      have h : m + n + 1 = n + (m + 1) := by omega
+      let tmp := if getMsb y i
+                 then (BitVec.zero n) ++ x
+                 else BitVec.cast h (BitVec.zero (m + n + 1))
+      let acc := (BitVec.cast h acc) ^^^ tmp
+      pmultTR x y (i + 1) (BitVec.cast h.symm acc)
     else acc
   pmultTR x y 0 (BitVec.zero (m + n + 1))
 
@@ -66,13 +68,16 @@ def pdiv (x: BitVec n) (y : BitVec m) (h : 0 < m): BitVec n :=
     (acc : BitVec n) : BitVec n :=
     if i < n then
       have h2 : (n - i - 1) - (n - i - 1) + 1 = 1 := by omega
-      let xi : BitVec 1 := h2 ▸ extractLsb (n - i - 1) (n - i - 1) x
-      have h3 : m = m - 1 - 0 + 1 := by omega
-      let zi : BitVec m := h3 ▸ extractLsb (m - 1) 0 ((GCMV8.reduce y z) ++ xi)
-      have h1 : 1 = GCMV8.degree y - GCMV8.degree y + 1 := by omega
-      let bit : BitVec 1 := h1 ▸ extractLsb (GCMV8.degree y) (GCMV8.degree y) zi
+      let xi : BitVec 1 := BitVec.cast h2 (extractLsb (n - i - 1) (n - i - 1) x)
+      have h3 : m - 1 - 0 + 1 = m := by omega
+      let zi : BitVec m :=
+        BitVec.cast h3 (extractLsb (m - 1) 0 ((GCMV8.reduce y z) ++ xi))
+      have h1 : GCMV8.degree y - GCMV8.degree y + 1 = 1 := by omega
+      let bit : BitVec 1 :=
+        BitVec.cast h1 $ extractLsb (GCMV8.degree y) (GCMV8.degree y) zi
       have h4 : 1 = (n - i - 1) - (n - i - 1) + 1 := by omega
-      let newacc : BitVec n := partInstall (n - i - 1) (n - i - 1) (h4 ▸ bit) acc
+      let newacc : BitVec n :=
+        partInstall (n - i - 1) (n - i - 1) (BitVec.cast h4 bit) acc
       pdivTR x y (i + 1) zi newacc
     else acc
   pdivTR x y 0 (BitVec.zero m) (BitVec.zero n)
@@ -82,15 +87,18 @@ example : pdiv 0x1a#5 0b10#2 (by omega) = 0b1101#5 := by rfl
 example : pdiv 0b1#1 0b10#2 (by omega) = 0b0#1 := by rfl
 
 /-- Performs modulus of polynomials over GF(2). -/
-def pmod (x : BitVec n) (y : BitVec (m + 1)) (H : m > 0) : BitVec m :=
+def pmod (x : BitVec n) (y : BitVec (m + 1)) (H : 0 < m) : BitVec m :=
   let rec pmodTR (x : BitVec n) (y : BitVec (m + 1)) (p : BitVec (m + 1))
-    (i : Nat) (r : BitVec m) (H : m > 0) : BitVec m :=
+    (i : Nat) (r : BitVec m) (H : 0 < m) : BitVec m :=
     if i < n then
       let xi := getLsb x i
       have h : m - 1 + 1 = m := by omega
-      let tmp := if xi then extractLsb (m - 1) 0 p else h ▸ BitVec.zero m
-      let r := h ▸ r ^^^ tmp
-      pmodTR x y (GCMV8.reduce y (p <<< 1)) (i + 1) (h ▸ r) H
+      let tmp : BitVec (m - 1 + 1) :=
+        if xi
+        then extractLsb (m - 1) 0 p
+        else BitVec.cast h.symm (BitVec.zero m)
+      let r := (BitVec.cast h.symm r) ^^^ tmp
+      pmodTR x y (GCMV8.reduce y (p <<< 1)) (i + 1) (BitVec.cast h r) H
     else r
   if y = 0 then 0 else pmodTR x y (GCMV8.reduce y 1) 0 (BitVec.zero m) H
 
@@ -164,7 +172,10 @@ def GCMInitV8 (H : BitVec 128) : (List (BitVec 128)) :=
   let H10 := ((hi H11) ^^^ (lo H11)) ++ ((hi H9) ^^^ (lo H9))
   [H0, H1, H2, H3, H4, H5, H6, H7, H8, H9, H10, H11]
 
--- TODO: This test could not be proved using rfl
+-- TODO: This test could not be proved using rfl nor decide
+-- set_option maxRecDepth 1000000 in
+-- set_option maxHeartbeats 1000000 in
+-- unseal pmod.pmodTR degree.degreeTR pmult.pmultTR reverse.reverseTR in
 example :  GCMInitV8 0x66e94bd4ef8a2c3b884cfa59ca342b2e#128 =
   [ 0xcdd297a9df1458771099f4b39468565c#128,
     0x62d81a7fe5da3296dd4b631a4b7c0e2b#128,
@@ -186,7 +197,7 @@ example :  GCMInitV8 0x66e94bd4ef8a2c3b884cfa59ca342b2e#128 =
 -/
 def GCMGmultV8 (H : BitVec 128) (Xi : List (BitVec 8)) (h : 8 * Xi.length = 128)
   : (List (BitVec 8)):=
-  split (GCMV8.gcm_polyval H (h ▸ BitVec.flatten Xi)) 8 (by omega)
+  split (GCMV8.gcm_polyval H (BitVec.cast h (BitVec.flatten Xi))) 8 (by omega)
 
 example : GCMGmultV8 0xcdd297a9df1458771099f4b39468565c#128
   [ 0x10#8, 0x54#8, 0x43#8, 0xb0#8, 0x2c#8, 0x4b#8, 0x1f#8, 0x24#8,
@@ -214,13 +225,15 @@ def GCMGhashV8 (H : BitVec 128) (Xi : List (BitVec 8))
       let lo := m - (i + 1) * 128
       let hi := lo + 127
       have h2 : hi - lo + 1 = 128 := by omega
-      let inpi : BitVec 128 := h2 ▸ extractLsb hi lo inp
+      let inpi : BitVec 128 := BitVec.cast h2 $ extractLsb hi lo inp
       let Xj := GCMV8.gcm_ghash_block H Xi inpi
       GCMGhashV8TR H Xj inp (i + 1) h1
     else Xi
   have h3 : 128 ∣ 8 * inp.length := by omega
   have h4 : 8 * Xi.length = 128 := by omega
-  split (GCMGhashV8TR H (h4 ▸ BitVec.flatten Xi) (BitVec.flatten inp) 0 h3) 8 (by omega)
+  let flat_Xi := BitVec.cast h4 $ BitVec.flatten Xi
+  let flat_inp := BitVec.flatten inp
+  split (GCMGhashV8TR H flat_Xi flat_inp 0 h3) 8 (by omega)
 
 example : GCMGhashV8 0xcdd297a9df1458771099f4b39468565c#128
   [ 0xa2#8, 0xc9#8, 0x9c#8, 0x56#8, 0xeb#8, 0xa7#8, 0x91#8, 0xf6#8,

--- a/Tests/AES-GCM/AESGCMProgramTests.lean
+++ b/Tests/AES-GCM/AESGCMProgramTests.lean
@@ -209,7 +209,7 @@ def final_state : ArmState :=
   have h : 8 * in_blocks.length = 4096 := by
     unfold in_blocks
     simp only [List.length_replicate]
-  aes_gcm_enc_kernel_test 1514 (h ▸ revflat in_blocks) (revflat Xi) (revflat Htable)
+  aes_gcm_enc_kernel_test 1514 (BitVec.cast h $ revflat in_blocks) (revflat Xi) (revflat Htable)
     rounds (revflat key) (revflat ivec)
 
 def final_ciphertext : BitVec 4096 := read_mem_bytes 512 out_address final_state
@@ -310,7 +310,7 @@ def final_state : ArmState :=
   have h : 8 * in_blocks.length = 4096 := by
     unfold in_blocks
     simp only [List.length_replicate]
-  aes_gcm_enc_kernel_test 1650 (h ▸ revflat in_blocks) (revflat Xi) (revflat Htable)
+  aes_gcm_enc_kernel_test 1650 (BitVec.cast h $ revflat in_blocks) (revflat Xi) (revflat Htable)
     rounds (revflat key) (revflat ivec)
 
 def final_ciphertext : BitVec 4096 := read_mem_bytes 512 out_address final_state
@@ -414,7 +414,7 @@ def final_state : ArmState :=
   have h : 8 * in_blocks.length = 4096 := by
     unfold in_blocks
     simp only [List.length_replicate]
-  aes_gcm_enc_kernel_test 1778 (h ▸ revflat in_blocks) (revflat Xi) (revflat Htable)
+  aes_gcm_enc_kernel_test 1778 (BitVec.cast h $ revflat in_blocks) (revflat Xi) (revflat Htable)
     rounds (revflat key) (revflat ivec)
 
 def final_ciphertext : BitVec 4096 := read_mem_bytes 512 out_address final_state

--- a/Tests/AES-GCM/AESV8ProgramTests.lean
+++ b/Tests/AES-GCM/AESV8ProgramTests.lean
@@ -316,10 +316,10 @@ def aes_hw_ctr32_encrypt_blocks_test (n : Nat)
              }
   -- write in_block
   have h1 : 8 * in_block.length = in_block.length * 8 := by omega
-  let s := write_mem_bytes in_block.length in_address (h1 ▸ (revflat in_block)) s
+  let s := write_mem_bytes in_block.length in_address (BitVec.cast h1 (revflat in_block)) s
   -- write key_schedule
-  have h2 : 4 * key_schedule.length * 8 = 32 * key_schedule.length := by omega
-  let s := write_mem_bytes (4 * key_schedule.length) key_address (h2 ▸ (revflat key_schedule)) s
+  have h2 : 32 * key_schedule.length = 4 * key_schedule.length * 8 := by omega
+  let s := write_mem_bytes (4 * key_schedule.length) key_address (BitVec.cast h2 (revflat key_schedule)) s
   -- write rounds
   let s := write_mem_bytes 8 round_address rounds s
   -- write ivec

--- a/Tests/AES-GCM/GCMProgramTests.lean
+++ b/Tests/AES-GCM/GCMProgramTests.lean
@@ -164,7 +164,7 @@ def gcm_gmult_final_state : ArmState :=
             }
   let s := write_mem_bytes 16 x_address flat_X_before s
   have h : 2048 = (128 * 16 / 8) * 8 := by decide
-  let s := write_mem_bytes (128 * 16 / 8) Htable_address (h ▸ (revflat Htable)) s
+  let s := write_mem_bytes (128 * 16 / 8) Htable_address (BitVec.cast h (revflat Htable)) s
   let final_state := run GCMGmultV8Program.gcm_gmult_v8_program.length s
   final_state
 
@@ -201,7 +201,7 @@ def gcm_ghash_test (n : Nat) (len : BitVec 64) (buf : BitVec 896)
            }
   let s := write_mem_bytes 16 x_address X_before s
   have h : 2048 = (128 * 16 / 8) * 8 := by decide
-  let s := write_mem_bytes (128 * 16 / 8) Htable_address (h ▸ (revflat Htable)) s
+  let s := write_mem_bytes (128 * 16 / 8) Htable_address (BitVec.cast h (revflat Htable)) s
   let s := write_mem_bytes 112 In_address buf s
   let final_state := run n s
   final_state

--- a/Tests/Common.lean
+++ b/Tests/Common.lean
@@ -6,5 +6,5 @@ Author(s): Yan Peng
 import Arm.BitVec
 
 def revflat (x : List (BitVec n)) : BitVec (n * x.length) := 
-  have h : x.reverse.length = x.length := by simp only [List.length_reverse]
-  h ▸ BitVec.flatten (List.reverse x)
+  have h : n * x.reverse.length = n * x.length := by simp only [List.length_reverse]
+  BitVec.cast h $ BitVec.flatten (List.reverse x)

--- a/Tests/SHA2/SHA512ProgramTest.lean
+++ b/Tests/SHA2/SHA512ProgramTest.lean
@@ -591,9 +591,9 @@ def init_sha512_test : ArmState :=
              program := sha512_program_map,
              error := StateError.None }
   have h_input : 1024 = 1024 / 8 * 8 := by decide
-  let s := write_mem_bytes (1024 / 8) input_address (h_input ▸ asm_input) s
+  let s := write_mem_bytes (1024 / 8) input_address (BitVec.cast h_input asm_input) s
   have h_H0 : 512 = 512 / 8 * 8 := by decide
-  let s := write_mem_bytes (512 / 8) ctx_address (h_H0 ▸ SHA512_H0) s
+  let s := write_mem_bytes (512 / 8) ctx_address (BitVec.cast h_H0 SHA512_H0) s
   let s := write_mem_bytes (80 * 8) ktbl_address SHA512_K s
   s
 


### PR DESCRIPTION
### Description:

Use of `BitVec.cast` is preferred instead of `\t`. This PR rewrites uses of `\t` to `BitVec.cast`. 

In doing so, it causes the theorem `sha512h_rule_2` in `Proofs/SHA512/Sha512_block_armv8_rules.lean` to fail. This is because extra `BitVec.cast` is introduced into the goal that could not be recognized by `bv_decide`. By simplifying the goal using rule `BitVec.cast_eq`, `BitVec.cast` is removed from the goal and the theorem goes through again.

### Testing:

"make all" and cosimulation on Graviton2 and Graviton3 succeed.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
