### PR TITLE
Respect Apple's ABI for cosimulations

### DIFF
--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -274,7 +274,7 @@ def run_all_tests (verbose : Bool) (n : Nat) : IO UInt32 := do
     { cmd  := "Arm/Insts/Cosim/platform_check.sh",
       args := #["-m"] }
   let mut tasks := #[]
-  if machine_check.exitCode == 0 then
+  if machine_check.exitCode == 1 then
     -- We are on an Aarch64 machine.
     -- Insts.rand is a list of functions of each class of instructions
     -- that generate legal, random 32-bit instructions.

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -21,6 +21,10 @@ as source operands does not violate the Apple ABI.
 
 For details, see
 https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Respect-the-purpose-of-specific-CPU-registers
+
+Also see "Procedure Call Standard for the Arm 64-bit Architecture";
+the latest version is available at
+https://github.com/ARM-software/abi-aa/releases
 -/
 partial def GPRIndex.rand (lo := 0) (hi := 31) :
   IO (BitVec 5) := do

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -22,16 +22,17 @@ as source operands does not violate the Apple ABI.
 For details, see
 https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Respect-the-purpose-of-specific-CPU-registers
 -/
-partial def GPRIndex.rand (lo := 0) (hi := 31) : 
+partial def GPRIndex.rand (lo := 0) (hi := 31) :
   IO (BitVec 5) := do
-  let feat_check ←
+  let darwin_check ←
   IO.Process.output
       { cmd  := "Arm/Insts/Cosim/platform_check.sh",
         args := #["-d"] }
-  if feat_check.exitCode == 0 then
-    BitVec.rand 5 lo hi
-  else 
+  if darwin_check.exitCode == 1 then
     go lo hi
+  else
+    -- On non-Darwin machines, fall through to `BitVec.rand`.
+    BitVec.rand 5 lo hi
   where go (lo hi : Nat) : IO (BitVec 5) := do
     let ans ← BitVec.rand 5 lo hi
     -- GPRs 18 and 29 are reserved on Apple Arm platforms.

--- a/Arm/Insts/Cosim/platform_check.sh
+++ b/Arm/Insts/Cosim/platform_check.sh
@@ -14,6 +14,15 @@ machine_check () {
     fi
 }
 
+is_darwin () {
+    os=$(uname -s)
+    if [[ $os == *Darwin* ]]; then
+	return 1
+    else
+	return 0
+    fi
+}
+
 feat_check () {
     os=$(uname -s)
     if [[ $os == *Linux* ]]; then
@@ -34,15 +43,18 @@ feat_check () {
     fi
 }
 
-while getopts ":mf:" option; do
+while getopts ":dfm:" option; do
    case $option in
-      m) # Execute machine_check
-	 machine_check
-	 exit;;
+      d) # Check if the platform is Darwin
+	  is_darwin
+	  exit;;
       f) # Enter a feature (convert to lower case)
 	  FEAT=$(echo "$OPTARG" | tr '[:upper:]' '[:lower:]')
 	  feat_check
 	  exit;;
+      m) # Execute machine_check
+	 machine_check
+	 exit;;
      \?) # Invalid option
 	 echo "platform_check error: Invalid option!"
 	 exit;;

--- a/Arm/Insts/Cosim/platform_check.sh
+++ b/Arm/Insts/Cosim/platform_check.sh
@@ -4,16 +4,19 @@
 # Released under Apache 2.0 license as described in the file LICENSE.
 # Author(s): Shilpi Goel
 
+# Note: we return 1 when we have an Arm machine.
 machine_check () {
     machine=$(uname -m)
-    -- Most Arm Linux machine use aarch64; some Arm Darwin machines use arm64.
+    # Most Arm Linux machines use aarch64; some Arm Darwin machines
+    # use arm64.
     if [[ $machine == *aarch64* || $machine == *arm64* ]]; then
-	return 0
-    else
 	return 1
+    else
+	return 0
     fi
 }
 
