### PR TITLE
refactor: assorted cleanups of `Sym`/`SymContext`

### DIFF
--- a/Proofs/Experiments/SHA512MemoryAliasing.lean
+++ b/Proofs/Experiments/SHA512MemoryAliasing.lean
@@ -82,7 +82,7 @@ theorem sha512_block_armv8_prelude_sym_ctx_access (s0 : ArmState)
   -- Prelude
   -- simp_all only [state_simp_rules, -h_run]
   -- Symbolic Simulation
-  -- sym1_i_n 0 4 h_s0_program
+  -- sym1_n 4
   sorry
 
 /-

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -85,7 +85,7 @@ theorem popcount32_sym_no_error (s0 s_final : ArmState)
   -- Prelude
   simp_all only [state_simp_rules, -h_run]
   -- Symbolic Simulation
-  sym1_i_n 0 27 h_s0_program
+  sym1_n 27
   try (clear h_step_1 h_step_2 h_step_3 h_step_4;
        clear h_step_5 h_step_6 h_step_7 h_step_8;
        clear h_step_9 h_step_10;
@@ -111,7 +111,7 @@ theorem popcount32_sym_no_error (s0 s_final : ArmState)
 --   -- Prelude
 --   simp_all only [state_simp_rules, -h_run]
 --   -- Symbolic Simulation
---   sym1_i_n 0 27 h_s0_program
+--   sym1_n 27
 --   try (clear h_step_1 h_step_2 h_step_3 h_step_4;
 --        clear h_step_5 h_step_6 h_step_7 h_step_8;
 --        clear h_step_9 h_step_10;

--- a/Proofs/SHA512/Sha512Sym.lean
+++ b/Proofs/SHA512/Sha512Sym.lean
@@ -18,7 +18,7 @@ section SHA512_Proof
 -- set_option pp.deepTerms false in
 theorem sha512_block_armv8_test_4_sym (s0 s_final : ArmState)
   (h_s0_err : read_err s0 = StateError.None)
-  (h_s0_sp_aligned : CheckSPAlignment s0 = true)
+  (h_s0_sp_aligned : CheckSPAlignment s0)
   (h_s0_pc : read_pc s0 = 0x1264c4#64)
   (h_s0_program : s0.program = sha512_program)
   (h_run : s_final = run 11 s0) :
@@ -26,7 +26,7 @@ theorem sha512_block_armv8_test_4_sym (s0 s_final : ArmState)
   -- Prelude
   simp_all only [state_simp_rules, -h_run]
   -- Symbolic Simulation
-  sym1_i_n 0 11 h_s0_program
+  sym1_n 11
   try (clear h_step_1 h_step_2 h_step_3 h_step_4;
        clear h_step_5 h_step_6 h_step_7 h_step_8;
        clear h_step_9 h_step_10 h_step_11)
@@ -37,7 +37,7 @@ theorem sha512_block_armv8_test_4_sym (s0 s_final : ArmState)
   done
 
 /-
-  -- sym1_i_n 0 1 h_s0_program
+  -- sym1_n 1
   -- let s0_x31 := (r (StateField.GPR 31#5) s0)
   -- simp only [state_value] at s0_x31
   -- have h_s0_x31 : s0_x31 = (r (StateField.GPR 31#5) s0) := by rfl

--- a/Tactics/Common.lean
+++ b/Tactics/Common.lean
@@ -81,7 +81,6 @@ def getStateFieldString? (e : Expr) : MetaM (Option String) := OptionT.run do
 
 /-! ## Reflection of literals (possibly after reduction) -/
 
-
 /-- A wrapper around `Lean.Meta.getBitVecValue?`
 that additionally recognizes:
 - a `BitVec.ofFin (Fin.mk _ _)` application (which is the raw normal form)

--- a/Tactics/StepThms.lean
+++ b/Tactics/StepThms.lean
@@ -306,11 +306,9 @@ partial def genStepTheorems (program map : Expr) (program_name : Name)
       throwError "Unexpected program map entry! {hd}"
     let address_expr ← whnfR address_expr -- whnfR vs whnfD?
     let raw_inst_expr ← whnfR raw_inst_expr
-    let address_str ← getBitVecString? address_expr (hex := true)
-    if address_str.isNone then
-      throwError "We expect program addresses to be concrete. \
+    let some address_string ← getBitVecString? address_expr (hex := true)
+      | throwError "We expect program addresses to be concrete. \
                   Found this instead: {address_expr}."
-    let address_string := address_str.get!
     trace[gen_step.debug] "[genStepTheorems: address_expr {address_expr} \
                               raw_inst_expr {raw_inst_expr}]"
     if thm_type == "fetch" then

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -127,7 +127,7 @@ end stepiTac
 open Lean.Elab.Tactic (TacticM withMainContext evalTactic) in
 def sym1 (c : SymContext) : TacticM SymContext :=
   withMainContext do
-    let c' := c.nextState
+    let c' := c.next
     -- h_st: prefix of user names of hypotheses about state st
     let h_st_prefix := Lean.Syntax.mkStrLit s!"h_{c.state}"
     -- h_step_n': name of the hypothesis with the `stepi` function

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -18,6 +18,7 @@ initialize
 
 open BitVec
 open Lean (FVarId)
+open Lean.Elab.Tactic (TacticM evalTactic withMainContext)
 
 /-- `init_next_step h_run` splits the hypothesis
 
@@ -40,8 +41,8 @@ macro "init_next_step" h_run:ident h_step:ident sn:ident : tactic =>
      clear $h_run:ident; rename_i $h_run:ident
      simp (config := {ground := true}) only at $h_run:ident))
 
-def sym_one (curr_state_number : Nat) : Lean.Elab.Tactic.TacticM Unit :=
-  Lean.Elab.Tactic.withMainContext do
+def sym_one (curr_state_number : Nat) : TacticM Unit :=
+  withMainContext do
     let n_str := toString curr_state_number
     let n'_str := toString (curr_state_number + 1)
     let mk_name (s : String) : Lean.Name :=
@@ -59,7 +60,7 @@ def sym_one (curr_state_number : Nat) : Lean.Elab.Tactic.TacticM Unit :=
     let h_run := Lean.mkIdent (mk_name "h_run")
     -- h_step_n': name of the hypothesis with the `stepi` function
     let h_step_n' := Lean.mkIdent (mk_name ("h_step_" ++ n'_str))
-    Lean.Elab.Tactic.evalTactic (←
+    evalTactic (←
       `(tactic|
          (init_next_step $h_run:ident $h_step_n':ident $st':ident
           -- Simulate one instruction
@@ -124,7 +125,6 @@ elab "stepi_tac" h_step:ident hyp_prefix:str : tactic =>
 
 end stepiTac
 
-open Lean.Elab.Tactic (TacticM withMainContext evalTactic) in
 def sym1 (c : SymContext) : TacticM SymContext :=
   withMainContext do
     let c' := c.next

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -160,6 +160,7 @@ h_run      : sf = run $STEPS s0
 Where $PC and $STEPS are concrete constants.
 Note that the tactic will search for assumption of *exactly* these names,
 it won't search by def-eq -/
+@[deprecated "Use `sym1_n` instead"]
 elab "sym1_i_n" i:num n:num _program:(ident)? : tactic => do
   Lean.Elab.Tactic.evalTactic (← `(tactic|
     simp (config := {failIfUnchanged := false}) only [state_simp_rules] at *

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -127,21 +127,20 @@ end stepiTac
 
 def sym1 (c : SymContext) : TacticM SymContext :=
   withMainContext do
-    let c' := c.next
-    -- h_st: prefix of user names of hypotheses about state st
+    trace[Sym] "(sym1): simulating step {c.curr_state_number}:\n{repr c}"
+    let h_step_n' := Lean.mkIdent (.mkSimple s!"h_step_{c.curr_state_number + 1}")
     let h_st_prefix := Lean.Syntax.mkStrLit s!"h_{c.state}"
-    -- h_step_n': name of the hypothesis with the `stepi` function
-    let h_step_n' := Lean.mkIdent (.str .anonymous s!"h_step_{c'.curr_state_number}")
+
     let stx ←
       `(tactic|
-         (init_next_step $c.h_run_ident:ident $h_step_n':ident $c'.state_ident:ident
+         (init_next_step $c.h_run_ident:ident $h_step_n':ident $c.next_state_ident:ident
           -- Simulate one instruction
           stepi_tac $h_step_n':ident $h_st_prefix:str
           intro_fetch_decode_lemmas $h_step_n':ident $c.h_program_ident:ident $h_st_prefix:str
       ))
     trace[Sym] "Running tactic:\n{stx}"
     evalTactic stx
-    return c'
+    return c.next
 
 
 open Lean (Name) in

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -277,17 +277,20 @@ def default (curr_state_number : Nat) : SymContext :=
 
 /-! ## Incrementing the context to the next state -/
 
-/-- `c.nextState` generates names for the next intermediate state in
-symbolic evaluation.
+/-- `next_state` generates the name for the next intermediate state -/
+def next_state (c : SymContext) : Name :=
+  .mkSimple s!"{c.state_prefix}{c.curr_state_number + 1}"
+
+/-- `c.next` generates names for the next intermediate state and its hypotheses
 
 `nextPc?`, if given, will be the pc of the next context.
 If `nextPC?` is `none`, then the previous pc is incremented by 4 -/
-def nextState (c : SymContext) (nextPc? : Option (BitVec 64) := none) :
+def next (c : SymContext) (nextPc? : Option (BitVec 64) := none) :
     SymContext :=
   let curr_state_number := c.curr_state_number + 1
-  let s := s!"{c.state_prefix}{curr_state_number}"
+  let s := c.next_state
   {
-    state     := .mkSimple s
+    state     := s
     h_run     := c.h_run
     h_program := .mkSimple s!"h_{s}_program"
     h_pc      := .mkSimple s!"h_{s}_pc"
@@ -312,6 +315,7 @@ def h_err : Name := c.h_err?.getD (.mkSimple s!"h_{c.state}_err")
 def h_sp  : Name := c.h_err?.getD (.mkSimple s!"h_{c.state}_sp")
 
 def state_ident       : Ident := mkIdent c.state
+def next_state_ident  : Ident := mkIdent c.next_state
 def h_run_ident       : Ident := mkIdent c.h_run
 def h_program_ident   : Ident := mkIdent c.h_program
 def h_pc_ident        : Ident := mkIdent c.h_pc


### PR DESCRIPTION
### Description:

A collection of non-functional refactors to the `Sym` and `SymContext` files among which:
- Introduce `SymContext.next_state` to generate the name for the next intermediate state
- Rename `h_err`/`h_sp` fields to `h_err?`/`h_sp?` to reflect they are options, and introduce `h_err`/`h_sp` functions with a hard-coded default value
- Reduce the use of full-qualified names, through `open`
- Deprecate `sym1_i_n` (which uses hard-coded names) in favour of `sym1_n` (which searches the local context)

### Testing:

`make all` runs locally

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
