### PR TITLE
fix: read the full 128 bits of an SFP register in cosimulation

### DIFF
--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -136,7 +136,7 @@ values.-/
 def sfp_list (s : ArmState) : List (BitVec 64) := Id.run do
   let mut acc := []
   for i in [0:32] do
-    let reg := read_sfp 64 (BitVec.ofNat 5 i) s
+    let reg := read_sfp 128 (BitVec.ofNat 5 i) s
     acc := acc ++ [(extractLsb 63 0 reg), (extractLsb 127 64 reg)]
   pure acc
 


### PR DESCRIPTION
### Description:

This fixes a conformance testing error introduced in #51, by reading the full 128 bits of an SFP register instead of only the lower 64

### Testing:

Conformance testing passed

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
