### PR TITLE
feat: add .github/CODEOWNERS to allow smooth collaboration.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code Ownership
+
+* @shigoel
+


### PR DESCRIPTION
We add @shigoel as a `CODEOWNER`, which means that only she can merge code into `main`.

We request that @bollu and @alexkeizer be added as collaborators to `leanprover/LNSym`. This enables them to open branches directly on `leanprover/LNSym`, allowing for effective `mathlib` style collaboration. In particular, it allows them to open shared branches to which *all three of* @bollu, @alexkeizer, and @shigoel can push.
This enables us to effectively work on problems that require shared expertise (e.g. the current development of the `Max` program), without having to faff about with remotes.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
