### PR TITLE
feat: introduce `sym1_n` tactic as a more intelligent version of `sym1_i_n`

### DIFF
--- a/Proofs/AES-GCM/GCMGmultV8Sym.lean
+++ b/Proofs/AES-GCM/GCMGmultV8Sym.lean
@@ -16,8 +16,7 @@ theorem gcm_gmult_v8_program_run_27 (s0 sf : ArmState)
     (h_run : sf = run gcm_gmult_v8_program.length s0) :
     read_err sf = .None := by
   simp (config := {ground := true}) only [Option.some.injEq] at h_s0_pc h_run
-  simp_all only [state_simp_rules, -h_run]
-  sym1_i_n 0 27 h_s0_program
+  sym1_n 27
   subst h_run
   assumption
   done

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -169,6 +169,22 @@ elab "sym1_i_n" i:num n:num _program:(ident)? : tactic => do
   for _ in List.range n.getNat do
     c ← sym1 c
 
+/--
+`sym1_n n` will symbolically evaluate a program for `n` steps.
+Alternatively,
+  `sym1_n n at s` does the same, with `s` as initial state
+
+If `s` is not passed, the initial state is inferred from the local context
+
+The context is searched (up-to def-eq!) for hypotheses
+```
+h_program : s.program = ?concreteProgram
+    h_err : r StateField.ERR s = .None
+     h_pc : r StateField.PC  s = ?PC
+    h_run : sf = run ?STEPS s
+```
+Where ?PC and ?STEPS must reduce to a concrete literal,
+and concreteProgram must be a constant (i.e., a global definition refered to by name). -/
 syntax sym_at := "at" ident
 elab "sym1_n" n:num s:(sym_at)? : tactic =>
   Lean.Elab.Tactic.withMainContext <| do

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -179,9 +179,10 @@ If `s` is not passed, the initial state is inferred from the local context
 The context is searched (up-to def-eq!) for hypotheses
 ```
 h_program : s.program = ?concreteProgram
-    h_err : r StateField.ERR s = .None
      h_pc : r StateField.PC  s = ?PC
     h_run : sf = run ?STEPS s
+    h_err : r StateField.ERR s = .None
+     h_sp : CheckSPAlignment s
 ```
 Where ?PC and ?STEPS must reduce to a concrete literal,
 and concreteProgram must be a constant (i.e., a global definition refered to by name). -/

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -145,9 +145,6 @@ def sym1 (c : SymContext) : TacticM SymContext :=
 
 
 open Lean (Name) in
-
-
-
 /-- `sym1_i_n i n h_program` will symbolically evaluate a program for `n` steps,
 starting from state `i`, where `h_program` is an assumption of the form:
 `s{i}.program = someConcreteProgam`.
@@ -169,6 +166,9 @@ elab "sym1_i_n" i:num n:num _program:(ident)? : tactic => do
   for _ in List.range n.getNat do
     c ← sym1 c
 
+/- used in `sym1_n` tactic -/
+syntax sym_at := "at" ident
+
 /--
 `sym1_n n` will symbolically evaluate a program for `n` steps.
 Alternatively,
