### PR TITLE
refactor: generate `stepi` theorems in the relevant program's namespace

### DIFF
--- a/Proofs/AES-GCM/GCMGmultV8Sym.lean
+++ b/Proofs/AES-GCM/GCMGmultV8Sym.lean
@@ -4,9 +4,9 @@ import Tactics.StepThms
 
 namespace GCMGmultV8Program
 
-#genStepTheorems gcm_gmult_v8_program namePrefix:="gcm_gmult_v8_" thmType:="fetch" `state_simp_rules
-#genStepTheorems gcm_gmult_v8_program namePrefix:="gcm_gmult_v8_" thmType:="decodeExec" `state_simp_rules
-#genStepTheorems gcm_gmult_v8_program namePrefix:="gcm_gmult_v8_" thmType:="step" `state_simp_rules
+#genStepTheorems gcm_gmult_v8_program thmType:="fetch" `state_simp_rules
+#genStepTheorems gcm_gmult_v8_program thmType:="decodeExec" `state_simp_rules
+#genStepTheorems gcm_gmult_v8_program thmType:="step" `state_simp_rules
 
 theorem gcm_gmult_v8_program_run_27 (s0 sf : ArmState)
     (h_s0_program : s0.program = gcm_gmult_v8_program)

--- a/Proofs/Experiments/AbsVCG.lean
+++ b/Proofs/Experiments/AbsVCG.lean
@@ -88,11 +88,11 @@ theorem Abs.csteps_eq (s : ArmState) (i : Nat) :
 -- Generating the program effects and non-effects
 
 -- set_option trace.gen_step.print_names true in
-#genStepTheorems program namePrefix:="abs_" thmType:="fetch"
+#genStepTheorems program thmType:="fetch"
 -- set_option trace.gen_step.print_names true in
-#genStepTheorems program namePrefix:="abs_" thmType:="decodeExec"
+#genStepTheorems program thmType:="decodeExec"
 -- set_option trace.gen_step.print_names true in
-#genStepTheorems program namePrefix:="abs_" thmType:="step" `state_simp_rules
+#genStepTheorems program thmType:="step" `state_simp_rules
 
 -- (FIXME) Obtain *_cut theorems for each instruction automatically.
 
