### PR TITLE
fix: use simprocs in step-theorem generation

### DIFF
--- a/Proofs/Experiments/AbsVCG.lean
+++ b/Proofs/Experiments/AbsVCG.lean
@@ -200,8 +200,6 @@ theorem program_effects_lemma (h_pre : abs_pre s0)
     simp only [run, h_step_2]
   replace h_step_2 : s2 = stepi s1 := h_step_2.symm
   rw [program.stepi_0x4005d4 s1 s2 h_s1_program h_s1_pc h_s1_err] at h_step_2
-  -- (FIXME) abs_stepi_0x4005d4 should have reduced `decode_bit_masks`.
-  simp only [reduceDecodeBitMasks] at h_step_2
   have h_s2_program : s2.program = program := by
     simp only [h_step_2, h_s1_program,
                state_simp_rules, minimal_theory, bitvec_rules]
@@ -274,6 +272,7 @@ theorem program_effects_lemma (h_pre : abs_pre s0)
             BitVec.truncate 64 1#32)) := by
     simp (config := {decide := true}) only [h_step_4, h_step_3, h_step_2, h_step_1,
                                             state_simp_rules]
+    rfl
 
   have h_sf_s4 : sf = s4 := by
     simp only [h_run, h_s4, h_s3, h_s2, h_s1, run]

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -126,4 +126,25 @@ theorem popcount32_sym_no_error (s0 s_final : ArmState)
 --   unfold popcount32_spec
 --   sorry
 
