### PR TITLE
Remove cadical build/install in workflows

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -17,11 +17,6 @@ jobs:
 
     steps:
 
-    - uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Install cadical
-      run: nix profile install nixpkgs#cadical
-
     - uses: actions/checkout@v4
 
     - uses: leanprover/lean-action@v1.0.1

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,11 +20,6 @@ jobs:
 
     steps:
 
-    - uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Install cadical
-      run: nix profile install nixpkgs#cadical
-
     - uses: actions/checkout@v4
 
     - uses: leanprover/lean-action@v1

--- a/README.md
+++ b/README.md
@@ -9,13 +9,9 @@ guidelines.
 
 ## Prerequisites
 
-1. Install the [Cadical SAT
-   Solver](https://github.com/arminbiere/cadical), and make sure that
-   it is in your path.
-
-2. Install Lean4 and your preferred editor's plug-in on your machine
-   by following [these
-   instructions](https://leanprover-community.github.io/get_started.html).
+Install Lean4 and your preferred editor's plug-in on your machine by
+following [these
+instructions](https://leanprover-community.github.io/get_started.html).
 
 ## Build Instructions
 


### PR DESCRIPTION
### Description:

Cadical is no longer a user-facing dependency of LNSym, now that it is available with Lean.

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine?

Yes

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.