### PR TITLE
Add tests for GCMV8 spec functions

### DIFF
--- a/Tests/AES-GCM/GCMSpecTests.lean
+++ b/Tests/AES-GCM/GCMSpecTests.lean
@@ -15,7 +15,8 @@ def flatten_H := BitVec.flatten GCMProgramTestParams.H
 def spec_table := GCMV8.GCMInitV8 flatten_H
 
 example : extractLsb (12 * 128) 0 (revflat spec_table)
-        = extractLsb (12 * 128) 0 (revflat GCMProgramTestParams.Htable) := by native_decide
+        = extractLsb (12 * 128) 0 (revflat GCMProgramTestParams.Htable)
+        := by native_decide
 
 end GCMInitV8SpecTest
 
@@ -27,8 +28,7 @@ def H : BitVec 128 :=
 def X0 := List.get! GCMProgramTestParams.X 0
 def X1 := List.get! GCMProgramTestParams.X 1
 
-example : have h : 8 * X0.length = 128 := by simp [List.length]
-  GCMV8.GCMGmultV8 H X0 h = X1 := by native_decide
+example : GCMV8.GCMGmultV8 H X0 (by simp [List.length]) = X1 := by native_decide
 
 end GCMGmultV8SpecTest
 
@@ -43,12 +43,10 @@ def X3 := List.get! GCMProgramTestParams.X 3
 def inp1 := List.replicate 16 0x2a#8
 def inp2 := List.replicate 32 0x2a#8
 
-example : have h1 : X1.length = 16 := by simp [List.length]
-  have h2 : 16 ∣ inp1.length := by simp [List.length]; omega
-  GCMV8.GCMGhashV8 H X1 inp1 h1 h2 = X2 := by native_decide
+example : GCMV8.GCMGhashV8 H X1 inp1 (by simp [List.length])
+            (by simp [List.length]; omega) = X2 := by native_decide
 
-example : have h1 : X2.length = 16 := by simp [List.length]
-  have h2 : 16 ∣ inp2.length := by simp [List.length]; omega
-  GCMV8.GCMGhashV8 H X2 inp2 h1 h2 = X3 := by native_decide
+example : GCMV8.GCMGhashV8 H X2 inp2 (by simp [List.length])
+            (by simp [List.length]; omega) = X3 := by native_decide
 
 end GCMGhashV8SpecTest

--- a/Tests/AES-GCM/GCMSpecTests.lean
+++ b/Tests/AES-GCM/GCMSpecTests.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Yan Peng
+-/
+import Arm.BitVec
+import Specs.GCMV8
+import Tests.«AES-GCM».GCMProgramTests
+
+open BitVec
+
+namespace GCMInitV8SpecTest
+
+def flatten_H := BitVec.flatten GCMProgramTestParams.H
+def spec_table := GCMV8.GCMInitV8 flatten_H
+
+example : extractLsb (12 * 128) 0 (revflat spec_table)
+        = extractLsb (12 * 128) 0 (revflat GCMProgramTestParams.Htable) := by native_decide
+
+end GCMInitV8SpecTest
+
+namespace GCMGmultV8SpecTest
+
+def H : BitVec 128 :=
+  List.get! GCMProgramTestParams.Htable 1 ++
+  List.get! GCMProgramTestParams.Htable 0
+def X0 := List.get! GCMProgramTestParams.X 0
+def X1 := List.get! GCMProgramTestParams.X 1
+
+example : have h : 8 * X0.length = 128 := by simp [List.length]
+  GCMV8.GCMGmultV8 H X0 h = X1 := by native_decide
+
+end GCMGmultV8SpecTest
+
+namespace GCMGhashV8SpecTest
+
+def H : BitVec 128 :=
+  List.get! GCMProgramTestParams.Htable 1 ++
+  List.get! GCMProgramTestParams.Htable 0
+def X1 := List.get! GCMProgramTestParams.X 1
+def X2 := List.get! GCMProgramTestParams.X 2
+def X3 := List.get! GCMProgramTestParams.X 3
+def inp1 := List.replicate 16 0x2a#8
+def inp2 := List.replicate 32 0x2a#8
+
+example : have h1 : X1.length = 16 := by simp [List.length]
+  have h2 : 16 ∣ inp1.length := by simp [List.length]; omega
+  GCMV8.GCMGhashV8 H X1 inp1 h1 h2 = X2 := by native_decide
+
+example : have h1 : X2.length = 16 := by simp [List.length]
+  have h2 : 16 ∣ inp2.length := by simp [List.length]; omega
+  GCMV8.GCMGhashV8 H X2 inp2 h1 h2 = X3 := by native_decide
+
+end GCMGhashV8SpecTest

--- a/Tests/LDSTTest.lean
+++ b/Tests/LDSTTest.lean
@@ -138,12 +138,7 @@ def stp_sfp_signed_offset_state : ArmState :=
   let s := write_sfp 128 0#5 0x1234#128 s
   write_sfp 128 2#5 0xabcd#128 s
 
-#eval stp_sfp_signed_offset_state
-
 def stp_sfp_signed_offset_final_state : ArmState := run 1 stp_sfp_signed_offset_state
-
-#eval stp_sfp_signed_offset_final_state
-#eval (read_mem_bytes 32 16#64 stp_sfp_signed_offset_final_state)
 
 example : (read_mem_bytes 32 16#64 stp_sfp_signed_offset_final_state) =
   0xabcd00000000000000000000000000001234#256 := by native_decide

--- a/Tests/Tests.lean
+++ b/Tests/Tests.lean
@@ -12,5 +12,6 @@ import «Tests».LDSTTest
 import «Tests».«AES-GCM».AESSpecTest
 import «Tests».«AES-GCM».AESGCMSpecTest
 import «Tests».«AES-GCM».GCMProgramTests
+import «Tests».«AES-GCM».GCMSpecTests
 import «Tests».«AES-GCM».AESV8ProgramTests
 import «Tests».«AES-GCM».AESGCMProgramTests


### PR DESCRIPTION
### Description:

This PR adds tests for GCMV8 functions including `GCMInitV8`, `GCMGmultV8` and `GCMGhashV8`. These serves as examples for showing the relationship between the specification and the ARM assembly functions. 

### Testing:

"make all" succeeds and cosimulation test succeeds on Graviton2 and Graviton3 machines.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