@@ -185,9 +185,8 @@ h_program : s.program = ?concreteProgram
      h_sp : CheckSPAlignment s
 ```
 Where ?PC and ?STEPS must reduce to a concrete literal,
-and concreteProgram must be a constant
+and ?concreteProgram must be a constant
 (i.e., a global definition refered to by name). -/
-syntax sym_at := "at" ident
 elab "sym1_n" n:num s:(sym_at)? : tactic =>
   Lean.Elab.Tactic.withMainContext <| do
     Lean.Elab.Tactic.evalTactic (← `(tactic|

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -186,24 +186,15 @@ h_program : s.program = ?concreteProgram
 ```
 Where ?PC and ?STEPS must reduce to a concrete literal,
 and ?concreteProgram must be a constant
-(i.e., a global definition refered to by name).
-
-Hypotheses `h_err` and `h_sp` may be missing,
-in which case a new goal of the appropriate type will be added.
-The other hypotheses *must* be present,
-since we infer required information from their types. -/
+(i.e., a global definition refered to by name). -/
 elab "sym1_n" n:num s:(sym_at)? : tactic =>
-  let s := s.map fun
-    | `(sym_at|at $s:ident) => s.getId
-    | _ => panic! "Unexpected syntax: {s}"
-
   Lean.Elab.Tactic.withMainContext <| do
     Lean.Elab.Tactic.evalTactic (← `(tactic|
       simp (config := {failIfUnchanged := false}) only [state_simp_rules] at *
     ))
-
+    let s := s.map fun
+      | `(sym_at|at $s:ident) => s.getId
+      | _ => panic! "Unexpected syntax: {s}"
     let mut c ← SymContext.fromLocalContext s
-    c ← c.addGoalsForMissingHypotheses
-
     for _ in List.range n.getNat do
       c ← sym1 c

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -8,6 +8,7 @@ import Arm.Memory.MemoryProofs
 import Tactics.FetchAndDecode
 import Tactics.ExecInst
 import Tactics.ChangeHyps
+import Tactics.SymContext
 
 import Lean.Elab
 import Lean.Expr
@@ -16,6 +17,7 @@ initialize
   Lean.registerTraceClass `Sym
 
 open BitVec
+open Lean (FVarId)
 
 /-- `init_next_step h_run` splits the hypothesis
 
@@ -122,42 +124,29 @@ elab "stepi_tac" h_step:ident hyp_prefix:str : tactic =>
 
 end stepiTac
 
-def sym1 (curr_state_number : Nat) (_hProgram : Lean.Ident) : Lean.Elab.Tactic.TacticM Unit :=
-  Lean.Elab.Tactic.withMainContext do
-    let n_str := toString curr_state_number
-    let n'_str := toString (curr_state_number + 1)
-    let mk_name (s : String) : Lean.Name :=
-      Lean.Name.mkStr Lean.Name.anonymous s
+open Lean.Elab.Tactic (TacticM withMainContext evalTactic) in
+def sym1 (c : SymContext) : TacticM SymContext :=
+  withMainContext do
+    let c' := c.nextState
     -- h_st: prefix of user names of hypotheses about state st
-    let h_st_prefix := Lean.Syntax.mkStrLit ("h_s" ++ n_str)
-    -- h_st_program: name of the hypothesis about the program at state st
-    let h_st_program := Lean.mkIdent (mk_name ("h_s" ++ n_str ++ "_program"))
-    let _h_st_pc := Lean.mkIdent (mk_name ("h_s" ++ n_str ++ "_pc"))
-    let _h_st_err := Lean.mkIdent (mk_name ("h_s" ++ n_str ++ "_err"))
-    -- st': name of the next state
-    let st' := Lean.mkIdent (mk_name ("s" ++ n'_str))
-    -- h_run: name of the hypothesis with the `run` function
-    let h_run := Lean.mkIdent (mk_name "h_run")
+    let h_st_prefix := Lean.Syntax.mkStrLit s!"h_{c.state}"
     -- h_step_n': name of the hypothesis with the `stepi` function
-    let h_step_n' := Lean.mkIdent (mk_name ("h_step_" ++ n'_str))
+    let h_step_n' := Lean.mkIdent (.str .anonymous s!"h_step_{c'.curr_state_number}")
     let stx ←
       `(tactic|
-         (init_next_step $h_run:ident $h_step_n':ident $st':ident
+         (init_next_step $c.h_run_ident:ident $h_step_n':ident $c'.state_ident:ident
           -- Simulate one instruction
           stepi_tac $h_step_n':ident $h_st_prefix:str
-          -- intro_change_hyps $h_step_n':ident $hProgram "h_s0"
-          -- clear $h_step_n':ident
-          -- simp only [stepi, $h_st_program:ident, $h_st_pc:ident, $h_st_err:ident,
-          --            state_simp_rules, bitvec_rules, minimal_theory] at $h_step_n':ident
-          -- (try clear $h_step_n:ident)
-          -- exec_inst $h_step_n':ident $h_st_prefix:str
-          intro_fetch_decode_lemmas $h_step_n':ident $h_st_program:ident $h_st_prefix:str
-          -- (try clear $h_st_pc:ident $h_st_err:ident) --$h_st_program:ident
-          -- (intro_change_hyps $h_step_n':ident $program:term $h_st_prefix:str)
-          -- (try clear $h_step_n':ident)
+          intro_fetch_decode_lemmas $h_step_n':ident $c.h_program_ident:ident $h_st_prefix:str
       ))
     trace[Sym] "Running tactic:\n{stx}"
-    Lean.Elab.Tactic.evalTactic stx
+    evalTactic stx
+    return c'
+
+
+open Lean (Name) in
+
+
 
 /-- `sym1_i_n i n h_program` will symbolically evaluate a program for `n` steps,
 starting from state `i`, where `h_program` is an assumption of the form:
@@ -172,9 +161,18 @@ h_run      : sf = run $STEPS s0
 Where $PC and $STEPS are concrete constants.
 Note that the tactic will search for assumption of *exactly* these names,
 it won't search by def-eq -/
-elab "sym1_i_n" i:num n:num program:ident : tactic => do
+elab "sym1_i_n" i:num n:num _program:(ident)? : tactic => do
   Lean.Elab.Tactic.evalTactic (← `(tactic|
     simp (config := {failIfUnchanged := false}) only [state_simp_rules] at *
   ))
-  for j in List.range n.getNat do
-    sym1 (i.getNat + j) program
+  let mut c := SymContext.default i.getNat
+  for _ in List.range n.getNat do
+    c ← sym1 c
+
+elab "sym1_n" n:num s:(ident)? : tactic => do
+  Lean.Elab.Tactic.evalTactic (← `(tactic|
+    simp (config := {failIfUnchanged := false}) only [state_simp_rules] at *
+  ))
+  let mut c ← SymContext.fromLocalContext (Lean.TSyntax.getId <$> s)
+  for _ in List.range n.getNat do
+    c ← sym1 c

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -185,7 +185,8 @@ h_program : s.program = ?concreteProgram
      h_sp : CheckSPAlignment s
 ```
 Where ?PC and ?STEPS must reduce to a concrete literal,
-and concreteProgram must be a constant (i.e., a global definition refered to by name). -/
+and concreteProgram must be a constant
+(i.e., a global definition refered to by name). -/
 syntax sym_at := "at" ident
 elab "sym1_n" n:num s:(sym_at)? : tactic =>
   Lean.Elab.Tactic.withMainContext <| do

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -203,9 +203,9 @@ def fromLocalContext (state? : Option Name) : MetaM SymContext := do
   }
 where
   findLocalDeclUsernameOfType? (expectedType : Expr) : MetaM (Option Name) := do
-    let some h_run ← findLocalDeclWithType? expectedType
+    let some fvarId ← findLocalDeclWithType? expectedType
       | return none
-    let decl := (← getLCtx).get! h_run
+    let decl := (← getLCtx).get! fvarId
     -- ^^ `findLocalDeclWithType?` only returns `FVarId`s which are present in the local context,
     --    so we can safely pass it to `get!`
     return decl.userName

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -169,10 +169,6 @@ where
       | throwError "Failed to find a local hypothesis of type {expectedType}"
     return name
 
-/-- `mkName` is a simple helper for turning a string into an unqualified name,
-as used for local variables and hypotheses -/
-private def mkName : String → Name :=
-  Lean.Name.mkStr Lean.Name.anonymous
 
 def default (curr_state_number : Nat) : SymContext :=
   let s := s!"s{curr_state_number}"

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -79,8 +79,9 @@ private def reflectNatLiteral (e : Expr) : MetaM Nat := do
   if e.hasFVar then
     throwError "Expected a ground term, but {e} has free variables"
 
-  let e ← instantiateMVars e
-  let some x := e.nat? | throwError "Expected a numeric literal, found:\n\t{e}"
+  let e' ← reduce (← instantiateMVars e)
+  let some x := e'.rawNatLit? | throwError "Expected a numeric literal, found:\n\t{e'}\nwhich was obtained by reducing:\n\t{e}"
+  -- ^^ The previous reduction will have reduced a canonical-form nat literal into a raw literal
   return x
 
 /-- For a concrete width `w`,

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -179,8 +179,8 @@ def default (curr_state_number : Nat) : SymContext :=
     h_run     := .mkSimple s!"h_run"
     h_program := .mkSimple s!"h_{s}_program"
     h_pc      := .mkSimple s!"h_{s}_pc"
-    h_err     := .mkSimple s!"h_{s}_err"
-    h_sp      := .mkSimple s!"h_{s}_sp"
+    h_err     := some <| .mkSimple s!"h_{s}_err"
+    h_sp      := some <| .mkSimple s!"h_{s}_sp"
     /-
       `runSteps`, `pc` and `program` actually require inspection of the context to determine.
       However, these values are not actually used yet,
@@ -206,10 +206,10 @@ def nextState (c : SymContext) (nextPc? : Option (BitVec 64) := none) : SymConte
   {
     state     := .mkSimple s
     h_run     := c.h_run
-    h_program := mkName s!"h_{s}_program"
+    h_program := .mkSimple s!"h_{s}_program"
     h_pc      := .mkSimple s!"h_{s}_pc"
-    h_err     := .mkSimple s!"h_{s}_err"
-    h_sp      := .mkSimple s!"h_{s}_sp"
+    h_err     := some <| .mkSimple s!"h_{s}_err"
+    h_sp      := some <| .mkSimple s!"h_{s}_sp"
     runSteps  := c.runSteps - 1
     program   := c.program
     pc        := nextPc?.getD (c.pc + 4#64)

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -1,0 +1,225 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
+import Lean
+import Arm.Exec
+
+/-!
+This files defines the `SymContext` structure,
+which is collects
+-/
+
+open Lean Meta
+open BitVec
+
+/--
+
+-/
+structure SymContext where
+  /-- `state` and `finalState` are local variable of type `ArmState` -/
+  state : Name
+  /-- `runSteps` is the number of steps that we can *maximally* simulate,
+  because of the way it occurs in `h_run`.
+  Note that `runSteps` is a meta-level natural number, reflecting the fact that we expect the number
+  of steps in `h_run` to be expressed as a concrete literal -/
+  runSteps : Nat
+  /-- `h_run` is a local hypothesis of the form `finalState = run {runSteps} state` -/
+  h_run : Name
+  /-- `program` is a *constant* which represents the program being evaluated -/
+  program : Name
+  /-- `h_program` is a local hypothesis of the form `state.program = program` -/
+  h_program : Name
+  /-- `pc` is the *concrete* value of the program counter -/
+  pc : BitVec 64
+  /-- `h_pc` is a local hypothesis of the form `r StateField.PC state = pc` -/
+  h_pc  : Name
+  /-- `h_err` is a local hypothesis of the form `r StateField.ERR state = .None` -/
+  h_err : Option Name
+  /-- `h_sp` is a local hypothesis of the form `CheckSPAlignment state` -/
+  h_sp  : Option Name
+
+  /-- `state_prefix` is used together with `curr_state_number`
+  to determine the name of the next state variable that is added by `sym` -/
+  state_prefix      : String := "s"
+  /-- `curr_state_number` is incremented each simulation step,
+  and used together with `curr_state_number`
+  to determine the name of the next state variable that is added by `sym`  -/
+  curr_state_number : Nat := 0
+
+
+namespace SymContext
+
+/-! ## Creating initial contexts -/
+
+/-- Infer `state_prefix` and `curr_state_number` from the `state` name as follows:
+if `state` is `s{i}` for some number `i` and a single character `s`,
+then `s` is the prefix and `i` the number,
+otherwise simple take `{state}_` as the prefix and start counting from zero -/
+def inferStatePrefixAndNumber (ctxt : SymContext) : SymContext :=
+  let state := ctxt.state.toString
+  let tail := state.toSubstring.drop 1
+
+  if let some curr_state_number := tail.toNat? then
+    { ctxt with
+      state_prefix := (state.get? 0).getD 's' |>.toString,
+      curr_state_number }
+  else
+    { ctxt with
+      state_prefix := state ++ "_",
+      curr_state_number := 0 }
+
+
+private def reflectBitVecLiteral (w : Nat) (e : Expr) : MetaM (BitVec w) := do
+  let x ← mkFreshExprMVar (Expr.const ``Nat [])
+  let e' ← mkAppM ``BitVec.ofNat #[toExpr w, x]
+  if !(←isDefEq e e') then
+    throwError "Not def-eq:\n\t{e}\nand\n\t{e'}" -- TODO: error message
+  else
+    let x ← instantiateMVars x
+    let some x := x.nat? | throwError "Not a nat:\n\t{x}" -- TODO: error message
+    return BitVec.ofNat w x
+
+def fromLocalContext (state? : Option Name) : MetaM SymContext := do
+  let lctx ← getLCtx
+
+  -- Either get the state expression from the local context,
+  -- or, if no state was given, create a new meta variable for the state
+  let stateExpr : Expr ← match state? with
+    | some state =>
+      let some decl := lctx.findFromUserName? state
+        | throwError "Unknown local variable `{state}`"
+      pure (Expr.fvar decl.fvarId)
+    | none => mkFreshExprMVar (Expr.const ``ArmState [])
+
+  -- Find `h_run` and infer `runSteps` from it
+  let sf ← mkFreshExprMVar none
+  let runSteps ← mkFreshExprMVar (Expr.const ``Nat [])
+  let h_run_type ← mkEq sf (←mkAppM ``run #[runSteps, stateExpr])
+  let h_run ← findLocalDeclUsernameOfTypeOrError h_run_type
+
+  -- Unwrap and reflect `runSteps`
+  let some runSteps := (← instantiateMVars runSteps).nat?
+    | throwError "Expected a numeric literal, found:\n\t{runSteps}\nIn\n\t {h_run} : {h_run_type}"
+
+  -- At this point, `stateExpr` should have been assigned (if it was an mvar),
+  -- so we can unwrap it to get the underlying name
+  let stateExpr ← instantiateMVars stateExpr
+  let state ← state?.getDM <| do
+    let .fvar state := stateExpr
+      | throwError
+  "Expected a free variable, found:
+    {stateExpr}
+  We inferred this as the initial state because we found:
+    {h_run} : {← instantiateMVars h_run_type}
+  in the local context.
+
+  If this is wrong, please explicitly provide the right initial state
+  "
+    let some state := lctx.find? state
+      /- I don't expect this error to be possible in a well-formed state, but you never know -/
+      | throwError "Failed to find local variable for state {stateExpr}"
+    pure state.userName
+
+  -- Try to find `h_program`, and infer `program` from it
+  let program ← mkFreshExprMVar none
+  let h_program_type ← mkEq (← mkAppM ``ArmState.program #[stateExpr]) program
+  let h_program ← findLocalDeclUsernameOfTypeOrError h_program_type
+
+  -- Assert that `program` is a(n application of a) constant, and find its name
+  let program := (← instantiateMVars program).getAppFn
+  let .const program _ := program
+    | throwError "Expected a constant, found:\n\t{program}\nIn: {h_program} : {h_program_type}"
+  /-
+    TODO: assert that the expected `stepi` theorems have been generated for `program`
+  -/
+
+  -- Then, try to find `h_pc`
+  let pc ← mkFreshExprMVar (← mkAppM ``BitVec #[toExpr 64])
+  let h_pc_type ← mkEq (← mkAppM ``r #[(.const ``StateField.PC []), stateExpr]) pc
+  let h_pc ← findLocalDeclUsernameOfTypeOrError h_pc_type
+
+  -- Unwrap and reflect `pc`
+  let pc ← instantiateMVars pc
+  let pc ←
+    try
+      reflectBitVecLiteral 64 pc
+    catch e =>
+      throwError "{e.toMessageData}\nIn\n\t{h_pc} : {h_pc_type}"
+
+  return inferStatePrefixAndNumber {
+    state, h_run, runSteps, program, h_program, pc, h_pc,
+    h_err := none,
+    h_sp := none,
+  }
+where
+  findLocalDeclUsernameOfType? (expectedType : Expr) : MetaM (Option Name) := do
+    let some h_run ← findLocalDeclWithType? expectedType
+      | return none
+    let decl := (← getLCtx).get! h_run
+    return decl.userName
+  findLocalDeclUsernameOfTypeOrError (expectedType : Expr) : MetaM Name := do
+    let some name ← findLocalDeclUsernameOfType? expectedType
+      | throwError "Failed to find a local hypothesis of type {expectedType}"
+    return name
+
+/-- `mkName` is a simple helper for turning a string into an unqualified name,
+as used for local variables and hypotheses -/
+private def mkName : String → Name :=
+  Lean.Name.mkStr Lean.Name.anonymous
+
+def default (curr_state_number : Nat) : SymContext :=
+  let s := s!"s{curr_state_number}"
+  {
+    state     := mkName s
+    h_run     := mkName s!"h_run"
+    h_program := mkName s!"h_{s}_program"
+    h_pc      := mkName s!"h_{s}_pc"
+    h_err     := mkName s!"h_{s}_err"
+    h_sp      := mkName s!"h_{s}_sp"
+    /-
+      `runSteps`, `pc` and `program` actually require inspection of the context to determine.
+      However, these values are not actually used yet,
+      they are merely kept because they will be useful in the future.
+      We can safely put in bogus values for now.
+      (Or we could do the honest thing and make these `Option`s)
+    -/
+    runSteps  := 9999999999
+    program   := `UNUSED
+    pc        := 0#64
+  }
+
+/-! ## Incrementing the context to the next state -/
+
+/-- `c.nextState` generates names for the next intermediate state in symbolic evaluation.
+
+`nextPc?`, if given, will be the pc of the next context.
+If `nextPC?` is `none`, then the previous pc is incremented by 4
+ -/
+def nextState (c : SymContext) (nextPc? : Option (BitVec 64) := none) : SymContext :=
+  let curr_state_number := c.curr_state_number + 1
+  let s := s!"{c.state_prefix}{curr_state_number}"
+  {
+    state     := mkName s
+    h_run     := c.h_run
+    h_program := mkName s!"h_{s}_program"
+    h_pc      := mkName s!"h_{s}_pc"
+    h_err     := mkName s!"h_{s}_err"
+    h_sp      := mkName s!"h_{s}_sp"
+    runSteps  := c.runSteps - 1
+    program   := c.program
+    pc        := nextPc?.getD (c.pc + 4#64)
+    curr_state_number
+    state_prefix := c.state_prefix
+  }
+
+/-! ## Simple projections -/
+open Lean (Ident mkIdent)
+
+def state_ident     (c : SymContext) : Ident := mkIdent c.state
+def h_run_ident     (c : SymContext) : Ident := mkIdent c.h_run
+def h_program_ident (c : SymContext) : Ident := mkIdent c.h_program
+def h_pc_ident      (c : SymContext) : Ident := mkIdent c.h_pc
+def h_err_ident     (c : SymContext) : Option Ident := mkIdent <$> c.h_err
+def h_sp_ident      (c : SymContext) : Option Ident := mkIdent <$> c.h_sp

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author(s): Alex Keizer
 -/
 import Lean
-import Lean.Meta
-
 import Arm.Exec
 
 /-!
@@ -24,7 +22,7 @@ without looking at the local context.
 This function exists for backwards compatibility,
 and is likely to be deprecated and removed in the near future. -/
 
-open Lean Meta Elab.Tactic
+open Lean Meta
 open BitVec
 
 /-- A `SymContext` collects the names of various variables/hypotheses in
@@ -77,17 +75,6 @@ structure SymContext where
   to determine the name of the next state variable that is added by `sym` -/
   curr_state_number : Nat := 0
 
-/-- `h_err_type state` returns an Expr representing `r state = .None`,
-the expected type of `h_err` -/
-private def h_err_type (state : Expr) : MetaM Expr :=
-  mkEq
-    (mkApp2 (.const ``r []) (.const ``StateField.ERR []) state)
-    (.const ``StateError.None [])
-
-/-- `h_sp_type state` returns an Expr representing `CheckSPAlignment state`,
-the expected type of `h_sp` -/
-private def h_sp_type (state : Expr) : Expr :=
-  mkApp (.const ``CheckSPAlignment []) state
 
 namespace SymContext
 
@@ -109,50 +96,6 @@ def inferStatePrefixAndNumber (ctxt : SymContext) : SymContext :=
     { ctxt with
       state_prefix := "s",
       curr_state_number := 1 }
-
-/-- If `h_sp` or `h_err` are missing from the `SymContext`,
-add new goals of the expected types,
-and use these to add `h_sp` and `h_err` to the main goal context -/
-def addGoalsForMissingHypotheses (ctx : SymContext) : TacticM SymContext :=
-  withMainContext do
-    let mut ctx := ctx
-    let mut goal ← getMainGoal
-    let mut newGoals := []
-    let lCtx ← getLCtx
-    let some stateExpr :=
-      (Expr.fvar ·.fvarId) <$> lCtx.findFromUserName? ctx.state
-      | throwError "Could not find '{ctx.state}' in the local context"
-
-    if ctx.h_err.isNone then
-      let h_err := Name.mkSimple s!"h_{ctx.state}_run"
-      let newGoal ← mkFreshMVarId
-
-      goal := ← do
-        let goalType ← h_err_type stateExpr
-        let newGoalExpr ← mkFreshExprMVarWithId newGoal goalType
-        let goal' ← goal.assert h_err goalType newGoalExpr
-        let ⟨_, goal'⟩ ← goal'.intro1P
-        return goal'
-
-      newGoals := newGoal :: newGoals
-      ctx := { ctx with h_err }
-
-    if ctx.h_sp.isNone then
-      let h_sp := Name.mkSimple s!"h_{ctx.state}_sp"
-      let newGoal ← mkFreshMVarId
-
-      goal := ← do
-        let h_sp_type := h_sp_type stateExpr
-        let newGoalExpr ← mkFreshExprMVarWithId newGoal h_sp_type
-        let goal' ← goal.assert h_sp h_sp_type newGoalExpr
-        let ⟨_, goal'⟩ ← goal'.intro1P
-        return goal'
-
-      newGoals := newGoal :: newGoals
-      ctx := { ctx with h_sp }
-
-    replaceMainGoal (goal :: newGoals)
-    return ctx
 
 /-- Given a ground term `e` of type `Nat`, fully reduce it,
 and attempt to reflect it into a meta-level `Nat` -/
@@ -217,7 +160,7 @@ def fromLocalContext (state? : Option Name) : MetaM SymContext := do
   -- Find `h_run` and infer `runSteps` from it
   let sf ← mkFreshExprMVar none
   let runSteps ← mkFreshExprMVar (Expr.const ``Nat [])
-  let h_run_type ← mkEq sf (←mkAppM ``_root_.run #[runSteps, stateExpr])
+  let h_run_type ← mkEq sf (←mkAppM ``run #[runSteps, stateExpr])
   let h_run ← findLocalDeclUsernameOfTypeOrError h_run_type
 
   -- Unwrap and reflect `runSteps`

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -7,18 +7,24 @@ import Lean
 import Arm.Exec
 
 /-!
-This files defines the `SymContext` structure,
-which is collects
--/
+This files defines the `SymContext` structure, which collects the names of various
+variables/hypotheses in the local context required for symbolic evaluation.
+
+The canonical way to construct a `SymContext` is through `SymContext.fromLocalContext`,
+which searches the local context (up to def-eq) for variables and hypothese of the expected types.
+
+Alternatively, there is `SymContext.default`, which returns a context using hard-coded names,
+simply assuming those hypotheses to be present without looking at the local context.
+This function exists for backwards compatibility, and is likely to be deprecated and removed in
+the near future. -/
 
 open Lean Meta
 open BitVec
 
-/--
-
--/
+/-- A `SymContext` collects the names of various variables/hypotheses in the local context required
+for symbolic evaluation -/
 structure SymContext where
-  /-- `state` and `finalState` are local variable of type `ArmState` -/
+  /-- `state` is a local variable of type `ArmState` -/
   state : Name
   -- TODO: Should we eventually track the final state as well?
   --       We could use it to avoid introducing the last intermediate state,
@@ -34,7 +40,15 @@ structure SymContext where
   program : Name
   /-- `h_program` is a local hypothesis of the form `state.program = program` -/
   h_program : Name
-  /-- `pc` is the *concrete* value of the program counter -/
+  /-- `pc` is the *concrete* value of the program counter
+
+  Note that for now we only support symbolic evaluation of programs at statically known addresses.
+  At some point in the near future, we will want to support addresses of the type `base +/- offset`
+  as well, where `base` is an arbitrary variable and `offset` is statically known.
+  We could do so by refactoring `pc` to be of type `Bool × BitVec 64`,
+  so long as we assume the instruction addresses in a single program will either be all
+  statically known, or all offset against the same `base` address,
+  and we assume that no overflow happens (i.e., `base - x` can never be equal to `base + y`) -/
   pc : BitVec 64
   /-- `h_pc` is a local hypothesis of the form `r StateField.PC state = pc` -/
   h_pc  : Name

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -94,8 +94,11 @@ private def reflectNatLiteral (e : Expr) : MetaM Nat := do
     throwError "Expected a ground term, but {e} has free variables"
 
   let e' ← reduce (← instantiateMVars e)
-  let some x := e'.rawNatLit? | throwError "Expected a numeric literal, found:\n\t{e'}\nwhich was obtained by reducing:\n\t{e}"
-  -- ^^ The previous reduction will have reduced a canonical-form nat literal into a raw literal
+  let some x := e'.rawNatLit?
+    | throwError "Expected a numeric literal, found:\n\t{e'}
+which was obtained by reducing:\n\t{e}"
+  -- ^^ The previous reduction will have reduced a canonical-form nat literal into a raw literal,
+  --    hence, we use `rawNatLit?` rather than `nat?`
   return x
 
 /-- For a concrete width `w`,

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -73,7 +73,7 @@ namespace SymContext
 /-- Infer `state_prefix` and `curr_state_number` from the `state` name as follows:
 if `state` is `s{i}` for some number `i` and a single character `s`,
 then `s` is the prefix and `i` the number,
-otherwise simple take `{state}_` as the prefix and start counting from zero -/
+otherwise ignore `state`, and start counting from `s1` -/
 def inferStatePrefixAndNumber (ctxt : SymContext) : SymContext :=
   let state := ctxt.state.toString
   let tail := state.toSubstring.drop 1

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -202,12 +202,12 @@ def nextState (c : SymContext) (nextPc? : Option (BitVec 64) := none) : SymConte
   let curr_state_number := c.curr_state_number + 1
   let s := s!"{c.state_prefix}{curr_state_number}"
   {
-    state     := mkName s
+    state     := .mkSimple s
     h_run     := c.h_run
     h_program := mkName s!"h_{s}_program"
-    h_pc      := mkName s!"h_{s}_pc"
-    h_err     := mkName s!"h_{s}_err"
-    h_sp      := mkName s!"h_{s}_sp"
+    h_pc      := .mkSimple s!"h_{s}_pc"
+    h_err     := .mkSimple s!"h_{s}_err"
+    h_sp      := .mkSimple s!"h_{s}_sp"
     runSteps  := c.runSteps - 1
     program   := c.program
     pc        := nextPc?.getD (c.pc + 4#64)

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -115,7 +115,7 @@ def fromLocalContext (state? : Option Name) : MetaM SymContext := do
     {h_run} : {← instantiateMVars h_run_type}
   in the local context.
 
-  If this is wrong, please explicitly provide the right initial state
+  If this is wrong, please explicitly provide the right initial state, as `sym {runSteps} at ?s0`
   "
     let some state := lctx.find? state
       /- I don't expect this error to be possible in a well-formed state, but you never know -/

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -84,8 +84,8 @@ def inferStatePrefixAndNumber (ctxt : SymContext) : SymContext :=
       curr_state_number }
   else
     { ctxt with
-      state_prefix := state ++ "_",
-      curr_state_number := 0 }
+      state_prefix := "s",
+      curr_state_number := 1 }
 
 /-- Given a ground term `e` of type `Nat`, fully reduce it,
 and attempt to reflect it into a meta-level `Nat`  -/

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -72,7 +72,7 @@ structure SymContext where
   state_prefix      : String := "s"
   /-- `curr_state_number` is incremented each simulation step,
   and used together with `curr_state_number`
-  to determine the name of the next state variable that is added by `sym`  -/
+  to determine the name of the next state variable that is added by `sym` -/
   curr_state_number : Nat := 0
 
 
@@ -98,7 +98,7 @@ def inferStatePrefixAndNumber (ctxt : SymContext) : SymContext :=
       curr_state_number := 1 }
 
 /-- Given a ground term `e` of type `Nat`, fully reduce it,
-and attempt to reflect it into a meta-level `Nat`  -/
+and attempt to reflect it into a meta-level `Nat` -/
 private def reflectNatLiteral (e : Expr) : MetaM Nat := do
   if e.hasFVar then
     throwError "Expected a ground term, but {e} has free variables"

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -206,7 +206,7 @@ def fromLocalContext (state? : Option Name) : MetaM SymContext := do
 
   -- Then, try to find `h_pc`
   let pc ← mkFreshExprMVar (← mkAppM ``BitVec #[toExpr 64])
-  let h_pc_type ←
+  let h_pc_type ← do
     let lhs ← mkAppM ``r #[(.const ``StateField.PC []), stateExpr]
     mkEq lhs pc
   let h_pc ← findLocalDeclUsernameOfTypeOrError h_pc_type

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -20,6 +20,9 @@ open BitVec
 structure SymContext where
   /-- `state` and `finalState` are local variable of type `ArmState` -/
   state : Name
+  -- TODO: Should we eventually track the final state as well?
+  --       We could use it to avoid introducing the last intermediate state,
+  --       when we detect that `runSteps = 0`
   /-- `runSteps` is the number of steps that we can *maximally* simulate,
   because of the way it occurs in `h_run`.
   Note that `runSteps` is a meta-level natural number, reflecting the fact that we expect the number
@@ -102,6 +105,8 @@ def fromLocalContext (state? : Option Name) : MetaM SymContext := do
   -- Unwrap and reflect `runSteps`
   let some runSteps := (← instantiateMVars runSteps).nat?
     | throwError "Expected a numeric literal, found:\n\t{runSteps}\nIn\n\t {h_run} : {h_run_type}"
+  -- TODO: we should allow all ground terms here, not just literals.
+  -- For example, we sometimes use `sf = run someProgram.length s0`
 
   -- At this point, `stateExpr` should have been assigned (if it was an mvar),
   -- so we can unwrap it to get the underlying name

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -163,6 +163,8 @@ where
     let some h_run ← findLocalDeclWithType? expectedType
       | return none
     let decl := (← getLCtx).get! h_run
+    -- ^^ `findLocalDeclWithType?` only returns `FVarId`s which are present in the local context,
+    --    so we can safely pass it to `get!`
     return decl.userName
   findLocalDeclUsernameOfTypeOrError (expectedType : Expr) : MetaM Name := do
     let some name ← findLocalDeclUsernameOfType? expectedType

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -173,12 +173,12 @@ where
 def default (curr_state_number : Nat) : SymContext :=
   let s := s!"s{curr_state_number}"
   {
-    state     := mkName s
-    h_run     := mkName s!"h_run"
-    h_program := mkName s!"h_{s}_program"
-    h_pc      := mkName s!"h_{s}_pc"
-    h_err     := mkName s!"h_{s}_err"
-    h_sp      := mkName s!"h_{s}_sp"
+    state     := .mkSimple s
+    h_run     := .mkSimple s!"h_run"
+    h_program := .mkSimple s!"h_{s}_program"
+    h_pc      := .mkSimple s!"h_{s}_pc"
+    h_err     := .mkSimple s!"h_{s}_err"
+    h_sp      := .mkSimple s!"h_{s}_sp"
     /-
       `runSteps`, `pc` and `program` actually require inspection of the context to determine.
       However, these values are not actually used yet,

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author(s): Alex Keizer
 -/
 import Lean
+import Lean.Meta
+
 import Arm.Exec
 
 /-!
@@ -22,7 +24,7 @@ without looking at the local context.
 This function exists for backwards compatibility,
 and is likely to be deprecated and removed in the near future. -/
 
-open Lean Meta
+open Lean Meta Elab.Tactic
 open BitVec
 
 /-- A `SymContext` collects the names of various variables/hypotheses in
@@ -75,6 +77,17 @@ structure SymContext where
   to determine the name of the next state variable that is added by `sym` -/
   curr_state_number : Nat := 0
 
+/-- `h_err_type state` returns an Expr representing `r state = .None`,
+the expected type of `h_err` -/
+private def h_err_type (state : Expr) : MetaM Expr :=
+  mkEq
+    (mkApp2 (.const ``r []) (.const ``StateField.ERR []) state)
+    (.const ``StateError.None [])
+
+/-- `h_sp_type state` returns an Expr representing `CheckSPAlignment state`,
+the expected type of `h_sp` -/
+private def h_sp_type (state : Expr) : Expr :=
+  mkApp (.const ``CheckSPAlignment []) state
 
 namespace SymContext
 
@@ -96,6 +109,50 @@ def inferStatePrefixAndNumber (ctxt : SymContext) : SymContext :=
     { ctxt with
       state_prefix := "s",
       curr_state_number := 1 }
+
+/-- If `h_sp` or `h_err` are missing from the `SymContext`,
+add new goals of the expected types,
+and use these to add `h_sp` and `h_err` to the main goal context -/
+def addGoalsForMissingHypotheses (ctx : SymContext) : TacticM SymContext :=
+  withMainContext do
+    let mut ctx := ctx
+    let mut goal ← getMainGoal
+    let mut newGoals := []
+    let lCtx ← getLCtx
+    let some stateExpr :=
+      (Expr.fvar ·.fvarId) <$> lCtx.findFromUserName? ctx.state
+      | throwError "Could not find '{ctx.state}' in the local context"
+
+    if ctx.h_err.isNone then
+      let h_err := Name.mkSimple s!"h_{ctx.state}_run"
+      let newGoal ← mkFreshMVarId
+
+      goal := ← do
+        let goalType ← h_err_type stateExpr
+        let newGoalExpr ← mkFreshExprMVarWithId newGoal goalType
+        let goal' ← goal.assert h_err goalType newGoalExpr
+        let ⟨_, goal'⟩ ← goal'.intro1P
+        return goal'
+
+      newGoals := newGoal :: newGoals
+      ctx := { ctx with h_err }
+
+    if ctx.h_sp.isNone then
+      let h_sp := Name.mkSimple s!"h_{ctx.state}_sp"
+      let newGoal ← mkFreshMVarId
+
+      goal := ← do
+        let h_sp_type := h_sp_type stateExpr
+        let newGoalExpr ← mkFreshExprMVarWithId newGoal h_sp_type
+        let goal' ← goal.assert h_sp h_sp_type newGoalExpr
+        let ⟨_, goal'⟩ ← goal'.intro1P
+        return goal'
+
+      newGoals := newGoal :: newGoals
+      ctx := { ctx with h_sp }
+
+    replaceMainGoal (goal :: newGoals)
+    return ctx
 
 /-- Given a ground term `e` of type `Nat`, fully reduce it,
 and attempt to reflect it into a meta-level `Nat` -/
@@ -160,7 +217,7 @@ def fromLocalContext (state? : Option Name) : MetaM SymContext := do
   -- Find `h_run` and infer `runSteps` from it
   let sf ← mkFreshExprMVar none
   let runSteps ← mkFreshExprMVar (Expr.const ``Nat [])
-  let h_run_type ← mkEq sf (←mkAppM ``run #[runSteps, stateExpr])
+  let h_run_type ← mkEq sf (←mkAppM ``_root_.run #[runSteps, stateExpr])
   let h_run ← findLocalDeclUsernameOfTypeOrError h_run_type
 
   -- Unwrap and reflect `runSteps`

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -51,7 +51,7 @@ structure SymContext where
   Note that for now we only support symbolic evaluation of programs
   at statically known addresses.
   At some point in the near future,
-  we will want to support addresses of the type `base +/- offset` as well,
+  we will want to support addresses of the type `base + / - offset` as well,
   where `base` is an arbitrary variable and `offset` is statically known.
   We could do so by refactoring `pc` to be of type `Bool × BitVec 64`,
   so long as we assume the instruction addresses in a single program will


### PR DESCRIPTION
### Description:

This refactors the symbolic evaluation using pre-generated theorems to maintain a context structure which tracks the names of the various theorems needed for eval, rather than relying on these theorems to be available with hard-coded names.

In the process, we also define a way to infer the initial context by searching through the local context for variables and hypothesis that are def-eq to what we expect (basically doing `by assumption`). This has two big benefits:
* It allows us to generate more meaningful error messages when the contract is broken, and
* During this search we also infer and assert more information. For example, we assert that the `m` in `sf = run m s0` is a numeric literal and reflect the value (we can use this in future to throw a meaningful error when the user asks to simulate more than `m` steps). Similarly, we reflect the PC (which is also assumed to be a concrete literal) and determine the name of the program; this information will be useful to more intelligently find the right `stepi` lemma to apply in future (in contrast to the current approach which assumes the right lemmas to be present in a simp-set).

Since the search matches up-to defeq, it might impact performance slightly. That said, the search only happens *once* per `sym_n` call, independent of the amount of steps we simulate, so this cost should pale in comparison to the cost of the actual symbolic eval.

I've demonstrated the new tactic works on `gcm_gmult_v8`. In a next PR, I intend to remove `sym_i_n` and replace all uses with `sym_n`.

### Testing:

`make all` passed on the cloud desktop, including conformance testing

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
