### PR TITLE
Avoid `x18` entirely on Arm-based Apple machines

### DIFF
--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -39,7 +39,9 @@ Our conformance testing framework is parallelized -- we spawn a task
 for each random test. This is why we cannot expect the contents of
 `x18` to be preserved -- `x18` is reserved on Apple's Arm machines and
 probably carries thread context (though we haven't actually found a
-reference for the latter).
+reference for the latter). See
+https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Respect-the-purpose-of-specific-CPU-registers
+for details.
 
 As such, when we check whether our model's state matches the machine
 after every instruction test, we ignore the contents of `x18` only on
@@ -263,7 +265,7 @@ def regStates_match (uniqueBaseName : String) (input o1 o2 : regState) :
     let isDarwin := (darwin_check.exitCode == 1)
      let gpr_mismatch ← gpr_mismatch isDarwin o1.gpr o2.gpr
      let nzcv_mismatch ← nzcv_mismatch o1.nzcv o2.nzcv
-     let sfp_mismatch  ← sfp_mismatch o1.sfp o2.sfp     
+     let sfp_mismatch  ← sfp_mismatch o1.sfp o2.sfp
      if gpr_mismatch.isEmpty &&
         nzcv_mismatch.isEmpty &&
         sfp_mismatch.isEmpty then

--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -273,6 +273,7 @@ def regStates_match (uniqueBaseName : String) (input o1 o2 : regState) :
         -- expected to be preserved on this platform.
         pure true
      else
+       -- TODO: also print the instruction class and sample.
        IO.println s!"ID: {uniqueBaseName}"
        IO.println s!"Instruction: {decode_raw_inst input.inst}"
        IO.println s!"input: {toString input}"

--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -8,7 +8,7 @@ import Arm.Exec
 namespace Cosim
 
 /-
-Considerations for running cosimulations on Arm-based Apple platforms:
+NOTE: Considerations for running cosimulations on Arm-based Apple platforms:
 
 On Arm-based Apple platforms, we completely avoid using the register
 `x18`. It is not allowed to be a source or a destination operand --

--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -7,6 +7,46 @@ import Arm.Exec
 
 namespace Cosim
 
+/-
+Considerations for running cosimulations on Arm-based Apple platforms:
+
+On Arm-based Apple platforms, we completely avoid using the register
+`x18`. It is not allowed to be a source or a destination operand --
+see `GPRIndex.rand`. Even with these restrictions, we cannot expect
+the value of `x18` to be preserved, even though it is callee-saved --
+see Arm/Insts/Cosim/template.S. Here's a quote from "Procedure Call
+Standard for the Arm 64-bit Architecture" (the latest version is
+available at https://github.com/ARM-software/abi-aa/releases) that
+informs this choice:
+
+"The role of register r18 is platform specific. If a platform ABI has
+need of a dedicated general-purpose register to carry inter-procedural
+state (for example, the thread context) then it should use this
+register for that purpose. If the platform ABI has no such
+requirements, then it should use r18 as an additional temporary
+register. The platform ABI specification must document the usage for
+this register...
+
+Software developers creating platform-independent code are advised to
+avoid using r18 if at all possible. Most compilers provide a mechanism
+to prevent specific registers from being used for general allocation;
+portable hand-coded assembler should avoid it entirely...
+
+It should not be assumed that treating the register as callee-saved
+will be sufficient to satisfy the requirements of the platform."
+
+Our conformance testing framework is parallelized -- we spawn a task
+for each random test. This is why we cannot expect the contents of
+`x18` to be preserved -- `x18` is reserved on Apple's Arm machines and
+probably carries thread context (though we haven't actually found a
+reference for the latter).
+
+As such, when we check whether our model's state matches the machine
+after every instruction test, we ignore the contents of `x18` only on
+Arm-based Apple machines -- `x18` is still checked on other Arm
+machines. See `gpr_mismatch` and `regStates_match` for details.
+-/
+
 open BitVec
 
 /-- A default concrete state to begin co-simulations. -/
@@ -173,10 +213,20 @@ def model_to_regState (inst : BitVec 32) (s : ArmState) : regState :=
     nzcv := nzcv s,
     sfp  := sfp_list s }
 
