### PR TITLE
Better bitvec reduction

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -159,6 +159,8 @@ attribute [bitvec_rules] BitVec.getLsb_rotateRight
 attribute [bitvec_rules] BitVec.ofBool_true
 attribute [bitvec_rules] BitVec.ofBool_false
 attribute [bitvec_rules] BitVec.ofNat_eq_ofNat
+attribute [bitvec_rules] BitVec.zero_eq
+attribute [bitvec_rules] BitVec.truncate_eq_zeroExtend
 
 -- BitVec Simproc rules:
 -- See Lean/Meta/Tactic/Simp/BuiltinSimprocs for the built-in

--- a/Arm/MinTheory.lean
+++ b/Arm/MinTheory.lean
@@ -88,9 +88,8 @@ attribute [minimal_theory] bne_self_eq_false
 attribute [minimal_theory] bne_self_eq_false'
 attribute [minimal_theory] decide_False
 attribute [minimal_theory] decide_True
-attribute [minimal_theory]
-  decide_eq_false_iff_not
-  decide_eq_true_iff
+attribute [minimal_theory] decide_eq_false_iff_not
+attribute [minimal_theory] decide_eq_true_iff
 attribute [minimal_theory] bne_iff_ne
 attribute [minimal_theory] Bool.false_eq
 attribute [minimal_theory] Bool.and_eq_false_imp

--- a/Arm/MinTheory.lean
+++ b/Arm/MinTheory.lean
@@ -88,6 +88,9 @@ attribute [minimal_theory] bne_self_eq_false
 attribute [minimal_theory] bne_self_eq_false'
 attribute [minimal_theory] decide_False
 attribute [minimal_theory] decide_True
+attribute [minimal_theory]
+  decide_eq_false_iff_not
+  decide_eq_true_iff
 attribute [minimal_theory] bne_iff_ne
 
 attribute [minimal_theory] Nat.le_zero_eq

--- a/Proofs/Experiments/AbsVCG.lean
+++ b/Proofs/Experiments/AbsVCG.lean
@@ -271,8 +271,7 @@ theorem program_effects_lemma (h_pre : abs_pre s0)
                 BitVec.truncate 64 4294967295#32) &&&
             BitVec.truncate 64 1#32)) := by
     simp (config := {decide := true}) only [h_step_4, h_step_3, h_step_2, h_step_1,
-                                            state_simp_rules]
-    rfl
+                                            state_simp_rules, bitvec_rules]
 
   have h_sf_s4 : sf = s4 := by
     simp only [h_run, h_s4, h_s3, h_s2, h_s1, run]

--- a/Proofs/Experiments/AbsVCG.lean
+++ b/Proofs/Experiments/AbsVCG.lean
@@ -200,8 +200,6 @@ theorem program_effects_lemma (h_pre : abs_pre s0)
     simp only [run, h_step_2]
   replace h_step_2 : s2 = stepi s1 := h_step_2.symm
   rw [program.stepi_0x4005d4 s1 s2 h_s1_program h_s1_pc h_s1_err] at h_step_2
-  -- (FIXME) abs_stepi_0x4005d4 should have reduced `decode_bit_masks`.
-  simp only [reduceDecodeBitMasks] at h_step_2
   have h_s2_program : s2.program = program := by
     simp only [h_step_2, h_s1_program,
                state_simp_rules, minimal_theory, bitvec_rules]
@@ -274,6 +272,7 @@ theorem program_effects_lemma (h_pre : abs_pre s0)
             BitVec.truncate 64 1#32)) := by
     simp (config := {decide := true}) only [h_step_4, h_step_3, h_step_2, h_step_1,
                                             state_simp_rules]
