### PR TITLE
refactor: remove `SymContext.h_err?` field, move `addGoalsForMissingHypotheses` functionality into `fromLocalContext`

### DIFF
--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -406,7 +406,6 @@ elab "sym_n" whileTac?:(sym_while)? n:num s:(sym_at)? : tactic => do
   let c ← withMainContext <| SymContext.fromLocalContext s
   SymM.run' c <| do
     -- Context preparation
-    addGoalsForMissingHypotheses
     canonicalizeHypothesisTypes
 
     -- Check pre-conditions


### PR DESCRIPTION
### Description:

Continues the cleanup started in #180 by getting rid of `h_err?` and `addGoalsForMissingHypotheses`.

Note that we remove the ability to add a goal for `CheckSPAlignment`, this option was false by default, and never used

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine? yes

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