+/-- Check whether the machine and model GPRs match. We ignore register
+`x18` on Arm-based Apple platforms because `x18` cannot be guaranteed
+to be preserved there. -/
 def gpr_mismatch (x1 x2 : List (BitVec 64)) : IO String := do
+  let darwin_check ←
+  IO.Process.output
+      { cmd  := "Arm/Insts/Cosim/platform_check.sh",
+        args := #["-d"] }
   let mut acc := ""
   for i in [0:31] do
-    if x1[i]! == x2[i]! then
+    if i == 18 && darwin_check.exitCode == 1 then
+      -- Ignore x18 contents.
+      continue
+    else if x1[i]! == x2[i]! then
       continue
     else
       acc := acc ++ s!"GPR{i} machine {x1[i]!} model {x2[i]!}"
@@ -205,19 +255,33 @@ def nzcv_mismatch (x1 x2 : BitVec 4) : IO String := do
       acc := acc ++ s!"Flag{flag} machine {f1} model {f2}"
   pure acc
 
-def regStates_match (uniqueBaseName : String) (input o1 o2 : regState) : 
+def regStates_match (uniqueBaseName : String) (input o1 o2 : regState) :
   IO Bool := do
   if o1 == o2 then
-     pure true
+      pure true
   else
+    let darwin_check ←
+    IO.Process.output
+      { cmd  := "Arm/Insts/Cosim/platform_check.sh",
+        args := #["-d"] }
      let gpr_mismatch ← gpr_mismatch o1.gpr o2.gpr
      let nzcv_mismatch ← nzcv_mismatch o1.nzcv o2.nzcv
-     let sfp_mismatch  ← sfp_mismatch o1.sfp o2.sfp
-     IO.println s!"ID: {uniqueBaseName}"
-     IO.println s!"Instruction: {decode_raw_inst input.inst}"
-     IO.println s!"input: {toString input}"
-     IO.println s!"Mismatch found: {gpr_mismatch} {nzcv_mismatch} {sfp_mismatch}"
-     pure false
+     let sfp_mismatch  ← sfp_mismatch o1.sfp o2.sfp     
+     if darwin_check.exitCode == 1 &&
+        gpr_mismatch.isEmpty &&
+        nzcv_mismatch.isEmpty &&
+        sfp_mismatch.isEmpty then
+        -- If we are on an Arm-based Apple platform where only the
+        -- value of `x18` differs between the model and the machine,
+        -- then we don't flag a mismatch. This register is not
+        -- expected to be preserved on this platform.
+        pure true
+     else
+       IO.println s!"ID: {uniqueBaseName}"
+       IO.println s!"Instruction: {decode_raw_inst input.inst}"
+       IO.println s!"input: {toString input}"
+       IO.println s!"Mismatch found: {gpr_mismatch} {nzcv_mismatch} {sfp_mismatch}"
+       pure false
 
 /-- Run one random test for the instruction `inst`. -/
 def one_test (inst : BitVec 32) (uniqueBaseName : String) : IO Bool := do

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -18,32 +18,10 @@ open BitVec
 `GPRIndex.rand` picks a safe GPR index for Arm-based Apple platforms
 i.e., one not reserved on them. Use this function instead of
 `BitVec.rand` to pick an appropriate random index for a source and
-destination GPR during cosimulations.
+destination GPR during cosimulations. 
 
-Here is a relevant quote from "Procedure Call Standard for the Arm
-64-bit Architecture"; the latest version is available at
-https://github.com/ARM-software/abi-aa/releases
-
-"The role of register r18 is platform specific. If a platform ABI has
-need of a dedicated general-purpose register to carry inter-procedural
-state (for example, the thread context) then it should use this
-register for that purpose. If the platform ABI has no such
-requirements, then it should use r18 as an additional temporary
-register. The platform ABI specification must document the usage for
-this register...
-
-Software developers creating platform-independent code are advised to
-avoid using r18 if at all possible. Most compilers provide a mechanism
-to prevent specific registers from being used for general allocation;
-portable hand-coded assembler should avoid it entirely...
-
-It should not be assumed that treating the register as callee-saved
-will be sufficient to satisfy the requirements of the platform."
-
-Arm-based Apple machines do reserve `x18` and `x29`; see the following
-link for details:
-https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Respect-the-purpose-of-specific-CPU-registers
-
+See "NOTE: Considerations for running cosimulations on Arm-based Apple
+platforms" in Arm/Cosim.lean for details.
 -/
 partial def GPRIndex.rand (lo := 0) (hi := 31) :
   IO (BitVec 5) := do

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -13,18 +13,37 @@ section Common
 open BitVec
 
 ----------------------------------------------------------------------
-/-- `GPRIndex.rand` picks a safe GPR index (i.e., one not reserved on
-Apple platforms). Use this function instead of `BitVec.rand` to pick
-an appropriate random index for a destination GPR during
-cosimulations. We say "destination" because using reserved registers
-as source operands does not violate the Apple ABI.
 
-For details, see
+/-- 
+`GPRIndex.rand` picks a safe GPR index for Arm-based Apple platforms
+i.e., one not reserved on them. Use this function instead of
+`BitVec.rand` to pick an appropriate random index for a source and
+destination GPR during cosimulations.
+
+Here is a relevant quote from "Procedure Call Standard for the Arm
+64-bit Architecture"; the latest version is available at
+https://github.com/ARM-software/abi-aa/releases
+
+"The role of register r18 is platform specific. If a platform ABI has
+need of a dedicated general-purpose register to carry inter-procedural
+state (for example, the thread context) then it should use this
+register for that purpose. If the platform ABI has no such
+requirements, then it should use r18 as an additional temporary
+register. The platform ABI specification must document the usage for
+this register...
+
+Software developers creating platform-independent code are advised to
+avoid using r18 if at all possible. Most compilers provide a mechanism
+to prevent specific registers from being used for general allocation;
+portable hand-coded assembler should avoid it entirely...
+
+It should not be assumed that treating the register as callee-saved
+will be sufficient to satisfy the requirements of the platform."
+
+Arm-based Apple machines do reserve `x18` and `x29`; see the following
+link for details:
 https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Respect-the-purpose-of-specific-CPU-registers
 
-Also see "Procedure Call Standard for the Arm 64-bit Architecture";
-the latest version is available at
-https://github.com/ARM-software/abi-aa/releases
 -/
 partial def GPRIndex.rand (lo := 0) (hi := 31) :
   IO (BitVec 5) := do

--- a/Arm/Insts/DPI/Add_sub_imm.lean
+++ b/Arm/Insts/DPI/Add_sub_imm.lean
@@ -52,7 +52,7 @@ def Add_sub_imm_cls.inst.rand : IO (Option (BitVec 32)) := do
        -- 31) since our simulation framework doesn't work in such
        -- cases. For now, we do sacrifice a little bit of the state
        -- space.
-      Rn    := ← BitVec.rand 5 (lo := 0) (hi := 30),
+      Rn    := ← GPRIndex.rand (lo := 0) (hi := 30),
       Rd    := ← GPRIndex.rand (lo := 0) (hi := 30) }
   pure (some (inst.toBitVec32))
 