+# Note: we return 1 when we have a Darwin machine.
 is_darwin () {
     os=$(uname -s)
     if [[ $os == *Darwin* ]]; then
@@ -23,6 +26,7 @@ is_darwin () {
     fi
 }
 
+# Note: we return 1 when the requested feature is supported.
 feat_check () {
     os=$(uname -s)
     if [[ $os == *Linux* ]]; then
@@ -37,13 +41,13 @@ feat_check () {
     fi
 
     if [[ feat_support -ne 0 ]]; then
-	return 0
-    else
 	return 1
+    else
+	return 0
     fi
 }
 
-while getopts ":dfm:" option; do
+while getopts ":df:m" option; do
    case $option in
       d) # Check if the platform is Darwin
 	  is_darwin

--- a/Arm/Insts/DPI/Add_sub_imm.lean
+++ b/Arm/Insts/DPI/Add_sub_imm.lean
@@ -53,7 +53,7 @@ def Add_sub_imm_cls.inst.rand : IO (Option (BitVec 32)) := do
        -- cases. For now, we do sacrifice a little bit of the state
        -- space.
       Rn    := ← BitVec.rand 5 (lo := 0) (hi := 30),
-      Rd    := ← BitVec.rand 5 (lo := 0) (hi := 30) }
+      Rd    := ← GPRIndex.rand (lo := 0) (hi := 30) }
   pure (some (inst.toBitVec32))
 
 def Add_sub_imm_cls.rand : List (IO (Option (BitVec 32))) :=

--- a/Arm/Insts/DPI/Bitfield.lean
+++ b/Arm/Insts/DPI/Bitfield.lean
@@ -76,7 +76,7 @@ partial def Bitfield_cls.all.rand : IO (Option (BitVec 32)) := do
       immr  := immr,
       imms  := imms,
       Rn    := ← BitVec.rand 5,
-      Rd    := ← BitVec.rand 5 }
+      Rd    := ← GPRIndex.rand }
   pure (some (inst.toBitVec32))
  where pick_legal_bitfield_opc : IO (BitVec 2) := do
   let opc ← BitVec.rand 2
@@ -102,7 +102,7 @@ partial def Bitfield_cls.lsr.rand : IO (Option (BitVec 32)) := do
       immr  := immr,
       imms  := imms,
       Rn    := ← BitVec.rand 5,
-      Rd    := ← BitVec.rand 5 }
+      Rd    := ← GPRIndex.rand }
   pure (some (inst.toBitVec32))
 
 partial def Bitfield_cls.lsl.rand : IO (Option (BitVec 32)) := do
@@ -118,7 +118,7 @@ partial def Bitfield_cls.lsl.rand : IO (Option (BitVec 32)) := do
       immr  := immr,
       imms  := imms,
       Rn    := ← BitVec.rand 5,
-      Rd    := ← BitVec.rand 5 }
+      Rd    := ← GPRIndex.rand }
   pure (some (inst.toBitVec32))
   where pick_legal_lsl_low_imms_bits : IO (BitVec 5) := do
     let bits ← BitVec.rand 5

--- a/Arm/Insts/DPI/Logical_imm.lean
+++ b/Arm/Insts/DPI/Logical_imm.lean
@@ -76,7 +76,7 @@ partial def Logical_imm_cls.inst.rand : IO (Option (BitVec 32)) := do
       immr  := ← BitVec.rand 6,
       imms  := ← BitVec.rand 6,
       Rn    := ← BitVec.rand 5 (lo := 0) (hi := hi),
-      Rd    := ← BitVec.rand 5 (lo := 0) (hi := hi)
+      Rd    := ← GPRIndex.rand (lo := 0) (hi := hi)
     }
   let datasize := 32 <<< inst.sf.toNat
   if inst.sf = 0#1 ∧ inst.N = 1#1 ∨ invalid_bit_masks inst.N inst.imms true datasize then

--- a/Arm/Insts/DPI/Move_wide_imm.lean
+++ b/Arm/Insts/DPI/Move_wide_imm.lean
@@ -47,7 +47,7 @@ partial def Move_wide_imm_cls.inst.rand : IO (Option (BitVec 32)) := do
         opc := opc,
         hw := hw,
         imm16 := ← BitVec.rand 16,
-        Rd := ← BitVec.rand 5
+        Rd := ← GPRIndex.rand
       }
     pure (some inst.toBitVec32)
 

