### PR TITLE
Fix DPI.Logical_imm instructions to account for aliases TST and MOV

### DIFF
--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -15,7 +15,7 @@ open BitVec
 
 ----------------------------------------------------------------------
 
-/--
+/-!
 `GPRIndex.rand` picks a safe GPR index for Arm-based Apple platforms
 i.e., one not reserved on them. Use this function instead of
 `BitVec.rand` to pick an appropriate random index for a source and
@@ -314,7 +314,7 @@ theorem M_divisible_by_esize_of_valid_bit_masks (immN : BitVec 1) (imms : BitVec
 --   https://developer.arm.com/documentation/dui0802/b/A64-General-Instructions/MOV--bitmask-immediate-
 --   https://kddnewton.com/2022/08/11/aarch64-bitmask-immediates.html
 -- Arm Implementation:
---   https://tiny.amazon.com/c57v7i1u/devearmdocuddi02023Sharaarc
+--   https://developer.arm.com/documentation/ddi0602/2023-12/Shared-Pseudocode/aarch64-functions-bitmasks?lang=en#impl-aarch64.DecodeBitMasks.5
 def decode_bit_masks (immN : BitVec 1) (imms : BitVec 6) (immr : BitVec 6)
   (immediate : Bool) (M : Nat) : Option (BitVec M × BitVec M) :=
   if h0 : invalid_bit_masks immN imms immediate M then none

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -15,7 +15,7 @@ open BitVec
 
 ----------------------------------------------------------------------
 
-/-!
+/--
 `GPRIndex.rand` picks a safe GPR index for Arm-based Apple platforms
 i.e., one not reserved on them. Use this function instead of
 `BitVec.rand` to pick an appropriate random index for a source and

--- a/Arm/Insts/DPI/Logical_imm.lean
+++ b/Arm/Insts/DPI/Logical_imm.lean
@@ -39,7 +39,7 @@ def exec_logical_imm_op (op : LogicalImmType) (op1 : BitVec n) (op2 : BitVec n)
     let result := op1 &&& op2
     (op1 &&& op2, some (update_logical_imm_pstate result))
 
-/-!
+/--
 Return `TRUE` if a bitmask immediate encoding would generate an
 immediate value that could also be represented by a single `MOVZ` or
 `MOVN` instruction.  Used as a condition for the preferred `MOV<-ORR`
@@ -82,7 +82,7 @@ def MoveWidePreferred (sf immN : BitVec 1) (imms immr : BitVec 6) : Bool :=
     else
       false
 
-/-!
+/--
 Instruction semantics for `Logical_imm_cls` instructions
 `AND, ORR, EOR, ANDS (immediate): 32- and 64-bit versions`.
 
@@ -144,7 +144,7 @@ def exec_logical_imm (inst : Logical_imm_cls) (s : ArmState) : ArmState :=
 
 ----------------------------------------------------------------------
 
-/-! Generate random instructions of the DPI.Logical_imm class. -/
+/-- Generate random instructions of the DPI.Logical_imm class. -/
 partial def Logical_imm_cls.inst.rand : Cosim.CosimM (Option (BitVec 32)) := do
   let sf ← BitVec.rand 1
   let N ← BitVec.rand 1

--- a/Arm/Insts/DPI/Logical_imm.lean
+++ b/Arm/Insts/DPI/Logical_imm.lean
@@ -39,7 +39,7 @@ def exec_logical_imm_op (op : LogicalImmType) (op1 : BitVec n) (op2 : BitVec n)
     let result := op1 &&& op2
     (op1 &&& op2, some (update_logical_imm_pstate result))
 
-/-!
+/--
 Return `TRUE` if a bitmask immediate encoding would generate an
 immediate value that could also be represented by a single `MOVZ` or
 `MOVN` instruction.  Used as a condition for the preferred `MOV<-ORR`

--- a/Arm/Insts/DPI/Logical_imm.lean
+++ b/Arm/Insts/DPI/Logical_imm.lean
@@ -120,10 +120,10 @@ def exec_logical_imm (inst : Logical_imm_cls) (s : ArmState) : ArmState :=
       let operand1 :=
         match op with
         | .ORR =>
-          if inst.Rn = 31#5 ∧
-            -- (TODO): a `dsimproc` for MoveWidePreferred?
-             ¬ MoveWidePreferred inst.sf inst.N inst.imms inst.immr then
-             -- MOV (bitmask immediate) is an alias of ORR.
+          -- (TODO): a `dsimproc` for MoveWidePreferred?
+          if  ¬ MoveWidePreferred inst.sf inst.N inst.imms inst.immr then
+             -- MOV (bitmask immediate) is an alias of ORR when
+             -- Rd == '11111' and Move Wide is not preferred.
              read_gpr_zr datasize inst.Rn s
           else
             read_gpr datasize inst.Rn s

--- a/Specs/GCMV8.lean
+++ b/Specs/GCMV8.lean
@@ -8,8 +8,8 @@ import Specs.GCM
 
 -- References:
 -- https://github.com/GaloisInc/cryptol/blob/master/lib/Cryptol/Reference.cry
--- https://tiny.amazon.com/12296d03c/githGalocrypblob1e31PrimSymm
--- https://tiny.amazon.com/3edw4edm/githawslawslblob02aaSAWspec
+-- https://github.com/GaloisInc/cryptol-specs/blob/1e31efb619f4c328845e254577dedeca66669068/Primitive/Symmetric/Cipher/Authenticated/AES_256_GCM.cry#L20
+-- https://github.com/awslabs/aws-lc-verification/blob/02aa15c93ed9d2ddc1f7c4742ff05b3e7f05c592/SAW/spec/AES/AES-GCM.cry#L75
 -- https://github.com/awslabs/aws-lc-verification/blob/master/SAW/proof/AES/GHASH.saw
 -- https://link.springer.com/chapter/10.1007/978-3-031-34671-2_30
 -- https://www.rfc-editor.org/rfc/rfc8452.txt


### PR DESCRIPTION
### Description:

Fix spec. of `DPI.Logical_imm` instructions to account for the behavior of `ORR`'s alias `MOV` and `ANDS`'s alias `TST`.

### Testing:

`make all` succeeded on my M3.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