--- a/Arm/Insts/DPI/Bitfield.lean
+++ b/Arm/Insts/DPI/Bitfield.lean
@@ -75,7 +75,7 @@ partial def Bitfield_cls.all.rand : IO (Option (BitVec 32)) := do
       N     := N,
       immr  := immr,
       imms  := imms,
-      Rn    := ← BitVec.rand 5,
+      Rn    := ← GPRIndex.rand,
       Rd    := ← GPRIndex.rand }
   pure (some (inst.toBitVec32))
  where pick_legal_bitfield_opc : IO (BitVec 2) := do
@@ -101,7 +101,7 @@ partial def Bitfield_cls.lsr.rand : IO (Option (BitVec 32)) := do
       N     := N,
       immr  := immr,
       imms  := imms,
-      Rn    := ← BitVec.rand 5,
+      Rn    := ← GPRIndex.rand,
       Rd    := ← GPRIndex.rand }
   pure (some (inst.toBitVec32))
 
@@ -117,7 +117,7 @@ partial def Bitfield_cls.lsl.rand : IO (Option (BitVec 32)) := do
       N     := N,
       immr  := immr,
       imms  := imms,
-      Rn    := ← BitVec.rand 5,
+      Rn    := ← GPRIndex.rand,
       Rd    := ← GPRIndex.rand }
   pure (some (inst.toBitVec32))
   where pick_legal_lsl_low_imms_bits : IO (BitVec 5) := do

