### PR TITLE
chore: docs and tracing for `sym1_i_n` tactic

### DIFF
--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -173,5 +173,8 @@ Where $PC and $STEPS are concrete constants.
 Note that the tactic will search for assumption of *exactly* these names,
 it won't search by def-eq -/
 elab "sym1_i_n" i:num n:num program:ident : tactic => do
+  Lean.Elab.Tactic.evalTactic (← `(tactic|
+    simp (config := {failIfUnchanged := false}) only [state_simp_rules] at *
+  ))
   for j in List.range n.getNat do
     sym1 (i.getNat + j) program


### PR DESCRIPTION
### Description:

We establish some minor documentation and tracing for the `sym1_i_n` tactic.

Furthermore, we add a simple `simp` pre-processing step to `sym1_i_n`, 
so that it can also deal with hypotheses stated using the more idiomatic `read_err`/`read_pc` family of functions.
This pre-processing happens only once, before starting symbolic evaluation, and should thus not have any significant performance impact.

### Testing:

`make all` passes, including conformance testing

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
