### PR TITLE
Popcount32 functional correctness and (non)effects characterization

### DIFF
--- a/Arm/State.lean
+++ b/Arm/State.lean
@@ -336,7 +336,7 @@ def r (fld : StateField) (s : ArmState) : (state_value fld) :=
 /-!
 
 We define helpers for reading and writing registers on the `ArmState` with the colloquial
-names. For example, the stack pointer (`sp`) refers to register 31. 
+names. For example, the stack pointer (`sp`) refers to register 31.
 These mnemonics make it much easier to read and write theorems about assembly programs.
 
 -/
@@ -1142,7 +1142,7 @@ theorem Memory.eq_of_read_mem_bytes_eq {m₁ m₂ : Memory}
   rw [BitVec.zero_append, BitVec.zero_append] at h
   simpa only [Nat.reduceAdd, BitVec.cast_eq] using h
 
-theorem mem_eq_iff_read_mem_bytes_eq {s₁ s₂ : ArmState} :
+theorem Memory.mem_eq_iff_read_mem_bytes_eq {s₁ s₂ : ArmState} :
     s₁.mem = s₂.mem
     ↔ ∀ n addr, read_mem_bytes n addr s₁ = read_mem_bytes n addr s₂ := by
   simp only [memory_rules]
@@ -1156,7 +1156,7 @@ theorem read_mem_bytes_write_mem_bytes_of_read_mem_eq
     read_mem_bytes n₁ addr₁ (write_mem_bytes n₂ addr₂ val s₁)
     = read_mem_bytes n₁ addr₁ (write_mem_bytes n₂ addr₂ val s₂) := by
   revert n₁ addr₁
-  simp only [← mem_eq_iff_read_mem_bytes_eq] at h ⊢
+  simp only [← Memory.mem_eq_iff_read_mem_bytes_eq] at h ⊢
   simp only [memory_rules, h]
 
 /- Helper lemma for `state_eq_iff_components_eq` -/

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -71,19 +71,6 @@ def popcount32_program : Program :=
 
 #genStepEqTheorems popcount32_program
 