--- a/Arm/Insts/DPI/Logical_imm.lean
+++ b/Arm/Insts/DPI/Logical_imm.lean
@@ -75,7 +75,7 @@ partial def Logical_imm_cls.inst.rand : IO (Option (BitVec 32)) := do
       N     := ← BitVec.rand 1,
       immr  := ← BitVec.rand 6,
       imms  := ← BitVec.rand 6,
-      Rn    := ← BitVec.rand 5 (lo := 0) (hi := hi),
+      Rn    := ← GPRIndex.rand (lo := 0) (hi := hi),
       Rd    := ← GPRIndex.rand (lo := 0) (hi := hi)
     }
   let datasize := 32 <<< inst.sf.toNat

--- a/Arm/Insts/DPR/Add_sub_carry.lean
+++ b/Arm/Insts/DPR/Add_sub_carry.lean
@@ -38,8 +38,8 @@ def Add_sub_carry_cls.rand : IO (Option (BitVec 32)) := do
     { sf    := ← BitVec.rand 1,
       op    := ← BitVec.rand 1,
       S     := ← BitVec.rand 1,
-      Rm    := ← BitVec.rand 5,
-      Rn    := ← BitVec.rand 5,
+      Rm    := ← GPRIndex.rand,
+      Rn    := ← GPRIndex.rand,
       Rd    := ← GPRIndex.rand }
   pure (some (inst.toBitVec32))
 

--- a/Arm/Insts/DPR/Add_sub_shifted_reg.lean
+++ b/Arm/Insts/DPR/Add_sub_shifted_reg.lean
@@ -52,9 +52,9 @@ partial def Add_sub_shifted_reg_cls.rand : IO (Option (BitVec 32)) := do
         op    := ← BitVec.rand 1,
         S     := ← BitVec.rand 1,
         shift := shift,
-        Rm    := ← BitVec.rand 5,
+        Rm    := ← GPRIndex.rand,
         imm6  := imm6,
-        Rn    := ← BitVec.rand 5,
+        Rn    := ← GPRIndex.rand,
         Rd    := ← GPRIndex.rand }
     pure (some (inst.toBitVec32))
 

--- a/Arm/Insts/DPR/Conditional_select.lean
+++ b/Arm/Insts/DPR/Conditional_select.lean
@@ -44,10 +44,10 @@ def Conditional_select_cls.rand : IO (Option (BitVec 32)) := do
     { sf    := ← BitVec.rand 1,
       op    := ← pure 0#1,
       S     := ← pure 0#1,
-      Rm    := ← BitVec.rand 5,
+      Rm    := ← GPRIndex.rand,
       cond  := ← BitVec.rand 4,
       op2   := ← pure 0b00#2,
-      Rn    := ← BitVec.rand 5,
+      Rn    := ← GPRIndex.rand,
       Rd    := ← GPRIndex.rand }
   pure (some (inst.toBitVec32))
 

--- a/Arm/Insts/DPR/Data_processing_one_source.lean
+++ b/Arm/Insts/DPR/Data_processing_one_source.lean
@@ -111,7 +111,7 @@ partial def Data_processing_one_source_cls.rev_all.rand : IO (Option (BitVec 32)
         S := 0b0#1,
         opcode2 := 0b00000#5,
         opcode := 0b0000#4 ++ opc,
-        Rn := ← BitVec.rand 5,
+        Rn := ← GPRIndex.rand,
         Rd := ← GPRIndex.rand
       }
     pure (some (inst.toBitVec32))

--- a/Arm/Insts/DPR/Data_processing_three_source.lean
+++ b/Arm/Insts/DPR/Data_processing_three_source.lean
@@ -79,10 +79,10 @@ def Data_processing_three_source_cls.shift.rand
     { sf := sf,
       op54 := op54,
       op31 := op31,
-      Rm := ← BitVec.rand 5,
+      Rm := ← GPRIndex.rand,
       o0 := o0,
-      Ra := ← BitVec.rand 5,
-      Rn := ← BitVec.rand 5,
+      Ra := ← GPRIndex.rand,
+      Rn := ← GPRIndex.rand,
       Rd := ← GPRIndex.rand
     }
   pure (some inst.toBitVec32)

