### PR TITLE
Reflect decode inst

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -343,8 +343,8 @@ instance : Ord (BitVec n) where
   -- Unsigned comparison
   compare := unsigned_compare
 
-instance : Hashable (BitVec n) where
-  hash x := ⟨Fin.ofNat' x.toNat (by decide)⟩
+instance {w} : Hashable (BitVec w) where
+  hash x := hash x.toNat
 
 -- Making sure that the following are decidable.
 example : 5#4 = 5#4 := by decide

--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -901,4 +901,10 @@ theorem getLsb_extractLsBytes (val : BitVec w) (base : Nat) (n : Nat) (i : Nat) 
   · simp only [extractLsBytes, getLsb_cast, getLsb_extract, Nat.zero_lt_succ, decide_True,
     Bool.true_and]
 
+/-! ## `Quote` instance -/
+
+instance (w : Nat) : Quote (BitVec w) `term where
+  quote x :=
+    Syntax.mkCApp ``BitVec.ofNat #[quote w, quote x.toNat]
+
 end BitVec

--- a/Tactics/Common.lean
+++ b/Tactics/Common.lean
@@ -81,7 +81,6 @@ def getStateFieldString? (e : Expr) : MetaM (Option String) := OptionT.run do
 
 /-! ## Reflection of literals (possibly after reduction) -/
 
-#check BitVec.ofFin
 
 /-- A wrapper around `Lean.Meta.getBitVecValue?`
 that additionally recognizes:

--- a/Tactics/Common.lean
+++ b/Tactics/Common.lean
@@ -78,3 +78,99 @@ def getStateFieldString? (e : Expr) : MetaM (Option String) := OptionT.run do
   | StateField.FLAG pExpr => getPFlagString? pExpr
   | StateField.ERR        => return "err"
   | _                     => panic! s!"[getStateFieldName?] Unexpected expression: {e}"
+
+/-! ## Reflection of literals (possibly after reduction) -/
+
+#check BitVec.ofFin
+
+/-- A wrapper around `Lean.Meta.getBitVecValue?`
+that additionally recognizes:
+- a `BitVec.ofFin (Fin.mk _ _)` application (which is the raw normal form)
+-/
+-- TODO: should this be upstreamed to core?
+def getBitVecValue? (e : Expr) : MetaM (Option ((n : Nat) × BitVec n)) :=
+  match_expr e with
+    | BitVec.ofFin _ i => OptionT.run do
+      let ⟨n, i⟩ ← getFinValue? i
+      let n' := Nat.log2 n
+      if h : n = 2^n' then
+        return ⟨n', .ofFin (Fin.cast h i)⟩
+      else
+        failure
+    | _ => Lean.Meta.getBitVecValue? e
+
+/-- Given a ground term `e` of type `Nat`, fully reduce it,
+and attempt to reflect it into a meta-level `Nat` -/
+def reflectNatLiteral (e : Expr) : MetaM Nat := do
+  if e.hasFVar then
+    throwError "Expected a ground term, but {e} has free variables"
+
+  let e' ← reduce (← instantiateMVars e)
+  let some x := e'.rawNatLit?
+    | throwError "Expected a numeric literal, found:\n\t{e'}
+which was obtained by reducing:\n\t{e}"
+  -- ^^ The previous reduction will have reduced a canonical-form nat literal
+  --    into a raw literal, hence, we use `rawNatLit?` rather than `nat?`
+  return x
+
+/-- For a concrete width `w`,
+reduce an expression `e` (of type `BitVec w`) to be of the form `?n#w`,
+and then reflect `?n` to build the meta-level bitvector -/
+def reflectBitVecLiteral (w : Nat) (e : Expr) : MetaM (BitVec w) := do
+  if e.hasFVar then
+    throwError "Expected a ground term, but {e} has free variables"
+
+  if let some ⟨n, x⟩ ← _root_.getBitVecValue? e then
+    if h : n = w then
+      return x.cast h
+    else
+      throwError "Expected a bitvector of width {w}, but\n\t{e}\nhas width {n}"
+
+  let x ← mkFreshExprMVar (Expr.const ``Nat [])
+  let e' ← mkAppM ``BitVec.ofNat #[toExpr w, x]
+  if (←isDefEq e e') then
+    return BitVec.ofNat w (← reflectNatLiteral x)
+  else
+    throwError "Failed to unify, expected:\n\t{e'}\nbut found:\n\t{e'}"
+
+/-! ## Local Context Search -/
+
+/-- Attempt to look-up a `name` in the local context,
+so that we can build an expression with its fvarid,
+to return a message with nice highlighting.
+If lookup fails, we return a message with the plain name, wihout highlighting -/
+def userNameToMessageData (name : Name) : MetaM MessageData := do
+  return match (← getLCtx).findFromUserName? name with
+    | some decl => m!"{Expr.fvar decl.fvarId}"
+    | none      => m!"{name}"
+
+def findLocalDeclOfType? (expectedType : Expr) : MetaM (Option LocalDecl) := do
+    let fvarId ← findLocalDeclWithType? expectedType
+    return ((← getLCtx).get! ·) <$> fvarId
+    -- ^^ `findLocalDeclWithType?` only returns `FVarId`s which are present in
+    --    the local context, so we can safely pass it to `get!`
+
+def findLocalDeclOfTypeOrError (expectedType : Expr) : MetaM LocalDecl := do
+    let some name ← findLocalDeclOfType? expectedType
+      | throwError "Failed to find a local hypothesis of type {expectedType}"
+    return name
+
+/-- `findProgramHyp` searches the local context for an hypothesis of type
+  `state.program = ?concreteProgram`,
+asserts that `?concreteProgram` is indeed a constant (i.e., global definition),
+then returns the decl of the local hypothesis and the name of the program.
+
+Throws an error if no such hypothesis could. -/
+def findProgramHyp (state : Expr) : MetaM (LocalDecl × Name) := do
+  -- Try to find `h_program`, and infer `program` from it
+  let program ← mkFreshExprMVar none
+  let h_program_type ← mkEq (← mkAppM ``ArmState.program #[state]) program
+  let h_program ← findLocalDeclOfTypeOrError h_program_type
+
+  -- Assert that `program` is a(n application of a) constant, and find its name
+  let program := (← instantiateMVars program).getAppFn
+  let .const program _ := program
+    |  -- withErrorContext h_run h_run_type <|
+        throwError "Expected a constant, found:\n\t{program}"
+
+  return ⟨h_program, program⟩

--- a/Tactics/Reflect/FetchAndDecode.lean
+++ b/Tactics/Reflect/FetchAndDecode.lean
@@ -19,7 +19,7 @@ def reduceFetchInst? (addr : Expr) (s : Expr) :
 
   let addr ← reflectBitVecLiteral 64 addr
   let ⟨programHyp, program⟩ ← findProgramHyp s
-  let programInfo ← try ProgramInfo.generateFromConstName program catch err =>
+  let programInfo ← try ProgramInfo.lookupOrGenerate program catch err =>
     throwErrorAt
       err.getRef
       "Could not generate ProgramInfo for {program}:\n\n{err.toMessageData}"

--- a/Tactics/Reflect/FetchAndDecode.lean
+++ b/Tactics/Reflect/FetchAndDecode.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
+import Arm.State
+import Tactics.Common
+import Tactics.Reflect.ProgramInfo
+
+open Lean Meta
+open Elab.Tactic Elab.Term
+
+initialize
+  Lean.registerTraceClass `Sym.reduceFetchInst
+
+def reduceFetchInst? (addr : Expr) (s : Expr) :
+    MetaM (BitVec 32 × Expr) := do
+  let e := mkApp2 (mkConst ``fetch_inst) addr s
+
+  let addr ← reflectBitVecLiteral 64 addr
+  let ⟨programHyp, program⟩ ← findProgramHyp s
+  let programInfo ← try ProgramInfo.generateFromConstName program catch err =>
+    throwErrorAt
+      err.getRef
+      "Could not generate ProgramInfo for {program}:\n\n{err.toMessageData}"
+
+  let some rawInst := programInfo.getRawInstrAt? addr
+    | throwError "No instruction found at address {addr}"
+
+  trace[Sym.reduceFetchInst] "{Lean.checkEmoji} reduced to: {rawInst}"
+
+  -- Now, construct the proof
+  let eqType ← mkEq e (toExpr (some rawInst))
+  trace[Sym.reduceFetchInst] "⚙️ deriving a proof of:\n\t{eqType}"
+
+  let h_program := mkIdent programHyp.userName
+  let eqProofStx ← `(term| by
+    unfold fetch_inst; rw [$h_program:ident]; decide
+  )
+  let proof ← TermElabM.run' <| do
+    let h ← elabTermEnsuringType eqProofStx eqType
+    synthesizeSyntheticMVarsNoPostponing
+    instantiateMVars h
+
+  trace[Sym.reduceFetchInst] "{Lean.checkEmoji} found a proof:\n\t{proof}"
+  return ⟨rawInst, proof⟩
+
+simproc reduceFetchInst (fetch_inst _ _) := fun e => do
+  trace[Sym.reduceFetchInst] "⚙️ simplifying {e}"
+  let_expr fetch_inst addr s := e
+    | return .continue
+
+  try
+    let ⟨x, proof?⟩ ← reduceFetchInst? addr s
+    return .done {expr := toExpr (some x), proof?}
+  catch err =>
+    trace[Sym.reduceFetchInst] "{Lean.crossEmoji} {err.toMessageData}"
+    return .continue

--- a/Tactics/Reflect/FetchAndDecode.lean
+++ b/Tactics/Reflect/FetchAndDecode.lean
@@ -13,10 +13,16 @@ open Elab.Tactic Elab.Term
 initialize
   Lean.registerTraceClass `Sym.reduceFetchInst
 
+theorem fetch_inst_eq_of_prgram_eq_of_map_find
+    {state : ArmState} {program : Program}
+    {addr : BitVec 64} {inst? : Option (BitVec 32)}
+    (h_program : state.program = program)
+    (h_map : program.find? addr = inst?) :
+    fetch_inst addr state = inst? := by
+  rw [fetch_inst, h_program, h_map]
+
 def reduceFetchInst? (addr : Expr) (s : Expr) :
     MetaM (BitVec 32 × Expr) := do
-  let e := mkApp2 (mkConst ``fetch_inst) addr s
-
   let addr ← reflectBitVecLiteral 64 addr
   let ⟨programHyp, program⟩ ← findProgramHyp s
   let programInfo ← try ProgramInfo.lookupOrGenerate program catch err =>
@@ -30,18 +36,17 @@ def reduceFetchInst? (addr : Expr) (s : Expr) :
   trace[Sym.reduceFetchInst] "{Lean.checkEmoji} reduced to: {rawInst}"
 
   -- Now, construct the proof
-  let eqType ← mkEq e (toExpr (some rawInst))
-  trace[Sym.reduceFetchInst] "⚙️ deriving a proof of:\n\t{eqType}"
-
-  let h_program := mkIdent programHyp.userName
-  let eqProofStx ← `(term| by
-    unfold fetch_inst; rw [$h_program:ident]; decide
-  )
-  let proof ← TermElabM.run' <| do
-    let h ← elabTermEnsuringType eqProofStx eqType
-    synthesizeSyntheticMVarsNoPostponing
-    instantiateMVars h
-
+  let proof := mkAppN (mkConst ``fetch_inst_eq_of_prgram_eq_of_map_find) #[
+    s,
+    mkConst program,
+    toExpr addr,
+    toExpr (some rawInst),
+    programHyp.toExpr,
+    mkApp2 (.const ``Eq.refl [1])
+      (mkApp (.const ``Option [0]) <|
+        mkApp (.const ``BitVec []) (toExpr 32))
+      (toExpr (some rawInst))
+  ]
   trace[Sym.reduceFetchInst] "{Lean.checkEmoji} found a proof:\n\t{proof}"
   return ⟨rawInst, proof⟩
 

--- a/Tactics/Reflect/ProgramInfo.lean
+++ b/Tactics/Reflect/ProgramInfo.lean
@@ -17,10 +17,6 @@ Furthermore, we define a persistent env extension to store `ProgramInfo` in.
 
 open Lean Meta Elab.Term
 
--- TODO: upstream this instance
-instance {w} : Hashable (BitVec w) where
-  hash x := hash x.toNat
-
 structure ProgramInfo where
   rawProgram : HashMap (BitVec 64) (BitVec 32)
 

--- a/Tactics/Reflect/ProgramInfo.lean
+++ b/Tactics/Reflect/ProgramInfo.lean
@@ -28,8 +28,6 @@ def ProgramInfo.getRawInstrAt? (pi : ProgramInfo) (addr : BitVec 64) :
     Option (BitVec 32) :=
   pi.rawProgram.find? addr
 
-#check def_program
-
 /-- Given an `Expr` of type `Program`, generate the basic `ProgramInfo` -/
 partial def ProgramInfo.generateFromExpr (e : Expr) : MetaM ProgramInfo := do
   let type ← inferType e

--- a/Tactics/Reflect/ProgramInfo.lean
+++ b/Tactics/Reflect/ProgramInfo.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
+import Arm.Map
+import Tactics.Common
+
+/-!
+# ProgramInfo
+We establish a `ProgramInfo` structure,
+which stores (reflected) information about ARM programs.
+
+Furthermore, we define a persistent env extension to store `ProgramInfo` in.
+
+-/
+
+open Lean Meta Elab.Term
+
+-- TODO: upstream this instance
+instance {w} : Hashable (BitVec w) where
+  hash x := hash x.toNat
+
+structure ProgramInfo where
+  rawProgram : HashMap (BitVec 64) (BitVec 32)
+
+def ProgramInfo.getRawInstrAt? (pi : ProgramInfo) (addr : BitVec 64) :
+    Option (BitVec 32) :=
+  pi.rawProgram.find? addr
+
+#check def_program
+
+/-- Given an `Expr` of type `Program`, generate the basic `ProgramInfo` -/
+partial def ProgramInfo.generateFromExpr (e : Expr) : MetaM ProgramInfo := do
+  let type ← inferType e
+  if !(←isDefEq type (mkConst ``Program)) then
+    throwError "type mismatch: {e} {← mkHasTypeButIsExpectedMsg type (mkConst ``Program)}"
+
+  let rec go (rawProgram : HashMap _ _) (e : Expr) : MetaM (HashMap _ _) := do
+    let e ← whnfD e
+    match_expr e with
+    | List.cons _ hd tl => do
+        let hd' ← reduce hd
+        let_expr Prod.mk _ _ addr inst := hd'
+          | throwError "expected `{hd}` to reduce to an application of `Prod.mk`, found:\n\t{hd'}"
+
+        let addr ← reflectBitVecLiteral 64 addr
+        let inst ← reflectBitVecLiteral 32 inst
+
+        let rawProgram := rawProgram.insert addr inst
+        go rawProgram tl
+    | List.nil _ => return rawProgram
+    | _ => throwError "expected `List.cons _ _` or `List.nil`, found:\n\t{e}"
+
+  return {
+    rawProgram := ← go ∅ e
+  }
+
+/-- Given the `Name` of a constant of type `Program`,
+generate the basic `ProgramInfo` -/
+def ProgramInfo.generateFromConstName (program : Name) : MetaM ProgramInfo := do
+  let .defnInfo defnInfo ← getConstInfo program
+    | throwError "expected a definition, but {program} is not"
+  generateFromExpr defnInfo.value
+
+/-! ## Env Extension -/
+
+initialize programInfoExt : PersistentEnvExtension (Name × ProgramInfo) (Name × ProgramInfo) (NameMap ProgramInfo) ←
+  registerPersistentEnvExtension {
+    name            := `programInfo
+    mkInitial       := pure {}
+    addImportedFn   := fun _ _ => pure {}
+    addEntryFn      := fun s p => s.insert p.1 p.2
+    exportEntriesFn := fun m =>
+      let r : Array (Name × _) := m.fold (fun a n p => a.push (n, p)) #[]
+      r.qsort (fun a b => Name.quickLt a.1 b.1)
+    statsFn         := fun s =>
+      "program info extension" ++ Format.line
+      ++ "number of local entries: " ++ format s.size
+  }
+
+/-- look up the `ProgramInfo` for a given program in the environment -/
+def ProgramInfo.lookup? [Monad m] [MonadEnv m] (program : Name) :
+    m (Option ProgramInfo) := do
+  let env ← getEnv
+  let state := programInfoExt.getState env
+  return state.find? program
+
+/-! ## `@[program]` attribute
+We define an attribute, such that annotating a defintion with `@[program]`
+will generate the relevant `ProgramInfo` and store it in the environment
+-/

--- a/Tactics/Reflect/ProgramInfo.lean
+++ b/Tactics/Reflect/ProgramInfo.lean
@@ -9,7 +9,7 @@ import Tactics.Common
 /-!
 # ProgramInfo
 We establish a `ProgramInfo` structure,
-which stores (reflected) information about ARM programs.
+which stores (reflected) information about Arm programs.
 
 Furthermore, we define a persistent env extension to store `ProgramInfo` in.
 

--- a/Tests/Tactics/ReduceFetchInst.lean
+++ b/Tests/Tactics/ReduceFetchInst.lean
@@ -5,9 +5,18 @@ Author(s): Alex Keizer
 -/
 import Tactics.Reflect.FetchAndDecode
 import Tests.«AES-GCM».GCMGmultV8Program
+import Proofs.SHA512.SHA512Program
 
 /-! ## Tests for `refuceFetchInst` simproc -/
 
 example (h : s.program = GCMGmultV8Program.gcm_gmult_v8_program) :
     fetch_inst 0x7d8800#64 s = (some 1279294481#32) := by
+  simp (config := {ground := false}) only [reduceFetchInst]
+
+example (h : s.program = sha512_program) :
+    fetch_inst 0x1264c4#64 s = (some 0x910003fd#32) := by
+  simp (config := {ground := false}) only [reduceFetchInst]
+
+example (h : s.program = sha512_program) :
+    fetch_inst 0x126c94#64 s = (some 0x4c002c00#32) := by
   simp (config := {ground := false}) only [reduceFetchInst]

--- a/Tests/Tactics/ReduceFetchInst.lean
+++ b/Tests/Tactics/ReduceFetchInst.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
 import Tactics.Reflect.FetchAndDecode
 import Tests.«AES-GCM».GCMGmultV8Program
 

--- a/Tests/Tactics/ReduceFetchInst.lean
+++ b/Tests/Tactics/ReduceFetchInst.lean
@@ -20,3 +20,19 @@ example (h : s.program = sha512_program_map) :
 example (h : s.program = sha512_program_map) :
     fetch_inst 0x126c98#64 s = (some 0xf84107fd#32) := by
   simp (config := {ground := false}) only [reduceFetchInst]
+
+/-! ## Tests for `refuceDecodeInst` simproc -/
+
+/--
+error: unsolved goals
+z : Option ArmInst
+⊢ some
+      (ArmInst.LDST
+        (LDSTInst.Advanced_simd_multiple_struct
+          { _fixed1 := 0#1, Q := 1#1, _fixed2 := 24#7, L := 1#1, _fixed3 := 0#6, opcode := 7#4, size := 3#2, Rn := 0#5,
+            Rt := 17#5 })) =
+    z
+-/
+#guard_msgs in
+example : decode_raw_inst 1279294481#32 = z := by
+  simp (config := {ground := false}) only [reduceDecodeInst]

--- a/Tests/Tactics/ReduceFetchInst.lean
+++ b/Tests/Tactics/ReduceFetchInst.lean
@@ -42,7 +42,7 @@ h : s.program = sha512_program_map
     fetch_inst 0x126c98#64 s = z := by
   simp (config := {ground := false}) only [reduceFetchInst]
 
-/-! ## Tests for `refuceDecodeInst` simproc -/
+/-! ## Tests for `reduceDecodeInst` simproc -/
 
 /--
 error: unsolved goals

--- a/Tests/Tactics/ReduceFetchInst.lean
+++ b/Tests/Tactics/ReduceFetchInst.lean
@@ -5,7 +5,7 @@ Author(s): Alex Keizer
 -/
 import Tactics.Reflect.FetchAndDecode
 import Tests.«AES-GCM».GCMGmultV8Program
-import Proofs.SHA512.SHA512Program
+import Tests.SHA2.SHA512ProgramTest
 
 /-! ## Tests for `refuceFetchInst` simproc -/
 
@@ -13,10 +13,10 @@ example (h : s.program = GCMGmultV8Program.gcm_gmult_v8_program) :
     fetch_inst 0x7d8800#64 s = (some 1279294481#32) := by
   simp (config := {ground := false}) only [reduceFetchInst]
 
-example (h : s.program = sha512_program) :
-    fetch_inst 0x1264c4#64 s = (some 0x910003fd#32) := by
+example (h : s.program = sha512_program_map) :
+    fetch_inst 0x1264c0#64 s = (some 0xa9bf7bfd#32) := by
   simp (config := {ground := false}) only [reduceFetchInst]
 
-example (h : s.program = sha512_program) :
-    fetch_inst 0x126c94#64 s = (some 0x4c002c00#32) := by
+example (h : s.program = sha512_program_map) :
+    fetch_inst 0x126c98#64 s = (some 0xf84107fd#32) := by
   simp (config := {ground := false}) only [reduceFetchInst]

--- a/Tests/Tactics/ReduceFetchInst.lean
+++ b/Tests/Tactics/ReduceFetchInst.lean
@@ -1,0 +1,8 @@
+import Tactics.Reflect.FetchAndDecode
+import Tests.«AES-GCM».GCMGmultV8Program
+
+/-! ## Tests for `refuceFetchInst` simproc -/
+
+example (h : s.program = GCMGmultV8Program.gcm_gmult_v8_program) :
+    fetch_inst 0x7d8800#64 s = (some 1279294481#32) := by
+  simp (config := {ground := false}) only [reduceFetchInst]

--- a/Tests/Tactics/ReduceFetchInst.lean
+++ b/Tests/Tactics/ReduceFetchInst.lean
@@ -9,16 +9,37 @@ import Tests.SHA2.SHA512ProgramTest
 
 /-! ## Tests for `refuceFetchInst` simproc -/
 
-example (h : s.program = GCMGmultV8Program.gcm_gmult_v8_program) :
-    fetch_inst 0x7d8800#64 s = (some 1279294481#32) := by
+/--
+error: unsolved goals
+s : ArmState
+z : Option (BitVec 32)
+h : s.program = GCMGmultV8Program.gcm_gmult_v8_program
+⊢ some 1279294481#32 = z
+-/
+#guard_msgs in example (h : s.program = GCMGmultV8Program.gcm_gmult_v8_program) :
+    fetch_inst 0x7d8800#64 s = z := by
   simp (config := {ground := false}) only [reduceFetchInst]
 
-example (h : s.program = sha512_program_map) :
-    fetch_inst 0x1264c0#64 s = (some 0xa9bf7bfd#32) := by
+/--
+error: unsolved goals
+s : ArmState
+z : Option (BitVec 32)
+h : s.program = sha512_program_map
+⊢ some 2847898621#32 = z
+-/
+#guard_msgs in example (h : s.program = sha512_program_map) :
+    fetch_inst 0x1264c0#64 s = z := by
   simp (config := {ground := false}) only [reduceFetchInst]
 
-example (h : s.program = sha512_program_map) :
-    fetch_inst 0x126c98#64 s = (some 0xf84107fd#32) := by
+/--
+error: unsolved goals
+s : ArmState
+z : Option (BitVec 32)
+h : s.program = sha512_program_map
+⊢ some 4165011453#32 = z
+-/
+#guard_msgs in example (h : s.program = sha512_program_map) :
+    fetch_inst 0x126c98#64 s = z := by
   simp (config := {ground := false}) only [reduceFetchInst]
 
 /-! ## Tests for `refuceDecodeInst` simproc -/
@@ -33,6 +54,5 @@ z : Option ArmInst
             Rt := 17#5 })) =
     z
 -/
-#guard_msgs in
-example : decode_raw_inst 1279294481#32 = z := by
+#guard_msgs in example : decode_raw_inst 1279294481#32 = z := by
   simp (config := {ground := false}) only [reduceDecodeInst]

--- a/Tests/Tactics/Sym.lean
+++ b/Tests/Tactics/Sym.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
 import Proofs.«AES-GCM».GCMGmultV8Sym
 
 namespace GCMGmultV8Program

--- a/Tests/Tests.lean
+++ b/Tests/Tests.lean
@@ -19,3 +19,5 @@ import «Tests».«AES-GCM».AESGCMProgramTests
 import «Tests».«ELFParser».AWSLCCrypto
 import «Tests».«ELFParser».MiscTests
 import «Tests».Tactics.CSE
+import «Tests».Tactics.Sym
+import «Tests».Tactics.ReduceFetchInst


### PR DESCRIPTION
### Description:

We add a `reduceDecodeInst` simproc, which will reduce `decode_raw_inst ?someConcreteRawInst` ground terms to a concrete decoded instruction.

Eventually, we'd like to do this by reflecting the raw instruction, running the decode function at meta-time, and then converting the value back to an expression. However, this requires `ToExpr` instances for all parts of instructions, and without a `ToExpr` derive handler available to us, this is extraordinarily painful.

Thus, we make do with `reduce`. This, however, also breaks down our nice `BitVec.ofNat` canonical form into the underlying `Fin`. We don't want this to happen, so we also add a `canonicalizeBitVec` helper function, which walks the expression and refolds bitvectors into what we consider to be the canonical form.
I've picked `BitVec.ofNat` for this, but that transformation does lose

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine?

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