+    rfl
 
   have h_sf_s4 : sf = s4 := by
     simp only [h_run, h_s4, h_s3, h_s2, h_s1, run]

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -136,11 +136,7 @@ info: popcount32_program.stepi_0x4005c0 (s sn : ArmState) (h_program : s.program
     (sn =
       w StateField.PC (4195780#64)
         (w (StateField.GPR 0#5)
-          (truncate 64 (BitVec.zero 32) &&& truncate 64 2147483648#32 |||
-            (truncate 64 (BitVec.zero 32) &&& 0#64 |||
-                truncate 64 ((zeroExtend 32 (r (StateField.GPR 0#5) s)).rotateRight 1) &&&
-                  truncate 64 4294967295#32) &&&
-              truncate 64 2147483647#32)
+          (zeroExtend 64 ((zeroExtend 32 (r (StateField.GPR 0#5) s)).rotateRight 1) &&& 4294967295#64 &&& 2147483647#64)
           s))
 -/
 #guard_msgs in #check popcount32_program.stepi_0x4005c0

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -126,4 +126,25 @@ theorem popcount32_sym_no_error (s0 s_final : ArmState)
 --   unfold popcount32_spec
 --   sorry
 
+/-! ## Tests for step theorem generation -/
+section Tests
+
+-- NOTE: the following test case currently fails, but it's what we'd like the
+--       stepi theorem statement to be!
+/--
+info: popcount32_program.stepi_0x4005c0 (s sn : ArmState) (h_program : s.program = popcount32_program)
+  (h_pc : r StateField.PC s = 4195776#64) (h_err : r StateField.ERR s = StateError.None) :
+  (sn = stepi s) =
+    (sn = w StateField.PC (4195780#64)
+          (w (StateField.GPR 0#5)
+            (truncate 64 (BitVec.zero 32) &&& truncate 64 (2147483648#32) |||
+              (truncate 64 (BitVec.zero 32) &&& truncate 64 (0#32) |||
+                  truncate 64 ((zeroExtend 32 (r (StateField.GPR 0#5) s)).rotateRight 1) &&& truncate 64 4294967295#32) &&&
+                truncate 64 2147483647#32)
+            s))
+-/
+#guard_msgs in #check popcount32_program.stepi_0x4005c0
+
+end Tests
+
 end popcount32

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -135,13 +135,15 @@ section Tests
 info: popcount32_program.stepi_0x4005c0 (s sn : ArmState) (h_program : s.program = popcount32_program)
   (h_pc : r StateField.PC s = 4195776#64) (h_err : r StateField.ERR s = StateError.None) :
   (sn = stepi s) =
-    (sn = w StateField.PC (4195780#64)
-          (w (StateField.GPR 0#5)
-            (truncate 64 (BitVec.zero 32) &&& truncate 64 (2147483648#32) |||
-              (truncate 64 (BitVec.zero 32) &&& truncate 64 (0#32) |||
-                  truncate 64 ((zeroExtend 32 (r (StateField.GPR 0#5) s)).rotateRight 1) &&& truncate 64 4294967295#32) &&&
-                truncate 64 2147483647#32)
-            s))
+    (sn =
+      w StateField.PC (4195780#64)
+        (w (StateField.GPR 0#5)
+          (truncate 64 (BitVec.zero 32) &&& truncate 64 2147483648#32 |||
+            (truncate 64 (BitVec.zero 32) &&& 0#64 |||
+                truncate 64 ((zeroExtend 32 (r (StateField.GPR 0#5) s)).rotateRight 1) &&&
+                  truncate 64 4294967295#32) &&&
+              truncate 64 2147483647#32)
+          s))
 -/
 #guard_msgs in #check popcount32_program.stepi_0x4005c0
 

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -129,8 +129,6 @@ theorem popcount32_sym_no_error (s0 s_final : ArmState)
 /-! ## Tests for step theorem generation -/
 section Tests
 
--- NOTE: the following test case currently fails, but it's what we'd like the
---       stepi theorem statement to be!
 /--
 info: popcount32_program.stepi_0x4005c0 (s sn : ArmState) (h_program : s.program = popcount32_program)
   (h_pc : r StateField.PC s = 4195776#64) (h_err : r StateField.ERR s = StateError.None) :

--- a/Proofs/SHA512/Sha512DecodeExecLemmas.lean
+++ b/Proofs/SHA512/Sha512DecodeExecLemmas.lean
@@ -25,7 +25,7 @@ info: sha512_program.exec_0x126c90 (s : ArmState) :
       (ArmInst.BR (BranchInst.Compare_branch { sf := 1#1, _fixed := 26#5, op := 1#1, imm19 := 523804#19, Rt := 2#5 }))
       s =
     w StateField.PC
-      (if decide (r (StateField.GPR 2#5) s = BitVec.zero 64) = false then r StateField.PC s + 18446744073709549680#64
+      (if ¬r (StateField.GPR 2#5) s = 0#64 then r StateField.PC s + 18446744073709549680#64
       else r StateField.PC s + 4#64)
       s
 -/

--- a/Proofs/SHA512/Sha512DecodeExecLemmas.lean
+++ b/Proofs/SHA512/Sha512DecodeExecLemmas.lean
@@ -25,8 +25,7 @@ info: sha512_program.exec_0x126c90 (s : ArmState) :
       (ArmInst.BR (BranchInst.Compare_branch { sf := 1#1, _fixed := 26#5, op := 1#1, imm19 := 523804#19, Rt := 2#5 }))
       s =
     w StateField.PC
-      (if decide (r (StateField.GPR 2#5) s = BitVec.zero (if 1#1 = 1#1 then 64 else 32)) = false then
-        r StateField.PC s + BitVec.signExtend 64 (523804#19 <<< 2)
+      (if decide (r (StateField.GPR 2#5) s = BitVec.zero 64) = false then r StateField.PC s + 18446744073709549680#64
       else r StateField.PC s + 4#64)
       s
 -/

--- a/Proofs/SHA512/Sha512StepLemmas.lean
+++ b/Proofs/SHA512/Sha512StepLemmas.lean
@@ -11,9 +11,7 @@ set_option maxHeartbeats 2000000 in
 /--
 info: sha512_program.stepi_0x126c90 (s sn : ArmState) (h_program : s.program = sha512_program)
   (h_pc : r StateField.PC s = 1207440#64) (h_err : r StateField.ERR s = StateError.None) :
-  (sn = stepi s) =
-    (sn =
-      w StateField.PC (if decide (r (StateField.GPR 2#5) s = BitVec.zero 64) = false then 1205504#64 else 1207444#64) s)
+  (sn = stepi s) = (sn = w StateField.PC (if ¬r (StateField.GPR 2#5) s = 0#64 then 1205504#64 else 1207444#64) s)
 -/
 #guard_msgs in
 #check sha512_program.stepi_0x126c90

--- a/Tactics/StepThms.lean
+++ b/Tactics/StepThms.lean
@@ -125,7 +125,7 @@ def genExecTheorem (program_name : Name) (address_str : String)
     -- let sp_aligned ← (mkAppM ``Eq #[(← mkAppM ``CheckSPAlignment #[s]), (mkConst ``true)])
     -- logInfo m!"sp_aligned: {sp_aligned}"
     -- withLocalDeclD `h_sp_aligned sp_aligned fun _h_sp_aligned => do
-    let (ctx, _simprocs) ←
+    let (ctx, simprocs) ←
             LNSymSimpContext
               -- Unfortunately, using `ground := true` exposes a lot of internal BitVec
               -- structure in terms of Fin.
@@ -140,7 +140,7 @@ def genExecTheorem (program_name : Name) (address_str : String)
       unless simpTheorems.isErased (.fvar h) do
         simpTheorems ← simpTheorems.addTheorem (.fvar h) (← h.getDecl).toExpr
     let ctx := { ctx with simpTheorems }
-    let (exec_inst_result, _) ← simp exec_inst_expr ctx
+    let (exec_inst_result, _) ← simp exec_inst_expr ctx simprocs
     trace[gen_step.debug] "[Exec_inst Simplified Expression: {exec_inst_result.expr}]"
     let hs ← getPropHyps
     let args := #[s] ++ (hs.map (fun f => (.fvar f)))
@@ -179,8 +179,8 @@ def genDecodeAndExecTheorems (program_name : Name) (address_str : String)
   -- BitVecs below. whnfR does not do enough and leaves the decode_raw_inst term
   -- unsimplified. So we use simp for this simplification.
   -- let rhs ← reduce lhs -- whnfD or whnfR?
-  let (ctx, _simprocs) ← LNSymSimpContext (config := {ground := true})
-  let (rhs, _) ← simp lhs ctx
+  let (ctx, simprocs) ← LNSymSimpContext (config := {ground := true})
+  let (rhs, _) ← simp lhs ctx simprocs
   let opt_arminst := (mkAppN (mkConst ``Option [0]) #[(mkConst ``ArmInst [])])
   let type := mkAppN (Expr.const ``Eq [1]) #[opt_arminst, lhs, rhs.expr]
   let value := mkAppN (Expr.const ``Eq.refl [1]) #[opt_arminst, lhs]


### PR DESCRIPTION
### Description:

Relatively minor PR: adds some existing lemmas to the `minimal_theory` and `bitvec_rules` to get nicer normal forms. 
In particular:
- `BitVec.zero` now becomes `0#_`, and
- `truncate` now becomes `zeroExtend`, since the latter has simprocs for better reduction

Various tests have been changed accordingly

### Testing:

`make all` ran locally

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
