### PR TITLE
chore: make cosim quicker on default build

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -20,7 +20,7 @@ def find_index (e : String) (xs : List String) : Option Nat :=
   find_index_aux e xs 0
 
 -- Default number of tests/instruction
-def default_numTests : Nat := 20
+def default_numTests : Nat := 3
 
 def numTests_option (args : List String) : IO Nat :=
   let maybe_idx := find_index "--num-tests" args

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 
 LAKE = lake
 
-NUM_TESTS?=20
+NUM_TESTS?=3
 VERBOSE?=--verbose
 
 .PHONY: all 


### PR DESCRIPTION
I realized that I was never really running cosim locally because it took too long --- in an effort to remedy the situation, I set `make` (the default `make all`) rule to run `quick-cosim`, which sets `--num-tests=3`. While this is still a tad too long for my taste, it is, at the very least, tolerable, so I actually run cosim locally now rather than relying on CI (: 

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