-theorem popcount32_sym_no_error (s0 s_final : ArmState)
-  (h_s0_pc : read_pc s0 = 0x4005b4#64)
-  (h_s0_program : s0.program = popcount32_program)
-  (h_s0_sp_aligned : CheckSPAlignment s0)
-  (h_s0_err : read_err s0 = StateError.None)
-  (h_run : s_final = run 27 s0) :
-  read_err s_final = StateError.None := by
-  -- Prelude
-  simp_all only [state_simp_rules, -h_run]
-  -- Symbolic Simulation
-  sym_n 27
-  done
-
 theorem popcount32_sym_meets_spec (s0 s_final : ArmState)
   (h_s0_pc : read_pc s0 = 0x4005b4#64)
   (h_s0_program : s0.program = popcount32_program)

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -31,10 +31,8 @@ def popcount32_spec_rec (i : Nat) (x : BitVec 32) : (BitVec 32) :=
   match i with
   | 0 => 0#32
   | i' + 1 =>
-    -- We do not use .ofBool here because it is unsupported by `bv_decide`.
-    -- let bit_idx := BitVec.getLsbD x i'
-    -- ((BitVec.zeroExtend 32 (BitVec.ofBool bit_idx)) + (popcount32_spec_rec i' x))
-    ((x >>> i') &&& 1#32) + (popcount32_spec_rec i' x)
+    let bit_idx := BitVec.getLsbD x i'
+    ((BitVec.zeroExtend 32 (BitVec.ofBool bit_idx)) + (popcount32_spec_rec i' x))
 
 def popcount32_spec (x : BitVec 32) : BitVec 32 :=
   popcount32_spec_rec 32 x

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -92,15 +92,7 @@ theorem popcount32_sym_meets_spec (s0 s_final : ArmState)
                fst_AddWithCarry_eq_sub_neg]
     repeat (simp only [popcount32_spec_rec])
     bv_decide
-  · -- sym_aggregate
-    intro f h_x0 h_x1 h_x31 h_pc
-    simp only [h_s27_non_effects _ h_pc,
-               h_s26_non_effects _ h_pc h_x31,
-               h_s25_non_effects _ h_x0 h_pc,
-               h_s24_non_effects _ h_pc,
-               h_s23_non_effects _ h_x0 h_pc,
-               h_s22_non_effects _ h_x0 h_pc]
-    sorry
+  · sym_aggregate
 
 -------------------------------------------------------------------------------
 

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -1,11 +1,12 @@
 /-
 Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author(s): Nathan Wetzler
+Author(s): Nathan Wetzler, Shilpi Goel, Alex Keizer
 -/
 import Arm.Exec
 import Arm.Util
 import Tactics.Sym
+import Tactics.Aggregate
 import Tactics.StepThms
 
 section popcount32
@@ -26,10 +27,12 @@ int popcount_32 (unsigned int v) {
 
 def popcount32_spec_rec (i : Nat) (x : BitVec 32) : (BitVec 32) :=
   match i with
-  | 0 => BitVec.zero 32
+  | 0 => 0#32
   | i' + 1 =>
-    let bit_idx := BitVec.getLsbD x i'
-    ((BitVec.zeroExtend 32 (BitVec.ofBool bit_idx)) + (popcount32_spec_rec i' x))
+    -- We do not use .ofBool here because it is unsupported by `bv_decide`.
+    -- let bit_idx := BitVec.getLsbD x i'
+    -- ((BitVec.zeroExtend 32 (BitVec.ofBool bit_idx)) + (popcount32_spec_rec i' x))
+    ((x >>> i') &&& 1#32) + (popcount32_spec_rec i' x)
 
 def popcount32_spec (x : BitVec 32) : BitVec 32 :=
   popcount32_spec_rec 32 x
@@ -81,31 +84,38 @@ theorem popcount32_sym_no_error (s0 s_final : ArmState)
   sym_n 27
   done
 
--- theorem popcount32_sym_meets_spec (s0 s_final : ArmState)
---   (h_s0_pc : read_pc s0 = 0x4005b4#64)
---   (h_s0_program : s0.program = popcount32_program)
---   (h_s0_sp_aligned : CheckSPAlignment s0)
---   (h_s0_err : read_err s0 = StateError.None)
---   (h_run : s_final = run 27 s0) :
---   read_gpr 32 0#5 s_final = popcount32_spec (read_gpr 32 0#5 s0) ∧
---   read_err s_final = StateError.None := by
---   -- Prelude
---   simp_all only [state_simp_rules, -h_run]
---   -- Symbolic Simulation
---   sym_n 27
---   try (clear h_step_1 h_step_2 h_step_3 h_step_4;
---        clear h_step_5 h_step_6 h_step_7 h_step_8;
---        clear h_step_9 h_step_10;
---        clear h_step_11 h_step_12 h_step_13 h_step_14;
---        clear h_step_15 h_step_16 h_step_17 h_step_18;
---        clear h_step_19 h_step_20;
---        clear h_step_21 h_step_22 h_step_23 h_step_24;
---        clear h_step_25 h_step_26)
---   -- Final Steps
---   unfold run at h_run
---   subst s_final
---   unfold popcount32_spec
---   sorry
+theorem popcount32_sym_meets_spec (s0 s_final : ArmState)
+  (h_s0_pc : read_pc s0 = 0x4005b4#64)
+  (h_s0_program : s0.program = popcount32_program)
+  (h_s0_sp_aligned : CheckSPAlignment s0)
+  (h_s0_err : read_err s0 = StateError.None)
+  (h_run : s_final = run 27 s0) :
+  read_gpr 32 0#5 s_final = popcount32_spec (read_gpr 32 0#5 s0) ∧
+  read_err s_final = StateError.None ∧
+  ∀ f, f ≠ (.GPR 0#5) ∧ f ≠ (.GPR 1#5) ∧ f ≠ (.GPR 31#5) ∧ f ≠ .PC →
+       r f s_final = r f s0 := by
+  -- Prelude
+  simp_all only [state_simp_rules, -h_run]
+  -- Symbolic Simulation
+  sym_n 27
+  -- Final Steps
+  constructor
+  · simp only [popcount32_spec,
+               fst_AddWithCarry_eq_add,
+               fst_AddWithCarry_eq_sub_neg]
+    repeat (simp only [popcount32_spec_rec])
+    bv_decide
+  · -- sym_aggregate
+    intro f h_x0 h_x1 h_x31 h_pc
+    simp only [h_s27_non_effects _ h_pc,
+               h_s26_non_effects _ h_pc h_x31,
+               h_s25_non_effects _ h_x0 h_pc,
+               h_s24_non_effects _ h_pc,
+               h_s23_non_effects _ h_x0 h_pc,
+               h_s22_non_effects _ h_x0 h_pc]
+    sorry
+
+-------------------------------------------------------------------------------
 
 /-! ## Tests for step theorem generation -/
 section Tests

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -90,11 +90,11 @@ theorem popcount32_sym_meets_spec (s0 s_final : ArmState)
   sym_n 27
   -- Final Steps
   -- Split all the Ands in the conclusion.
-  repeat (any_goals apply And.intro)
+  repeat' apply And.intro
   · simp only [popcount32_spec,
                fst_AddWithCarry_eq_add,
                fst_AddWithCarry_eq_sub_neg]
-    repeat (simp only [popcount32_spec_rec])
+    simp only [popcount32_spec_rec]
     bv_decide
   · sym_aggregate
   · -- (TODO @alex) Let's do away with


### PR DESCRIPTION
### Description:

Prove that the popcount32 program correctly computes the bitcount of its input, and prove that certain state components were left unmodified by this program.

### Testing:

`make all` ran locally.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
