### PR TITLE
Add general statements/proofs for partial/total correctness

### DIFF
--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -14,7 +14,7 @@ def init_cosim_state : ArmState :=
   { gpr := (fun (_ : BitVec 5) => 0#64),
     sfp := (fun (_ : BitVec 5) => 0#128),
     pc  := 0#64,
-    pstate := zero_pstate,
+    pstate := PState.zero,
     mem := (fun (_ : BitVec 64) => 0#8),
     program := Map.empty,
     error := StateError.None }

--- a/Arm/State.lean
+++ b/Arm/State.lean
@@ -142,14 +142,15 @@ structure ArmState where
   error      : StateError
 deriving Repr
 
-def ArmState.default : ArmState :=
-  { gpr := (fun (_ : BitVec 5) => 0#64),
-    sfp := (fun (_ : BitVec 5) => 0#128),
+def ArmState.default : ArmState := { 
+    gpr := fun _ => 0#64,
+    sfp := fun _ => 0#128),
     pc := 0#64,
     pstate := PState.zero,
-    mem := (fun (_ : BitVec 64) => 0#8),
+    mem := fun _ => 0#8,
     program := [],
-    error := StateError.None}
+    error := StateError.None
+  }
 
 ---- Basic State Accessors and Updaters (except memory) ----
 

--- a/Arm/State.lean
+++ b/Arm/State.lean
@@ -144,7 +144,7 @@ deriving Repr
 
 def ArmState.default : ArmState := { 
     gpr := fun _ => 0#64,
-    sfp := fun _ => 0#128),
+    sfp := fun _ => 0#128,
     pc := 0#64,
     pstate := PState.zero,
     mem := fun _ => 0#8,

--- a/Arm/State.lean
+++ b/Arm/State.lean
@@ -115,6 +115,9 @@ structure PState where
   v : BitVec 1
 deriving DecidableEq, Repr
 
+def PState.zero : PState :=
+  { n := 0#1, z := 0#1, c := 0#1, v := 0#1 }
+
 @[ext]
 structure ArmState where
   -- General-purpose registers: register 31 is the stack pointer.
@@ -138,6 +141,15 @@ structure ArmState where
   -- execution based off an erroneous state is invalid.
   error      : StateError
 deriving Repr
+
+def ArmState.default : ArmState :=
+  { gpr := (fun (_ : BitVec 5) => 0#64),
+    sfp := (fun (_ : BitVec 5) => 0#128),
+    pc := 0#64,
+    pstate := PState.zero,
+    mem := (fun (_ : BitVec 64) => 0#8),
+    program := [],
+    error := StateError.None}
 
 ---- Basic State Accessors and Updaters (except memory) ----
 
@@ -442,9 +454,6 @@ def write_pstate (pstate : PState) (s : ArmState) : ArmState :=
 @[state_simp_rules]
 def make_pstate (n z c v : BitVec 1) : PState :=
   { n, z, c, v }
-
-def zero_pstate : PState :=
-  { n := 0#1, z := 0#1, c := 0#1, v := 0#1 }
 
 @[state_simp_rules]
 def read_err (s : ArmState) : StateError :=

--- a/Correctness.lean
+++ b/Correctness.lean
@@ -1,0 +1,8 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Shilpi Goel
+-/
+-- This module serves as the root of the `Correctness` library.
+-- Import modules here that should be built as part of the library.
+import «Correctness».Correctness

--- a/Correctness/Basic.lean
+++ b/Correctness/Basic.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Leonardo de Moura
+-/
+
+/--
+A system with state `σ` is defined by a step relation `next`.
+-/
+class Sys (σ : Type) where
+  some : σ -- σ is not the empty type
+  next : σ → σ
+
+def Sys.run [Sys σ] (s : σ) (n : Nat) : σ :=
+  match n with
+  | 0 => s
+  | n+1 => run (next s) n
+
+open Sys
+
+theorem run_succ [Sys σ] (s : σ) (n : Nat) : run s (n+1) = run (next s) n :=
+  rfl
+
+theorem run_succ' [Sys σ] (s : σ) (n : Nat) : run s (n+1) = next (run s n) := by
+  induction n generalizing s with
+  | zero => simp [run]
+  | succ n ih => rw [run, ih, run_succ]
+
+theorem next_run [Sys σ] (s : σ) (i : Nat) : next (run s i) = run s (i + 1) := by
+  induction i generalizing s with
+  | zero => simp [run]
+  | succ i ih => rw [run, run, ← ih]
+
+theorem run_run [Sys σ] (s : σ) (i j : Nat) : run (run s i) j = run s (i+j) := by
+  induction i generalizing s with
+  | zero => simp [run]
+  | succ i ih => rw [run, ih, Nat.succ_add, run]
+
+/--
+A program's specification can be characterized by the following three predicates:
+- `pre`:  pre-condition
+- `post`: post-condition
+- `exit`: exit states
+-/
+class Spec (σ : Type) where
+  pre  : σ → Prop
+  post : σ → Prop
+  exit : σ → Prop
+
+/--
+In assertional methods, we specify interesting "cutpoints" of a program using
+`cut` and assertions that must hold at those cutpoints using `assert`.
+-/
+class Spec' (σ : Type) extends Spec σ where
+  cut    : σ → Prop
+  assert : σ → Prop
+
+/--
+Partial correctness: involves showing that for any state `s` satisfying `pre`,
+the predicate `post` holds at the first `exit` state reachable from `s` (if some
+such state exists).
+-/
+def PartialCorrectness (σ : Type) [Sys σ] [Spec σ] : Prop :=
+  open Spec in
+  ∀ (s : σ) n, pre s → exit (run s n) → ∃ m, m ≤ n ∧ exit (run s m) ∧ post (run s m)
+
+/--
+Termination: the machine starting from a state `s` satisfying `pre` eventually
+reaches an `exit` state.
+-/
+def Termination (σ : Type) [Sys σ] [Spec σ] : Prop :=
+  open Spec in
+  ∀ (s : σ), pre s → ∃ n, exit (run s n)

--- a/Correctness/Correctness.lean
+++ b/Correctness/Correctness.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Leonardo de Moura
+-/
+
+/-
+Lean4 Formalization of the ACL2 paper
+"Verification Condition Generation via Theorem Proving"
+(https://link.springer.com/chapter/10.1007/11916277_25)
+-/
+
+import Correctness.Iterate
+import Correctness.Basic
+
+namespace Correctness
+
+open Sys (next run)
+open Spec (pre post exit)
+open Spec' (cut assert)
+open Iterate (iterate iterate_eq)
+open Classical
+
+theorem not_forall_eq_exists_not (p : α → Prop) : (¬ ∀ x, p x) = ∃ x, ¬ p x := by
+  apply propext
+  constructor
+  · intro h₁
+    apply byContradiction
+    intro h₂
+    have := Iff.mp not_exists h₂
+    simp at this
+    contradiction
+  · intro h₁ h₂
+    have ⟨a, ha⟩ := h₁
+    have := h₂ a
+    contradiction
+
+/- Result from page 2: I1,I2,I3 implies Partial Correctness. -/
+theorem by_inv [Sys σ] [Spec σ] (inv : σ → Prop)
+    (ini  : ∀ s, pre s → inv s)  -- I1
+    (step : ∀ s, inv s → ¬ exit s → inv (next s)) -- I2
+    (stop : ∀ s, inv s → exit s → post s)  -- I3
+    : PartialCorrectness σ :=
+  fun s n hp he =>
+    let rec find (i : Nat) (h : inv (run s i)) (hle : i ≤ n) : ∃ m : Nat, m ≤ n ∧ exit (run s m) ∧ post (run s m) :=
+      if hn : i < n then
+        if he : exit (run s i) then
+          ⟨i, Nat.le_of_lt hn, he, stop _ h he⟩
+        else
+          have : inv (run s (i+1)) := by
+            rw [← next_run]; exact step _ h he
+          find (i+1) this hn
+      else
+        have := Nat.ge_of_not_lt hn
+        have := Nat.le_antisymm this hle
+        have hinv : inv (run s n) := by subst this; assumption
+        have hpost : post (run s n) := stop _ hinv he
+        ⟨n, Nat.le_refl _, he, hpost⟩
+    find 0 (ini _ hp) (Nat.zero_le _)
+
+noncomputable def csteps [Sys σ] [Spec' σ] (s : σ) (i : Nat) : Nat :=
+  iterate (fun (s, i) => if cut s then .inl i else .inr (next s, i + 1)) (s, i)
+
+theorem csteps_eq [Sys σ] [Spec' σ] (s : σ) (i : Nat)
+        : csteps s i = if cut s then i
+                       else csteps (next s) (i + 1) := by
+  unfold csteps
+  conv => lhs; rw [iterate_eq]
+  by_cases cut s <;> simp [*]
+
+/--
+Helper theorem for defining `d` described in the paper.
+-/
+theorem d_ex [Sys σ] [Spec' σ] : ∃ d : σ, cut d ↔ ∀ s : σ, cut s := by
+  by_cases ∀ s : σ, cut s
+  next h =>
+    exists Sys.some
+    constructor
+    · intro; assumption
+    · intro; exact h Sys.some
+  next h =>
+    have ⟨d, hd⟩ := Eq.mp (not_forall_eq_exists_not ..) h
+    exists d
+    constructor
+    · intro; contradiction
+    · intro h'; have := h' d; contradiction
+
+noncomputable def d [Sys σ] [Spec' σ] : σ :=
+  choose d_ex
+
+theorem d_spec [Sys σ] [Spec' σ] : cut (d : σ) ↔ ∀ s : σ, cut s :=
+  choose_spec d_ex
+
+noncomputable def nextc [Sys σ] [Spec' σ] (s : σ) : σ :=
+  if cut (run s (csteps s 0)) then
+    run s (csteps s 0)
+  else
+    d
+
+theorem csteps_cut [Sys σ] [Spec' σ] {s : σ} (h : cut s) (i : Nat) : csteps s i = i := by
+  rw [csteps_eq]
+  simp [*]
+
+theorem csteps_not_cut [Sys σ] [Spec' σ] {s : σ} (h₁ : ¬ cut s) (h₂ : csteps (next s) (i+1) = j) : csteps s i = j := by
+  rw [csteps_eq]
+  simp [h₁]
+  assumption
+
+/--
+Helper theorem. Given a state `s` and `cut (run s n)` for `n`, then there is
+`k` such that `csteps s 0 = k` and `k ≤ n`.
+Note that `cut (run s n)` ensures `csteps s 0` terminates because we will find a `cut` in at most `n` steps.
+-/
+theorem find_next_cut [Sys σ] [Spec' σ] (s : σ) (hc : cut (run s n)) :
+  ∃ k : Nat, csteps s 0 = k ∧ k ≤ n ∧ cut (run s k) :=
+  let rec loop (s' : σ) (i : Nat) (hle : i ≤ n) (heq : s' = run s i) :
+    ∃ k : Nat, csteps s' i = k ∧ k ≤ n ∧ cut (run s k) :=
+     if hn : i < n then
+       if hc : cut s' then
+         have := csteps_cut hc i
+         ⟨i, this, hle, by subst s'; assumption⟩
+       else
+         have ⟨k, hs, hkn, hck⟩ := loop (next s') (i+1) hn (by simp [heq, run_succ'])
+         ⟨k, csteps_not_cut hc hs, hkn, hck⟩
+     else
+       have hin : i = n := by omega
+       have := csteps_cut hc i
+       ⟨n, by subst s' i; assumption, Nat.le_refl .., by assumption⟩
+  loop s 0 (Nat.zero_le ..) rfl
+
+/--
+Theorem 1 from page 5. It shows that if V1-V4 hold, then we have partial
+correctness.
+-/
+theorem partial_correctness_from_verification_conditions [Sys σ] [Spec' σ]
+    (v1 : ∀ s : σ, pre s → assert s)
+    (v2 : ∀ s : σ, exit s → cut s)
+    (v3 : ∀ s : σ, assert s → exit s → post s)
+    (v4 : ∀ s : σ, assert s → ¬ exit s → assert (nextc (next s)))
+    : PartialCorrectness σ :=
+  fun s n hp hexit =>
+    let rec find (i : Nat) (h : assert (run s i)) (hle : i ≤ n) : ∃ m : Nat, m ≤ n ∧ exit (run s m) ∧ post (run s m) :=
+      if hn : i < n then
+        if he : exit (run s i) then
+          ⟨i, Nat.le_of_lt hn, he, v3 _ h he⟩
+        else
+          have : cut (run (run s (i + 1)) (n - Nat.succ i)) := by
+            rw [run_run, Nat.add_one, Nat.add_sub_cancel' hn]
+            exact v2 _ hexit
+          have ⟨k, hk, hlek, hck⟩ := find_next_cut (run s (i+1)) this
+          have hle' : i + 1 + k ≤ n := by
+            exact (Nat.le_sub_iff_add_le' hn).mp hlek
+          have : assert (nextc (next (run s i))) := v4 _ h he
+          have h' : assert (run s (i + 1 + k)) := by
+            rw [run_run] at hck
+            rw [nextc, next_run, hk, run_run] at this
+            simp [hck] at this
+            assumption
+          have : n - (i + 1 + k) < n - i := by
+            apply Nat.sub_lt_sub_left; assumption; simp_arith
+          find (i + 1 + k) h' hle'
+      else
+        have := Nat.ge_of_not_lt hn
+        have := Nat.le_antisymm this hle
+        have ha : assert (run s n) := by subst this; assumption
+        have hpost : post (run s n) := v3 _ ha hexit
+        ⟨n, Nat.le_refl _, hexit, hpost⟩
+    find 0 (v1 _ hp) (Nat.zero_le ..)
+
+end Correctness

--- a/Correctness/Iterate.lean
+++ b/Correctness/Iterate.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Leonardo de Moura
+-/
+
+namespace Iterate
+/-
+The purpose of Iterate is to implement partial tail recursion that is
+available in ACL2 using `defpun`; see
+https://www.cs.utexas.edu/~moore/acl2/manuals/current/manual/?topic=ACL2____DEFPUN.
+
+We define the `def iterate (f : α → Sum β α) (a : α) : β`, and prove
+the equation:
+```
+     iterate f a = match f a with
+                  | .inl b => b
+                  | .inr a => iterate f a
+```
+-/
+
+def test (f : α → Sum β α) (a : α) : Bool :=
+  match f a with
+  | .inl _ => true
+  | .inr _ => false
+
+def base [Inhabited β] (f : α → Sum β α) (a : α) : β :=
+  match f a with
+  | .inl b => b
+  | .inr _ => default
+
+def next (f : α → Sum β α) (a : α) (h : ¬ test f a) : α :=
+  match he : f a with
+  | .inl _ => by unfold test at h; simp [he] at h
+  | .inr a => a
+
+def iterate' [Inhabited β] (f : α → Sum β α) (a : α) (fuel : Nat) : Option β :=
+  if fuel = 0 then
+    none
+  else if h : test f a then
+    some (base f a)
+  else
+    iterate' f (next f a h) (fuel - 1)
+
+theorem iterate'_eq [Inhabited β] (f : α → Sum β α) (a : α) (h : fuel ≠ 0)
+        : iterate' f a fuel = if ht : test f a then some (base f a) else iterate' f (next f a ht) (fuel - 1) := by
+  conv => lhs; unfold iterate'; simp [*]
+
+theorem iterate'_succ_eq [Inhabited β] (f : α → Sum β α) (a : α) (fuel : Nat)
+        : iterate' f a (fuel + 1) = if ht : test f a then some (base f a) else iterate' f (next f a ht) fuel := by
+   conv => lhs; unfold iterate'; simp only [↓reduceIte, Nat.add_one_sub_one]
+
+variable [Inhabited β] {f : α → Sum β α}
+
+theorem fuel_ne_zero (h : iterate' f a fuel ≠ none) : fuel ≠ 0 := by
+  intro hn; simp [hn] at h; unfold iterate' at h; simp_arith at h
+
+theorem iterate'_next_ne_none (h : iterate' f a fuel ≠ none) (ht : ¬ test f a) : iterate' f (next f a ht) (fuel - 1) ≠ none := by
+  have : fuel ≠ 0 := fuel_ne_zero h
+  unfold iterate' at h
+  simp [*] at h
+  assumption
+
+theorem fuel_extra (h : iterate' f a fuel ≠ none) : iterate' f a (fuel + 1) = iterate' f a fuel := by
+  have : fuel ≠ 0 := fuel_ne_zero h
+  have := iterate'_eq f a this
+  have := iterate'_succ_eq f a fuel
+  by_cases test f a <;> simp [*]
+  next ht =>
+    have := iterate'_next_ne_none h ht
+    have ih := fuel_extra this
+    have : 1 ≤ fuel := by cases fuel <;> simp [*]; contradiction
+    have hf₁ : fuel - 1 + 1 = fuel := Nat.sub_add_cancel this
+    simp [hf₁] at ih
+    simp [ih]
+
+theorem fuel_extra' (h : iterate' f a fuel ≠ none) :  iterate' f a (fuel + 1) ≠ none := by
+  have : fuel ≠ 0 := fuel_ne_zero h
+  have := iterate'_eq f a this
+  have := iterate'_succ_eq f a fuel
+  by_cases test f a
+  next => simp_arith [*]
+  next ht =>
+    have := iterate'_next_ne_none h ht
+    have ih := fuel_extra' this
+    have : 1 ≤ fuel := by cases fuel <;> simp [*]; contradiction
+    have hf₁ : fuel - 1 + 1 = fuel := Nat.sub_add_cancel this
+    have : fuel + 1 - 1 = fuel := Nat.pred_succ _
+    simp [hf₁] at ih
+    unfold iterate'
+    have : fuel + 1 ≠ 0 := by simp_arith
+    simp [*]
+
+theorem fuel_extra_ge (h₁ : fuel₁ ≤ fuel₂) (h₂ : iterate' f a fuel₁ ≠ none) : iterate' f a fuel₂ = iterate' f a fuel₁ :=
+  if h : fuel₁ = fuel₂ then
+    by simp [h] at h₂; simp [*]
+  else
+    have : fuel₁ ≠ 0 := fuel_ne_zero h₂
+    have h₁' : fuel₁ + 1 ≤ fuel₂ := Nat.lt_of_le_of_ne h₁ h
+    have h₂' : iterate' f a (fuel₁ + 1) ≠ none := fuel_extra' h₂
+    have he := fuel_extra h₂
+    have ih := fuel_extra_ge h₁' h₂'
+    by simp [he] at ih; assumption
+termination_by (fuel₂ - fuel₁)
+
+theorem iterate'_det (h₁ : iterate' f a fuel₁ ≠ none) (h₂ : iterate' f a fuel₂ ≠ none) : iterate' f a fuel₁ = iterate' f a fuel₂ :=
+  if h : fuel₁ ≤ fuel₂ then
+    fuel_extra_ge h h₁ |>.symm
+  else
+    fuel_extra_ge (Nat.le_of_lt (Nat.gt_of_not_le h)) h₂
+
+partial def iterate_impl [Inhabited β] (f : α → Sum β α) (a : α) : β :=
+  match f a with
+  | .inl b => b
+  | .inr a => iterate_impl f a
+
+open Classical in
+@[implemented_by iterate_impl]
+def iterate (f : α → Sum β α) (init : α) : β :=
+  if h : ∃ fuel, iterate' f init fuel ≠ none then
+    match iterate' f init (choose h) with
+    | some b => b
+    | none => default
+  else
+    default
+
+theorem iterate_eq₁ (h : ¬ ∃ fuel, iterate' f a fuel ≠ none) : iterate f a = default := by
+  simp [iterate, h]
+
+open Classical in
+theorem iterate_eq₂ (h : ∃ fuel, iterate' f a fuel ≠ none) : some (iterate f a) = iterate' f a (choose h) := by
+  simp [iterate, h]
+  split
+  next h' => rw [←h']
+  next h' =>
+    have hspec := choose_spec h
+    have : iterate' f a (choose h) = none := h'
+    rw [this] at hspec
+    contradiction
+
+theorem fuel_ex (ht : ¬ test f a) : (∃ fuel, iterate' f (next f a ht) fuel ≠ none) → ∃ fuel, iterate' f a fuel ≠ none := by
+  intro ⟨fuel, h⟩
+  exists fuel+1
+  unfold iterate'
+  have : fuel + 1 ≠ 0 := by simp_arith
+  have : fuel + 1 - 1 = fuel := Nat.pred_succ _
+  simp [*]
+
+theorem fuel_nex (ht : ¬ test f a) : (¬ ∃ fuel, iterate' f a fuel ≠ none) → (¬ ∃ fuel, iterate' f (next f a ht) fuel ≠ none) := by
+  intro h h₁
+  have := fuel_ex ht h₁
+  contradiction
+
+theorem fuel_ex₂' (h₁ : ¬ test f a) (h₂ : iterate' f a fuel ≠ none) : iterate' f (next f a h₁) (fuel - 1) ≠ none := by
+  unfold iterate' at h₂
+  by_cases fuel = 0 <;> simp [*] at h₂
+  assumption
+
+theorem fuel_ex₂ (h₁ : ¬ test f a) (h₂ : ∃ fuel, iterate' f a fuel ≠ none) : ∃ fuel, iterate' f (next f a h₁) fuel ≠ none := by
+  have ⟨fuel, h₂⟩ := h₂
+  unfold iterate' at h₂
+  by_cases fuel = 0 <;> simp [*] at h₂
+  exists fuel - 1
+
+theorem ex_fuel_of_test (h : test f a = true) : ∃ fuel, iterate' f a fuel ≠ none := by
+  exists 1
+  unfold iterate'
+  simp_arith [*]
+
+open Classical in
+theorem iterate_eq' (a : α) : iterate f a = if ht : test f a then base f a else iterate f (next f a ht) := by
+  split
+  next h =>
+    have hex := ex_fuel_of_test h
+    have he₁ := iterate_eq₂ hex
+    have hspec := choose_spec hex
+    have := fuel_ne_zero hspec
+    unfold iterate' at he₁
+    simp [*] at he₁
+    assumption
+  next h =>
+    by_cases ∃ fuel, iterate' f a fuel ≠ none
+    next hex =>
+      have hex₂ := fuel_ex₂ h hex
+      have heq₁ := iterate_eq₂ hex
+      have heq₂ := iterate_eq₂ hex₂
+      have : iterate' f a (choose hex) = iterate' f (next f a h) (choose hex₂) := by
+        have hspec₁ := choose_spec hex
+        have hne_zero := fuel_ne_zero hspec₁
+        have hgt₂ := choose_spec hex₂
+        conv => lhs; unfold iterate'
+        simp [*]
+        have hgt₁ := fuel_ex₂' h hspec₁
+        exact iterate'_det hgt₁ hgt₂
+      simp [← heq₁, ← heq₂] at this
+      assumption
+      done;
+    next hex =>
+      have := iterate_eq₁ hex
+      have := fuel_nex h hex
+      have := iterate_eq₁ this
+      simp [*]
+
+theorem iterate_eq (a : α) :
+     iterate f a = match f a with
+                  | .inl b => b
+                  | .inr a => iterate f a := by
+  split
+  next b h =>
+    rw [iterate_eq']
+    simp [*, test, base]
+  next b h =>
+    rw [iterate_eq']
+    simp [*, test, next]
+    split
+    next b he => rw [he] at h; simp at h
+    next b he => rw [he] at h; simp at h; simp [h]
+
+end Iterate

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,14 @@ NUM_TESTS?=20
 VERBOSE?=--verbose
 
 .PHONY: all 
-all: specs proofs tests cosim
+all: specs correctness proofs tests cosim
 
 .PHONY: specs
 	time -p $(LAKE) build Specs
+
+.PHONY: correctness
+correctness:
+	time -p $(LAKE) build Correctness
 
 .PHONY: proofs
 proofs:

--- a/Tests/AES-GCM/AESGCMProgramTests.lean
+++ b/Tests/AES-GCM/AESGCMProgramTests.lean
@@ -86,7 +86,7 @@ def aes_gcm_enc_kernel_test (n : Nat) (plain_blocks : BitVec 4096)
   let s := { gpr := init_gpr,
              sfp := (fun (_ : BitVec 5) => 0#128),
              pc := 0x7a0cf0#64,
-             pstate := zero_pstate,
+             pstate := PState.zero,
              mem := (fun (_ :BitVec 64) => 0#8),
              program := AESGCMEncKernelProgram.aes_gcm_enc_kernel_program,
              error := StateError.None
@@ -124,7 +124,7 @@ def aes_gcm_dec_kernel_test (n : Nat) (cipher_blocks : BitVec 4096)
   let s := { gpr := init_gpr,
              sfp := (fun (_ : BitVec 5) => 0#128),
              pc := 0x7a1880#64,
-             pstate := zero_pstate,
+             pstate := PState.zero,
              mem := (fun (_ :BitVec 64) => 0#8),
              program := AESGCMDecKernelProgram.aes_gcm_dec_kernel_program,
              error := StateError.None

--- a/Tests/AES-GCM/AESV8ProgramTests.lean
+++ b/Tests/AES-GCM/AESV8ProgramTests.lean
@@ -78,7 +78,7 @@ def aes_hw_set_encrypt_key_test (n : Nat) (key_bits : BitVec 64) : ArmState :=
   let s := { gpr := init_gpr,
              sfp := (fun (_ : BitVec 5) => 0#128),
              pc := 0x79f380#64,
-             pstate := zero_pstate,
+             pstate := PState.zero,
              mem := (fun (_ :BitVec 64) => 0#8),
              program := AESHWSetEncryptKeyProgram.aes_hw_set_encrypt_key_program,
              error := StateError.None
@@ -201,7 +201,7 @@ def aes_hw_encrypt_test (n : Nat) (in_block : BitVec 128)
     let s := { gpr := init_gpr,
                sfp := (fun (_ : BitVec 5) => 0#128),
                pc := 0x79f5a0#64,
-               pstate := zero_pstate,
+               pstate := PState.zero,
                mem := (fun (_ :BitVec 64) => 0#8),
                program := AESHWEncryptProgram.aes_hw_encrypt_program,
                error := StateError.None
@@ -309,7 +309,7 @@ def aes_hw_ctr32_encrypt_blocks_test (n : Nat)
     let s := { gpr := init_gpr,
                sfp := (fun (_ : BitVec 5) => 0#128),
                pc := 0x79f8a0#64,
-               pstate := zero_pstate,
+               pstate := PState.zero,
                mem := (fun (_ :BitVec 64) => 0#8),
                program := AESHWCtr32EncryptBlocksProgram.aes_hw_ctr32_encrypt_blocks_program,
                error := StateError.None

--- a/Tests/AES-GCM/GCMProgramTests.lean
+++ b/Tests/AES-GCM/GCMProgramTests.lean
@@ -120,7 +120,7 @@ def init_gcm_init_test : ArmState :=
   let s := { gpr := init_gpr,
              sfp := (fun (_ : BitVec 5) => 0#128),
              pc := 0x7aa1c0#64,
-             pstate := zero_pstate,
+             pstate := PState.zero,
              mem := (fun (_ :BitVec 64) => 0#8),
              program := GCMInitV8Program.gcm_init_v8_program,
              error := StateError.None
@@ -157,7 +157,7 @@ def gcm_gmult_final_state : ArmState :=
   let s := { gpr := init_gpr,
              sfp := (fun (_ : BitVec 5) => 0#128),
              pc  := 0x7aa420#64,
-             pstate := zero_pstate,
+             pstate := PState.zero,
              mem := (fun (_ : BitVec 64) => 0#8),
              program := GCMGmultV8Program.gcm_gmult_v8_program,
              error := StateError.None
@@ -194,7 +194,7 @@ def gcm_ghash_test (n : Nat) (len : BitVec 64) (buf : BitVec 896)
   let s := { gpr := init_gpr,
              sfp := (fun (_ : BitVec 5) => 0#128),
              pc := 0x7aa490#64,
-             pstate := zero_pstate,
+             pstate := PState.zero,
              mem := (fun (_ :BitVec 64) => 0#8),
              program := GCMGhashV8Program.gcm_ghash_v8_program,
              error := StateError.None

--- a/Tests/LDSTTest.lean
+++ b/Tests/LDSTTest.lean
@@ -18,7 +18,7 @@ def set_init_state (program : Program) : ArmState :=
   let s := { gpr := (fun (_ : BitVec 5) => 0#64),
              sfp := (fun (_ : BitVec 5) => 0#128),
              pc := 0#64,
-             pstate := zero_pstate,
+             pstate := PState.zero,
              mem := (fun (_ : BitVec 64) => 0#8),
              program := program,
              error := StateError.None}

--- a/Tests/SHA2/SHA512ProgramTest.lean
+++ b/Tests/SHA2/SHA512ProgramTest.lean
@@ -593,7 +593,7 @@ def init_sha512_test : ArmState :=
   let s := { gpr := init_gpr,
              sfp := (fun (_ : BitVec 5) => 0#128),
              pc  := 0x1264c0#64,
-             pstate := zero_pstate,
+             pstate := PState.zero,
              mem := (fun (_ : BitVec 64) => 0#8),
              program := sha512_program_map,
              error := StateError.None }

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -7,6 +7,8 @@ package «lnsym» where
 lean_lib «Arm» where
   -- add library configuration options here
 
+lean_lib «Correctness» where
+
 lean_lib «Specs» where
   -- add library configuration options here
 


### PR DESCRIPTION
Partial correctness can be proved by discharging verification conditions.

### Testing:

`make all` succeeds.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.