--- a/Arm/Insts/DPR/Add_sub_carry.lean
+++ b/Arm/Insts/DPR/Add_sub_carry.lean
@@ -40,7 +40,7 @@ def Add_sub_carry_cls.rand : IO (Option (BitVec 32)) := do
       S     := ← BitVec.rand 1,
       Rm    := ← BitVec.rand 5,
       Rn    := ← BitVec.rand 5,
-      Rd    := ← BitVec.rand 5 }
+      Rd    := ← GPRIndex.rand }
   pure (some (inst.toBitVec32))
 
 ----------------------------------------------------------------------

--- a/Arm/Insts/DPR/Add_sub_shifted_reg.lean
+++ b/Arm/Insts/DPR/Add_sub_shifted_reg.lean
@@ -55,7 +55,7 @@ partial def Add_sub_shifted_reg_cls.rand : IO (Option (BitVec 32)) := do
         Rm    := ← BitVec.rand 5,
         imm6  := imm6,
         Rn    := ← BitVec.rand 5,
-        Rd    := ← BitVec.rand 5 }
+        Rd    := ← GPRIndex.rand }
     pure (some (inst.toBitVec32))
 
 ----------------------------------------------------------------------

--- a/Arm/Insts/DPR/Conditional_select.lean
+++ b/Arm/Insts/DPR/Conditional_select.lean
@@ -48,7 +48,7 @@ def Conditional_select_cls.rand : IO (Option (BitVec 32)) := do
       cond  := ← BitVec.rand 4,
       op2   := ← pure 0b00#2,
       Rn    := ← BitVec.rand 5,
-      Rd    := ← BitVec.rand 5 }
+      Rd    := ← GPRIndex.rand }
   pure (some (inst.toBitVec32))
 
 ----------------------------------------------------------------------

--- a/Arm/Insts/DPR/Data_processing_one_source.lean
+++ b/Arm/Insts/DPR/Data_processing_one_source.lean
@@ -112,7 +112,7 @@ partial def Data_processing_one_source_cls.rev_all.rand : IO (Option (BitVec 32)
         opcode2 := 0b00000#5,
         opcode := 0b0000#4 ++ opc,
         Rn := ← BitVec.rand 5,
-        Rd := ← BitVec.rand 5
+        Rd := ← GPRIndex.rand
       }
     pure (some (inst.toBitVec32))
 

--- a/Arm/Insts/DPR/Data_processing_three_source.lean
+++ b/Arm/Insts/DPR/Data_processing_three_source.lean
@@ -83,7 +83,7 @@ def Data_processing_three_source_cls.shift.rand
       o0 := o0,
       Ra := ← BitVec.rand 5,
       Rn := ← BitVec.rand 5,
-      Rd := ← BitVec.rand 5
+      Rd := ← GPRIndex.rand
     }
   pure (some inst.toBitVec32)
 

--- a/Arm/Insts/DPR/Data_processing_two_source.lean
+++ b/Arm/Insts/DPR/Data_processing_two_source.lean
@@ -49,7 +49,7 @@ def Data_processing_two_source_cls.shift.rand
       Rm := ← BitVec.rand 5,
       opcode := opcode,
       Rn := ← BitVec.rand 5,
-      Rd := ← BitVec.rand 5
+      Rd := ← GPRIndex.rand
     }
   pure (some inst.toBitVec32)
 

--- a/Arm/Insts/DPR/Logical_shifted_reg.lean
+++ b/Arm/Insts/DPR/Logical_shifted_reg.lean
@@ -85,7 +85,7 @@ partial def Logical_shifted_reg_cls.rand : IO (Option (BitVec 32)) := do
         Rm    := ← BitVec.rand 5,
         imm6  := imm6,
         Rn    := ← BitVec.rand 5,
-        Rd    := ← BitVec.rand 5 }
+        Rd    := ← GPRIndex.rand }
     pure (some (inst.toBitVec32))
 
 ----------------------------------------------------------------------

