### PR TITLE
feat: copy `#time` command from Mathlib

### DIFF
--- a/Tactics/Time.lean
+++ b/Tactics/Time.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2021 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+Taken from: https://github.com/leanprover-community/mathlib4/blob/318082b0bccc3abd9d654496f7b60267f277d5fd/Mathlib/Util/Time.lean#L28-L33
+-/
+import Lean
+
+/-!
+# Defines `#time` command.
+
+Time the elaboration of a command, and print the result (in milliseconds).
+-/
+
+section
+open Lean Elab Command
+
+/--
+Time the elaboration of a command, and print the result (in milliseconds).
+
+Example usage:
+```
+set_option maxRecDepth 100000 in
+#time example : (List.range 500).length = 500 := rfl
+```
+-/
+elab "#time " cmd:many1Indent(command) : command => do
+  let start ← IO.monoMsNow
+  for stx in cmd.raw.getArgs do
+    elabCommand stx
+  logInfo m!"time: {(← IO.monoMsNow) - start}ms"
+
+end


### PR DESCRIPTION
### Description:

Copy the `#time` command, with some adaptations, from Mathlib, since it's very useful in getting rough performance numbers for automation.

License-wise, this should be fine, since both are Apache licensed, but we're waiting on an official answer from Leo on that.


EDIT: Leo confirmed it's fine, but also suggested asking Kim if it's worth upstreaming to core, so [I've pinged them](https://leanprover.zulipchat.com/#narrow/stream/424609-lean-at-aws/topic/Moving.20.60.23time.60.20to.20core). Let's wait for the result of that

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
