### PR TITLE
Modify cosim scripts to work on M* Apple machines

### DIFF
--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -116,9 +116,8 @@ def arm_cosim_test (input : regState) : IO String := do
   if out.exitCode != 0 then
     throw
       <| IO.userError
-      <| "Process '" ++ sargs.cmd ++ "' exited with code "
-          ++ toString out.exitCode ++ "\nStdErr:\n" ++ out.stderr ++
-          (if out.stdout.isEmpty then "" else "\nStdOut:\n" ++ out.stdout)
+      <| s!"Process '{sargs.cmd}' exited with code {out.exitCode}\nStdErr: {out.stderr}" ++
+          (if out.stdout.isEmpty then "" else s!"\nStdOut:\n{out.stdout}")
   pure out.stdout
 
 /-- Call Arm/Insts/Cosim/disasm.sh to get the disassembly of the

--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -99,7 +99,7 @@ def machine_to_regState (inst : BitVec 32) (str : String) : regState :=
   { inst, gpr, nzcv := flags[0]!, sfp }
 
 /-- Call the `armsimulate` script. -/
-def arm_cosim_test (input : regState) : IO String :=
+def arm_cosim_test (input : regState) : IO String := do
   -- Input args for the armsimulate script:
   --  first, the 32-bit instruction
   --  then 31 64-bit GPRs (no SP)
@@ -110,9 +110,16 @@ def arm_cosim_test (input : regState) : IO String :=
   let flags'  := bitvec_to_hex input.nzcv
   let sfps'   := bitvec_to_hex_list input.sfp
   let args    := ([inst'] ++ gprs' ++ [flags'] ++ sfps').toArray
-  -- (FIXME): catch exception nicely
-  IO.Process.run
-  { cmd := "Arm/Insts/Cosim/armsimulate", args := args }
+  let sargs   := { cmd := "Arm/Insts/Cosim/armsimulate", args := args }
+  -- Copied from IO.Process.run:
+  let out ← IO.Process.output sargs
+  if out.exitCode != 0 then
+    throw
+      <| IO.userError
+      <| "Process '" ++ sargs.cmd ++ "' exited with code "
+          ++ toString out.exitCode ++ "\nStdErr:\n" ++ out.stderr ++
+          (if out.stdout.isEmpty then "" else "\nStdOut:\n" ++ out.stdout)
+  pure out.stdout
 
 /-- Call Arm/Insts/Cosim/disasm.sh to get the disassembly of the
 instruction under test. -/

--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -110,7 +110,7 @@ def arm_cosim_test (input : regState) : IO String := do
   let flags'  := bitvec_to_hex input.nzcv
   let sfps'   := bitvec_to_hex_list input.sfp
   let args    := ([inst'] ++ gprs' ++ [flags'] ++ sfps').toArray
-  let sargs   := { cmd := "Arm/Insts/Cosim/armsimulate", args := args }
+  let sargs := { cmd := "Arm/Insts/Cosim/armsimulate", args }
   -- Copied from IO.Process.run:
   let out ← IO.Process.output sargs
   if out.exitCode != 0 then

--- a/Arm/Insts/Cosim/disasm.sh
+++ b/Arm/Insts/Cosim/disasm.sh
@@ -8,15 +8,15 @@ cd Arm/Insts/Cosim
 
 if [ -e instance.o ]; then
 
-    # Disassemble the .text section of instance.o
-    base_cmd="objdump -d -j .text instance.o"
+    # Disassemble instance.o.
+    base_cmd="objdump -d instance.o"
 
     # Get 1 line (i.e., 1 instruction) after a "modinst" match.  Given
     # the layout of instance.S, this will always be the instruction
     # under test.
     raw_inst="grep -A 1 \"modinst\" | tail -n 1"
 
-    # Do not print the address -- just the instruciton bytes and its
+    # Do not print the address -- just the instruction bytes and its
     # corresponding disassembly.
     snip_inst="awk '{\$1=\"\"; print}'"
 

--- a/Arm/Insts/Cosim/platform_check.sh
+++ b/Arm/Insts/Cosim/platform_check.sh
@@ -6,7 +6,8 @@
 
 machine_check () {
     machine=$(uname -m)
-    if [[ $machine == *aarch64* ]]; then
+    -- Most Arm Linux machine use aarch64; some Arm Darwin machines use arm64.
+    if [[ $machine == *aarch64* || $machine == *arm64* ]]; then
 	return 0
     else
 	return 1

--- a/Arm/Insts/Cosim/simulator.c
+++ b/Arm/Insts/Cosim/simulator.c
@@ -13,7 +13,11 @@
 // regs[32 + 2*i+1]: Qi.d[1]
 static uint64_t regs[32 + /*Q registers */2 * 32];
 
-extern uint64_t harness(uint64_t *regfile);
+// [Shilpi]: We explicitly specify the asm routine name to use (i.e.,
+// "harness" instead of "_harness") for predictable behavior across
+// systems.
+// See https://gcc.gnu.org/onlinedocs/gcc-4.4.0/gcc/Asm-Labels.html#Asm-Labels
+extern uint64_t harness(uint64_t *regfile) asm("harness");
 
 void print_regs()
 { uint64_t i;


### PR DESCRIPTION
### Description:

Cosimulation can now be run on Arm-based Apple machines.

### Testing:

`make all` and conformance testing succeeded on an Apple M3 machine and an Amazon Linux Graviton2 machine.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