+/-! ## Tests for step theorem generation -/
+section Tests
+
+-- NOTE: the following test case currently fails, but it's what we'd like the
+--       stepi theorem statement to be!
+/--
+info: popcount32_program.stepi_0x4005c0 (s sn : ArmState) (h_program : s.program = popcount32_program)
+  (h_pc : r StateField.PC s = 4195776#64) (h_err : r StateField.ERR s = StateError.None) :
+  (sn = stepi s) =
+    (sn = w StateField.PC (4195780#64)
+          (w (StateField.GPR 0#5)
+            (truncate 64 (BitVec.zero 32) &&& truncate 64 (2147483648#32) |||
+              (truncate 64 (BitVec.zero 32) &&& truncate 64 (0#32) |||
+                  truncate 64 ((zeroExtend 32 (r (StateField.GPR 0#5) s)).rotateRight 1) &&& truncate 64 4294967295#32) &&&
+                truncate 64 2147483647#32)
+            s))
+-/
+#guard_msgs in #check popcount32_program.stepi_0x4005c0
+
+end Tests
+
 end popcount32

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -135,13 +135,15 @@ section Tests
 info: popcount32_program.stepi_0x4005c0 (s sn : ArmState) (h_program : s.program = popcount32_program)
   (h_pc : r StateField.PC s = 4195776#64) (h_err : r StateField.ERR s = StateError.None) :
   (sn = stepi s) =
-    (sn = w StateField.PC (4195780#64)
-          (w (StateField.GPR 0#5)
-            (truncate 64 (BitVec.zero 32) &&& truncate 64 (2147483648#32) |||
-              (truncate 64 (BitVec.zero 32) &&& truncate 64 (0#32) |||
-                  truncate 64 ((zeroExtend 32 (r (StateField.GPR 0#5) s)).rotateRight 1) &&& truncate 64 4294967295#32) &&&
-                truncate 64 2147483647#32)
-            s))
+    (sn =
+      w StateField.PC (4195780#64)
+        (w (StateField.GPR 0#5)
+          (truncate 64 (BitVec.zero 32) &&& truncate 64 2147483648#32 |||
+            (truncate 64 (BitVec.zero 32) &&& 0#64 |||
+                truncate 64 ((zeroExtend 32 (r (StateField.GPR 0#5) s)).rotateRight 1) &&&
+                  truncate 64 4294967295#32) &&&
+              truncate 64 2147483647#32)
+          s))
 -/
 #guard_msgs in #check popcount32_program.stepi_0x4005c0
 

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -129,8 +129,6 @@ theorem popcount32_sym_no_error (s0 s_final : ArmState)
 /-! ## Tests for step theorem generation -/
 section Tests
 
--- NOTE: the following test case currently fails, but it's what we'd like the
---       stepi theorem statement to be!
 /--
 info: popcount32_program.stepi_0x4005c0 (s sn : ArmState) (h_program : s.program = popcount32_program)
   (h_pc : r StateField.PC s = 4195776#64) (h_err : r StateField.ERR s = StateError.None) :

--- a/Proofs/SHA512/Sha512DecodeExecLemmas.lean
+++ b/Proofs/SHA512/Sha512DecodeExecLemmas.lean
@@ -25,8 +25,7 @@ info: sha512_program.exec_0x126c90 (s : ArmState) :
       (ArmInst.BR (BranchInst.Compare_branch { sf := 1#1, _fixed := 26#5, op := 1#1, imm19 := 523804#19, Rt := 2#5 }))
       s =
     w StateField.PC
-      (if decide (r (StateField.GPR 2#5) s = BitVec.zero (if 1#1 = 1#1 then 64 else 32)) = false then
-        r StateField.PC s + BitVec.signExtend 64 (523804#19 <<< 2)
+      (if decide (r (StateField.GPR 2#5) s = BitVec.zero 64) = false then r StateField.PC s + 18446744073709549680#64
       else r StateField.PC s + 4#64)
       s
 -/

--- a/Tactics/StepThms.lean
+++ b/Tactics/StepThms.lean
@@ -125,7 +125,7 @@ def genExecTheorem (program_name : Name) (address_str : String)
     -- let sp_aligned ← (mkAppM ``Eq #[(← mkAppM ``CheckSPAlignment #[s]), (mkConst ``true)])
     -- logInfo m!"sp_aligned: {sp_aligned}"
     -- withLocalDeclD `h_sp_aligned sp_aligned fun _h_sp_aligned => do
-    let (ctx, _simprocs) ←
+    let (ctx, simprocs) ←
             LNSymSimpContext
               -- Unfortunately, using `ground := true` exposes a lot of internal BitVec
               -- structure in terms of Fin.
@@ -140,7 +140,7 @@ def genExecTheorem (program_name : Name) (address_str : String)
       unless simpTheorems.isErased (.fvar h) do
         simpTheorems ← simpTheorems.addTheorem (.fvar h) (← h.getDecl).toExpr
     let ctx := { ctx with simpTheorems }
-    let (exec_inst_result, _) ← simp exec_inst_expr ctx
+    let (exec_inst_result, _) ← simp exec_inst_expr ctx simprocs
     trace[gen_step.debug] "[Exec_inst Simplified Expression: {exec_inst_result.expr}]"
     let hs ← getPropHyps
     let args := #[s] ++ (hs.map (fun f => (.fvar f)))
@@ -179,8 +179,8 @@ def genDecodeAndExecTheorems (program_name : Name) (address_str : String)
   -- BitVecs below. whnfR does not do enough and leaves the decode_raw_inst term
   -- unsimplified. So we use simp for this simplification.
   -- let rhs ← reduce lhs -- whnfD or whnfR?
-  let (ctx, _simprocs) ← LNSymSimpContext (config := {ground := true})
-  let (rhs, _) ← simp lhs ctx
+  let (ctx, simprocs) ← LNSymSimpContext (config := {ground := true})
+  let (rhs, _) ← simp lhs ctx simprocs
   let opt_arminst := (mkAppN (mkConst ``Option [0]) #[(mkConst ``ArmInst [])])
   let type := mkAppN (Expr.const ``Eq [1]) #[opt_arminst, lhs, rhs.expr]
   let value := mkAppN (Expr.const ``Eq.refl [1]) #[opt_arminst, lhs]


### PR DESCRIPTION
### Description:

Some stepi-theorems were being generated which still included elements like `decode_bit_masks 0#1 3#6 0#6 false`.
After investigation, I noticed simprocs were *not* being passed to `simp` in `StepThms`, so I fixed that.

### Testing:

`make all` ran locally

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