--- a/Arm/Insts/DPR/Data_processing_two_source.lean
+++ b/Arm/Insts/DPR/Data_processing_two_source.lean
@@ -46,9 +46,9 @@ def Data_processing_two_source_cls.shift.rand
   let (inst : Data_processing_two_source_cls) :=
     { sf := ← BitVec.rand 1,
       S := 0b0#1,
-      Rm := ← BitVec.rand 5,
+      Rm := ← GPRIndex.rand,
       opcode := opcode,
-      Rn := ← BitVec.rand 5,
+      Rn := ← GPRIndex.rand,
       Rd := ← GPRIndex.rand
     }
   pure (some inst.toBitVec32)

--- a/Arm/Insts/DPR/Logical_shifted_reg.lean
+++ b/Arm/Insts/DPR/Logical_shifted_reg.lean
@@ -82,9 +82,9 @@ partial def Logical_shifted_reg_cls.rand : IO (Option (BitVec 32)) := do
         opc   := ← BitVec.rand 2,
         shift := ← BitVec.rand 2,
         N     := ← BitVec.rand 1,
-        Rm    := ← BitVec.rand 5,
+        Rm    := ← GPRIndex.rand,
         imm6  := imm6,
-        Rn    := ← BitVec.rand 5,
+        Rn    := ← GPRIndex.rand,
         Rd    := ← GPRIndex.rand }
     pure (some (inst.toBitVec32))
 

--- a/Arm/Insts/DPSFP/Conversion_between_FP_and_Int.lean
+++ b/Arm/Insts/DPSFP/Conversion_between_FP_and_Int.lean
@@ -91,26 +91,32 @@ partial def Conversion_between_FP_and_Int_cls.fmov_general.rand : IO (Option (Bi
   let sf := ← BitVec.rand 1
   let intsize := 32 <<< sf.toNat
   let decode_fltsize := if ftype == 0b10#2 then 64 else (8 <<< (ftype ^^^ 0b10#2).toNat)
-  if ftype == 0b10#2 && (extractLsb 2 1 opcode) ++ rmode != 0b1101#4
-  || decode_fltsize != 16 && decode_fltsize != intsize
-  || intsize != 64 || ftype != 0b10#2 then
+  if ftype == 0b10#2 && ((extractLsb 2 1 opcode) ++ rmode) != 0b1101#4 ||
+     decode_fltsize != 16 && decode_fltsize != intsize ||
+     intsize != 64 || ftype != 0b10#2 then
     Conversion_between_FP_and_Int_cls.fmov_general.rand
   else
     let (inst : Conversion_between_FP_and_Int_cls) :=
+      let gpr_idx := ←GPRIndex.rand
+      let sfp_idx := ←BitVec.rand 5
+      let (src_idx, dst_idx) :=
+        if (lsb opcode 0) = 1#1 then
+        -- FPConvOp.FPConvOp_MOV_ItoF
+        -- Source operand is a GPR.
+        -- Destination operand is a SIMD&FP register.
+          (gpr_idx, sfp_idx)
+       else
+       -- FPConvOp.FPConvOp_MOV_FtoI
+       -- Source operand is a SIMD&FP register.
+       -- Destination operand is a GPR.
+         (sfp_idx, gpr_idx)
       { sf := sf,
         S := 0b0#1,
         ftype := ftype,
         rmode  := rmode,
         opcode := opcode,
-        Rn := ← BitVec.rand 5,
-        Rd := ← (if (lsb opcode 0) = 1#1 then
-                -- FPConvOp.FPConvOp_MOV_ItoF
-                -- Destination operand is a SIMD&FP register.
-                  BitVec.rand 5
-                else
-                -- FPConvOp.FPConvOp_MOV_FtoI
-                -- Destination operand is a GPR register.
-                  GPRIndex.rand) }
+        Rn := src_idx,
+        Rd := dst_idx }
     pure (inst.toBitVec32)
 
 /-- Generate random instructions of Conversion_between_FP_and_Int class. -/


### PR DESCRIPTION
### Description:

`x18` is not used either as a source or destination register. Moreover, it is not expected to be preserved after a cosim test.

This is expected to clear up the bogus mismatches we see on Arm-based Apple machines.

Another relevant PR: https://github.com/leanprover/LNSym/pull/98 

### Testing:

`make all` succeeds on my M3.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
