### PR TITLE
feat: ofBool_getLsbD normalization rule for bv_decide

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -1073,6 +1073,14 @@ theorem not_slt {w} (a b : BitVec w) : ¬ (a.slt b) ↔ (b.sle a) := by
   · simp [h]
     exact Int.not_lt.mp h
 
+-- TODO: delete once https://github.com/leanprover/lean4/pull/5375/files
+--       is merged
+@[bv_normalize]
+theorem BitVec.ofBool_getLsbD (a : BitVec w) (i : Nat) :
+    BitVec.ofBool (a.getLsbD i) = a.extractLsb' i 1 := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro ⟨0, _⟩
+  simp
 
 /-! ## `Quote` instance -/
 


### PR DESCRIPTION
### Description:

I've opened [#5375](https://github.com/leanprover/lean4/pull/5375) upstream, but in the meantime we can add the normalization rule ourselves. This ensures we don't have to get rid of uses of the `ofBool (getLsb ..)` pattern in #159

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine? Yes

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