@@ -101,7 +101,7 @@ theorem abs_stepi_0x4005d0_cut (s : ArmState)
   (h_pc : r StateField.PC s = 0x4005d0#64)
   (h_err : r StateField.ERR s = StateError.None) :
   abs_cut (stepi s) = false := by
-  have := abs_stepi_0x4005d0 s (stepi s) h_program h_pc h_err
+  have := program.stepi_0x4005d0 s (stepi s) h_program h_pc h_err
   simp only [minimal_theory] at this
   simp only [abs_cut, this, state_simp_rules, bitvec_rules, minimal_theory]
   done
@@ -111,7 +111,7 @@ theorem abs_stepi_0x4005d4_cut (s : ArmState)
   (h_pc : r StateField.PC s = 0x4005d4#64)
   (h_err : r StateField.ERR s = StateError.None) :
   abs_cut (stepi s) = false := by
-  have := abs_stepi_0x4005d4 s (stepi s) h_program h_pc h_err
+  have := program.stepi_0x4005d4 s (stepi s) h_program h_pc h_err
   simp only [minimal_theory] at this
   simp only [abs_cut, this, state_simp_rules, bitvec_rules, minimal_theory]
   done
@@ -121,7 +121,7 @@ theorem abs_stepi_0x4005d8_cut (s : ArmState)
   (h_pc : r StateField.PC s = 0x4005d8#64)
   (h_err : r StateField.ERR s = StateError.None) :
   abs_cut (stepi s) = false := by
-  have := abs_stepi_0x4005d8 s (stepi s) h_program h_pc h_err
+  have := program.stepi_0x4005d8 s (stepi s) h_program h_pc h_err
   simp only [minimal_theory] at this
   simp only [abs_cut, this, state_simp_rules, bitvec_rules, minimal_theory]
   done
@@ -131,7 +131,7 @@ theorem abs_stepi_0x4005dc_cut (s : ArmState)
   (h_pc : r StateField.PC s = 0x4005dc#64)
   (h_err : r StateField.ERR s = StateError.None) :
   abs_cut (stepi s) = true := by
-  have := abs_stepi_0x4005dc s (stepi s) h_program h_pc h_err
+  have := program.stepi_0x4005dc s (stepi s) h_program h_pc h_err
   simp only [minimal_theory] at this
   simp only [abs_cut, this, state_simp_rules, bitvec_rules, minimal_theory]
   done
@@ -181,7 +181,7 @@ theorem program_effects_lemma (h_pre : abs_pre s0)
   have h_s1 : s1 = run 1 s0 := by
     simp only [run, h_step_1]
   replace h_step_1 : s1 = stepi s0 := h_step_1.symm
-  rw [abs_stepi_0x4005d0 s0 s1 h_s0_program h_s0_pc h_s0_err] at h_step_1
+  rw [program.stepi_0x4005d0 s0 s1 h_s0_program h_s0_pc h_s0_err] at h_step_1
   have h_s1_program : s1.program = program := by
     simp only [h_step_1, h_s0_program,
                state_simp_rules, minimal_theory, bitvec_rules]
@@ -199,7 +199,7 @@ theorem program_effects_lemma (h_pre : abs_pre s0)
   have h_s2 : s2 = run 1 s1 := by
     simp only [run, h_step_2]
   replace h_step_2 : s2 = stepi s1 := h_step_2.symm
-  rw [abs_stepi_0x4005d4 s1 s2 h_s1_program h_s1_pc h_s1_err] at h_step_2
+  rw [program.stepi_0x4005d4 s1 s2 h_s1_program h_s1_pc h_s1_err] at h_step_2
   -- (FIXME) abs_stepi_0x4005d4 should have reduced `decode_bit_masks`.
   simp only [reduceDecodeBitMasks] at h_step_2
   have h_s2_program : s2.program = program := by
@@ -219,7 +219,7 @@ theorem program_effects_lemma (h_pre : abs_pre s0)
   have h_s3 : s3 = run 1 s2 := by
     simp only [run, h_step_3]
   replace h_step_3 : s3 = stepi s2 := h_step_3.symm
-  rw [abs_stepi_0x4005d8 s2 s3 h_s2_program h_s2_pc h_s2_err] at h_step_3
+  rw [program.stepi_0x4005d8 s2 s3 h_s2_program h_s2_pc h_s2_err] at h_step_3
   have h_s3_program : s3.program = program := by
     simp only [h_step_3, h_s2_program,
                state_simp_rules, minimal_theory, bitvec_rules]
@@ -237,7 +237,7 @@ theorem program_effects_lemma (h_pre : abs_pre s0)
   have h_s4 : s4 = run 1 s3 := by
     simp only [run, h_step_4]
   replace h_step_4 : s4 = stepi s3 := h_step_4.symm
-  rw [abs_stepi_0x4005dc s3 s4 h_s3_program h_s3_pc h_s3_err] at h_step_4
+  rw [program.stepi_0x4005dc s3 s4 h_s3_program h_s3_pc h_s3_err] at h_step_4
   have _h_s4_program : s4.program = program := by
     simp only [h_step_4, h_s3_program,
                state_simp_rules, minimal_theory, bitvec_rules]

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -12,7 +12,7 @@ section popcount32
 
 open BitVec
 
-/-! 
+/-!
 Source: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
 
 int popcount_32 (unsigned int v) {
@@ -66,14 +66,14 @@ def popcount32_program : Program :=
    (0x40061c#64 , 0xd65f03c0#32)] -- ret
 
 
-#genStepTheorems popcount32_program namePrefix:="popcount32_" thmType:="fetch"
+#genStepTheorems popcount32_program thmType:="fetch"
 
 -- #guard_msgs in
 -- #check popcount32_fetch_0x4005b4
 
-#genStepTheorems popcount32_program namePrefix:="popcount32_" thmType:="decodeExec"
+#genStepTheorems popcount32_program thmType:="decodeExec"
 
-#genStepTheorems popcount32_program namePrefix:="popcount32_" thmType:="step" `state_simp_rules
+#genStepTheorems popcount32_program thmType:="step" `state_simp_rules
 
 theorem popcount32_sym_no_error (s0 s_final : ArmState)
   (h_s0_pc : read_pc s0 = 0x4005b4#64)

--- a/Proofs/SHA512/Sha512DecodeExecLemmas.lean
+++ b/Proofs/SHA512/Sha512DecodeExecLemmas.lean
@@ -4,7 +4,7 @@ import Proofs.SHA512.Sha512Program
 
 -- set_option trace.gen_step.debug.heartBeats true in
 -- set_option trace.gen_step.print_names true in
-set_option maxHeartbeats 2000000 in
+set_option maxHeartbeats 1005000 in
 #genStepTheorems sha512_program thmType:="decodeExec"
 
 /--

--- a/Proofs/SHA512/Sha512DecodeExecLemmas.lean
+++ b/Proofs/SHA512/Sha512DecodeExecLemmas.lean
@@ -4,7 +4,7 @@ import Proofs.SHA512.Sha512Program
 
 -- set_option trace.gen_step.debug.heartBeats true in
 -- set_option trace.gen_step.print_names true in
-set_option maxHeartbeats 1005000 in
+set_option maxHeartbeats 1002500 in
 #genStepTheorems sha512_program thmType:="decodeExec"
 
 /--

--- a/Proofs/SHA512/Sha512DecodeExecLemmas.lean
+++ b/Proofs/SHA512/Sha512DecodeExecLemmas.lean
@@ -4,11 +4,11 @@ import Proofs.SHA512.Sha512Program
 
 -- set_option trace.gen_step.debug.heartBeats true in
 -- set_option trace.gen_step.print_names true in
-set_option maxHeartbeats 1000000 in
-#genStepTheorems sha512_program namePrefix:="sha512_" thmType:="decodeExec"
+set_option maxHeartbeats 2000000 in
+#genStepTheorems sha512_program thmType:="decodeExec"
 
 /--
-info: sha512_decode_0x1264e8 :
+info: sha512_program.decode_0x1264e8 :
   decode_raw_inst 1310722675#32 =
     some
       (ArmInst.DPSFP
@@ -17,10 +17,10 @@ info: sha512_decode_0x1264e8 :
             _fixed4 := 2#2, Rn := 19#5, Rd := 19#5 }))
 -/
 #guard_msgs in
-#check sha512_decode_0x1264e8
+#check sha512_program.decode_0x1264e8
 
 /--
-info: sha512_exec_0x126c90 (s : ArmState) :
+info: sha512_program.exec_0x126c90 (s : ArmState) :
   exec_inst
       (ArmInst.BR (BranchInst.Compare_branch { sf := 1#1, _fixed := 26#5, op := 1#1, imm19 := 523804#19, Rt := 2#5 }))
       s =
@@ -31,4 +31,4 @@ info: sha512_exec_0x126c90 (s : ArmState) :
       s
 -/
 #guard_msgs in
-#check sha512_exec_0x126c90
+#check sha512_program.exec_0x126c90

--- a/Proofs/SHA512/Sha512FetchLemmas.lean
+++ b/Proofs/SHA512/Sha512FetchLemmas.lean
@@ -5,10 +5,11 @@ import Proofs.SHA512.Sha512Program
 -- set_option trace.gen_step.debug.heartBeats true in
 -- set_option trace.gen_step.print_names true in
 set_option maxHeartbeats 1000000 in
-#genStepTheorems sha512_program namePrefix:="sha512_" thmType:="fetch"
+#genStepTheorems sha512_program thmType:="fetch"
 
 /--
-info: sha512_fetch_0x1264e8 (s : ArmState) (h : s.program = sha512_program) : fetch_inst (1205480#64) s = some 1310722675#32
+info: sha512_program.fetch_0x1264e8 (s : ArmState) (h : s.program = sha512_program) :
+  fetch_inst (1205480#64) s = some 1310722675#32
 -/
 #guard_msgs in
-#check sha512_fetch_0x1264e8
+#check sha512_program.fetch_0x1264e8

--- a/Proofs/SHA512/Sha512StepLemmas.lean
+++ b/Proofs/SHA512/Sha512StepLemmas.lean
@@ -6,14 +6,14 @@ import Proofs.SHA512.Sha512Program
 -- set_option trace.gen_step.debug.heartBeats true in
 -- set_option trace.gen_step.print_names true in
 set_option maxHeartbeats 2000000 in
-#genStepTheorems sha512_program namePrefix:="sha512_" thmType:="step" `state_simp_rules
+#genStepTheorems sha512_program thmType:="step" `state_simp_rules
 
 /--
-info: sha512_stepi_0x126c90 (s sn : ArmState) (h_program : s.program = sha512_program) (h_pc : r StateField.PC s = 1207440#64)
-  (h_err : r StateField.ERR s = StateError.None) :
+info: sha512_program.stepi_0x126c90 (s sn : ArmState) (h_program : s.program = sha512_program)
+  (h_pc : r StateField.PC s = 1207440#64) (h_err : r StateField.ERR s = StateError.None) :
   (sn = stepi s) =
     (sn =
       w StateField.PC (if decide (r (StateField.GPR 2#5) s = BitVec.zero 64) = false then 1205504#64 else 1207444#64) s)
 -/
 #guard_msgs in
-#check sha512_stepi_0x126c90
+#check sha512_program.stepi_0x126c90

--- a/Tactics/StepThms.lean
+++ b/Tactics/StepThms.lean
@@ -45,7 +45,7 @@ def genFetchTheorem (program_name : Name) (address_str : String)
   : MetaM Unit := do
   let startHB ← IO.getNumHeartbeats
   trace[gen_step.debug.heartBeats] "[genFetchTheorem] Start heartbeats: {startHB}"
-  let declName := Name.str program_name s!"fetch_0x{address_str}"
+  let declName := Name.str program_name ("fetch_0x" ++ address_str)
   let s_program_hyp_fn :=
       fun s => -- (s.program = <orig_map>)
          (mkAppN (mkConst ``Eq [1])
@@ -118,7 +118,7 @@ def genExecTheorem (program_name : Name) (address_str : String)
     (decoded_inst : Expr) : MetaM Unit := do
   let startHB ← IO.getNumHeartbeats
   trace[gen_step.debug.heartBeats] "[genExecTheorem] Start heartbeats: {startHB}"
-  let declName := Name.str program_name s!"exec_0x{address_str}"
+  let declName := Name.str program_name ("exec_0x" ++ address_str)
   withLocalDeclD `s (mkConst ``ArmState) fun s => do
     let exec_inst_expr := (mkAppN (mkConst ``exec_inst) #[decoded_inst, s])
     trace[gen_step.debug] "[Exec_inst Expression: {exec_inst_expr}]"
@@ -173,7 +173,7 @@ def genDecodeAndExecTheorems (program_name : Name) (address_str : String)
   MetaM Unit := do
   let startHB ← IO.getNumHeartbeats
   trace[gen_step.debug.heartBeats] "[genDecodeTheorem] Start heartbeats: {startHB}"
-  let declName := Name.str program_name s!"decode_0x{address_str}"
+  let declName := Name.str program_name ("decode_0x" ++ address_str)
   let lhs := (mkAppN (Expr.const ``decode_raw_inst []) #[raw_inst])
   -- reduce and whnfD do too much and expose the internal Fin structure of the
   -- BitVecs below. whnfR does not do enough and leaves the decode_raw_inst term
@@ -215,7 +215,7 @@ def genStepTheorem (program_name : Name) (address_str : String)
   (orig_map address_expr : Expr) (simpExt : Option Name) : MetaM Unit := do
   let startHB ← IO.getNumHeartbeats
   trace[gen_step.debug.heartBeats] "[genStepTheorem] Start heartbeats: {startHB}"
-  let declName := Name.str program_name s!"stepi_0x{address_str}"
+  let declName := Name.str program_name ("stepi_0x" ++ address_str)
   let s_program_hyp_fn :=
       fun s => -- (s.program = <orig_map>)
         (mkAppN (mkConst ``Eq [1])
@@ -322,7 +322,7 @@ partial def genStepTheorems (program map : Expr) (program_name : Name)
     genStepTheorems program tl program_name thm_type simpExt
   | List.nil _ => return
   | _ =>
-    throwError s!"Unexpected program map term! {map}"
+    throwError "Unexpected program map term! {map}"
 
 -- TODO:
 -- The arguments of this command are pretty clunky. For instance, they are sort


### PR DESCRIPTION
### Description:

Change `#genStepTheorems` theorem generation so that the generated theorems are put in the namespace of the program they belong to.

This removes the need for the user to pick a prefix, but most importantly, gives these theorems predictable names, so that other automation (i.e., `sym_n`) knows where to find them.

### Testing:

`make all` succeeds, I've not run conformance testing, since I haven't changed any definitions

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
