### PR TITLE
chore: add .vscode/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 /build
 /lakefile.olean
 /lake-packages/*


### PR DESCRIPTION
I noticed that VScode now has a `.vscode/` folder for me, which holds workspace-specific settings. Add this folder into `.gitignore` to prevent accidental check-ins