--- a/Arm/Insts/DPSFP/Conversion_between_FP_and_Int.lean
+++ b/Arm/Insts/DPSFP/Conversion_between_FP_and_Int.lean
@@ -103,7 +103,14 @@ partial def Conversion_between_FP_and_Int_cls.fmov_general.rand : IO (Option (Bi
         rmode  := rmode,
         opcode := opcode,
         Rn := ← BitVec.rand 5,
-        Rd := ← BitVec.rand 5 }
+        Rd := ← (if (lsb opcode 0) = 1#1 then
+                -- FPConvOp.FPConvOp_MOV_ItoF
+                -- GPR used as a source operand.
+                  BitVec.rand 5
+                else
+                -- FPConvOp.FPConvOp_MOV_FtoI
+                -- GPR used as a destination operand.
+                  GPRIndex.rand) }
     pure (inst.toBitVec32)
 
 /-- Generate random instructions of Conversion_between_FP_and_Int class. -/

--- a/Arm/Insts/DPSFP/Conversion_between_FP_and_Int.lean
+++ b/Arm/Insts/DPSFP/Conversion_between_FP_and_Int.lean
@@ -105,11 +105,11 @@ partial def Conversion_between_FP_and_Int_cls.fmov_general.rand : IO (Option (Bi
         Rn := ← BitVec.rand 5,
         Rd := ← (if (lsb opcode 0) = 1#1 then
                 -- FPConvOp.FPConvOp_MOV_ItoF
-                -- GPR used as a source operand.
+                -- Destination operand is a SIMD&FP register.
                   BitVec.rand 5
                 else
                 -- FPConvOp.FPConvOp_MOV_FtoI
-                -- GPR used as a destination operand.
+                -- Destination operand is a GPR register.
                   GPRIndex.rand) }
     pure (inst.toBitVec32)
 

--- a/Arm/Insts/DPSFP/Crypto_four_reg.lean
+++ b/Arm/Insts/DPSFP/Crypto_four_reg.lean
@@ -39,7 +39,8 @@ def Crypto_four_reg_cls.eor3.rand : IO (Option (BitVec 32)) := do
       IO.Process.output
       { cmd  := "Arm/Insts/Cosim/platform_check.sh",
         args := #["-f", "sha3"] }
-  if feat_check.exitCode = 0 then
+  if feat_check.exitCode = 1 then
+    -- SHA3 feature supported.
     let (inst : Crypto_four_reg_cls) :=
       { Op0    := ← pure 0b00#2,
         Rm     := ← BitVec.rand 5,

--- a/Arm/Insts/DPSFP/Crypto_three_reg_sha512.lean
+++ b/Arm/Insts/DPSFP/Crypto_three_reg_sha512.lean
@@ -99,7 +99,8 @@ def Crypto_three_reg_sha512_cls.sha512.rand : IO (Option (BitVec 32)) := do
       IO.Process.output
       { cmd  := "Arm/Insts/Cosim/platform_check.sh",
         args := #["-f", "sha512"] }
-  if feat_check.exitCode == 0 then
+  if feat_check.exitCode == 1 then 
+    -- SHA512 feature supported.
     let (inst : Crypto_three_reg_sha512_cls) :=
       { Rm     := ← BitVec.rand 5,
         O      := ← pure 0b0#1,

--- a/Arm/Insts/DPSFP/Crypto_two_reg_sha512.lean
+++ b/Arm/Insts/DPSFP/Crypto_two_reg_sha512.lean
@@ -55,7 +55,8 @@ def Crypto_two_reg_sha512_cls.sha512su0.rand : IO (Option (BitVec 32)) := do
       IO.Process.output
       { cmd  := "Arm/Insts/Cosim/platform_check.sh",
         args := #["-f", "sha512"] }
-  if feat_check.exitCode = 0 then
+  if feat_check.exitCode = 1 then
+    -- SHA512 feature supported.
     let (inst : Crypto_two_reg_sha512_cls) :=
       { opcode := ← pure 0b00#2,
         Rn     := ← BitVec.rand 5,


### PR DESCRIPTION
### Description:

Workaround to avoid clobbering `x18` and `x29` on Apple's Arm machines.

### Testing:

`make all` ran on my M3 and a Graviton2 machine.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
