### PR TITLE
chore: add code workspace for first time use of repo

### DIFF
--- a/LNSym.code-workspace
+++ b/LNSym.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+	],
+	"settings": {
+		"files.insertFinalNewline": true,
+		"files.trimTrailingWhitespace": true,
+	},
+	"extensions": {
+		"recommendations": [
+			"leanprover.lean4"
+		]
+	}
+}
+


### PR DESCRIPTION
This makes it easy(er) to launch a new VSCode instance on a fresh machine, by pointing it to `code LNSym.code-workspace`. Discovered this necessity when setting a new laptop!