### PR TITLE
Refactor to use `extractLsb'` instead of `extractLsb`

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -539,6 +539,12 @@ theorem zeroExtend_if_false [Decidable p] (x : BitVec n)
   (zeroExtend (if p then a else b) x) = BitVec.cast h_eq (zeroExtend b x) := by
   simp only [toNat_eq, toNat_truncate, ← h_eq, toNat_cast]
 
+theorem extractLsb_eq (x : BitVec n) (h : n = n - 1 + 1) :
+  BitVec.extractLsb (n - 1) 0 x = BitVec.cast h x := by
+  unfold extractLsb extractLsb'
+  ext1
+  simp [←h]
+
 theorem extractLsb'_eq (x : BitVec n) :
   BitVec.extractLsb' 0 n x = x := by
   unfold extractLsb'
@@ -626,17 +632,15 @@ theorem append_of_extract_general_nat (high low n vn : Nat) (h : vn < 2 ^ n) :
 
 theorem append_of_extract (n : Nat) (v : BitVec n)
   (high0 : high = n - low) (h : high + low = n) :
-  zeroExtend high (v >>> low) ++ extractLsb' 0 low v = BitVec.cast h.symm v := by
+  BitVec.cast h (zeroExtend high (v >>> low) ++ extractLsb' 0 low v) = v := by
   ext
   subst high
   have vlt := v.isLt
   have := append_of_extract_general_nat (n - low) low n (BitVec.toNat v) vlt
   have low_le : low ≤ n := by omega
-  simp only [toNat_append, toNat_truncate, toNat_ushiftRight, extractLsb'_toNat,
-    Nat.shiftRight_zero, toNat_cast]
-  -- simp_all [toNat_zeroExtend, Nat.sub_add_cancel, low_le]
+  simp_all [toNat_zeroExtend, Nat.sub_add_cancel, low_le]
   rw [Nat.mod_eq_of_lt (b := 2 ^ n)] at this
-  · sorry -- rw [this]
+  · rw [this]
   · rw [Nat.shiftRight_eq_div_pow]
     exact Nat.lt_of_le_of_lt (Nat.div_le_self _ _) vlt
   done

--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -933,6 +933,16 @@ theorem extractLsByte_def (val : BitVec w₁) (n : Nat) :
     val.extractLsByte n = val.extractLsb' (n * 8) 8 := rfl
 
 -- TODO: upstream
+theorem extractLsb_or (x y : BitVec w₁) (n : Nat) :
+    (x ||| y).extractLsb n lo = (x.extractLsb n lo ||| y.extractLsb n lo) := by
+  apply BitVec.eq_of_getLsbD_eq
+  simp only [getLsbD_extract, getLsbD_or]
+  intros i
+  by_cases h : (i : Nat) ≤ n - lo
+  · simp only [h, decide_True, Bool.true_and]
+  · simp only [h, decide_False, Bool.false_and, Bool.or_self]
+
+-- TODO: upstream
 theorem extractLsb'_or (x y : BitVec w₁) (n : Nat) :
     (x ||| y).extractLsb' lo n = (x.extractLsb' lo n ||| y.extractLsb' lo n) := by
   apply BitVec.eq_of_getLsbD_eq

--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -955,7 +955,7 @@ theorem extractLsb'_or (x y : BitVec w₁) (n : Nat) :
 
 -- TODO: upstream
 protected theorem extractLsb'_ofNat (x n : Nat) (l lo : Nat) :
-  extractLsb' lo l (BitVec.ofNat n x) = .ofNat l ((x % 2^n) >>> lo) := by
+    extractLsb' lo l (BitVec.ofNat n x) = .ofNat l ((x % 2^n) >>> lo) := by
   apply eq_of_getLsbD_eq
   intro ⟨i, _lt⟩
   simp [BitVec.ofNat]

--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -289,7 +289,7 @@ abbrev lsb (x : BitVec n) (i : Nat) : BitVec 1 :=
   --   BitVec.extractLsb' i 1 x
   -- and avoid the cast here, but unfortunately, extractLsb' isn't supported
   -- by LeanSAT.
-  (BitVec.extractLsb i i x).cast (by omega)
+  (BitVec.extractLsb' i 1 x).cast (by omega)
 
 abbrev partInstall (hi lo : Nat) (val : BitVec (hi - lo + 1)) (x : BitVec n): BitVec n :=
   let mask := allOnes (hi - lo + 1)
@@ -554,14 +554,12 @@ theorem extractLsb_eq (x : BitVec n) (h : n = n - 1 + 1) :
 
 @[bitvec_rules]
 protected theorem extract_lsb_of_zeroExtend (x : BitVec n) (h : j < i) :
-    extractLsb j 0 (zeroExtend i x) = zeroExtend (j + 1) x := by
+    extractLsb' 0 (j + 1) (zeroExtend i x) = zeroExtend (j + 1) x := by
   apply BitVec.eq_of_getLsbD_eq
   simp
   intro k
   have q : k < i := by omega
   by_cases h : decide (k ≤ j) <;> simp [q, h]
-  simp_all
-  omega
 
 @[bitvec_rules, simp]
 theorem zero_append {w} (x : BitVec 0) (y : BitVec w) :

--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -59,7 +59,10 @@ attribute [bitvec_rules] BitVec.getLsbD_truncate
 attribute [bitvec_rules] BitVec.zeroExtend_zeroExtend_of_le
 attribute [bitvec_rules] BitVec.truncate_truncate_of_le
 attribute [bitvec_rules] BitVec.truncate_cast
+attribute [bitvec_rules] BitVec.extractLsb_ofFin
+attribute [bitvec_rules] BitVec.extractLsb_ofNat
 attribute [bitvec_rules] BitVec.extractLsb'_toNat
+attribute [bitvec_rules] BitVec.extractLsb_toNat
 attribute [bitvec_rules] BitVec.getLsbD_extract
 attribute [bitvec_rules] BitVec.toNat_allOnes
 attribute [bitvec_rules] BitVec.getLsbD_allOnes

--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -59,10 +59,7 @@ attribute [bitvec_rules] BitVec.getLsbD_truncate
 attribute [bitvec_rules] BitVec.zeroExtend_zeroExtend_of_le
 attribute [bitvec_rules] BitVec.truncate_truncate_of_le
 attribute [bitvec_rules] BitVec.truncate_cast
-attribute [bitvec_rules] BitVec.extractLsb_ofFin
-attribute [bitvec_rules] BitVec.extractLsb_ofNat
 attribute [bitvec_rules] BitVec.extractLsb'_toNat
-attribute [bitvec_rules] BitVec.extractLsb_toNat
 attribute [bitvec_rules] BitVec.getLsbD_extract
 attribute [bitvec_rules] BitVec.toNat_allOnes
 attribute [bitvec_rules] BitVec.getLsbD_allOnes
@@ -546,17 +543,15 @@ theorem zeroExtend_if_false [Decidable p] (x : BitVec n)
   (zeroExtend (if p then a else b) x) = BitVec.cast h_eq (zeroExtend b x) := by
   simp only [toNat_eq, toNat_truncate, ← h_eq, toNat_cast]
 
-theorem extractLsb_eq (x : BitVec n) (h : n = n - 1 + 1) :
-  BitVec.extractLsb (n - 1) 0 x = BitVec.cast h x := by
-  unfold extractLsb extractLsb'
-  ext1
-  simp [←h]
+theorem extractLsb'_eq (x : BitVec n) :
+  BitVec.extractLsb' 0 n x = x := by
+  unfold extractLsb'
+  simp only [Nat.shiftRight_zero, ofNat_toNat, zeroExtend_eq]
 
 @[bitvec_rules]
-protected theorem extract_lsb_of_zeroExtend (x : BitVec n) (h : j < i) :
-    extractLsb' 0 (j + 1) (zeroExtend i x) = zeroExtend (j + 1) x := by
+protected theorem extractLsb'_of_zeroExtend (x : BitVec n) (h : j ≤ i) :
+    extractLsb' 0 j (zeroExtend i x) = zeroExtend j x := by
   apply BitVec.eq_of_getLsbD_eq
-  simp
   intro k
   have q : k < i := by omega
   by_cases h : decide (k ≤ j) <;> simp [q, h]
@@ -634,12 +629,11 @@ theorem append_of_extract_general_nat (high low n vn : Nat) (h : vn < 2 ^ n) :
   done
 
 theorem append_of_extract (n : Nat) (v : BitVec n)
-  (high0 : high = n - low) (low0 : 1 <= low)
-  (h : high + (low - 1 - 0 + 1) = n) :
-  BitVec.cast h (zeroExtend high (v >>> low) ++ extractLsb (low - 1) 0 v) = v := by
+  (high0 : high = n - low) (h : high + low = n) :
+  BitVec.cast h (zeroExtend high (v >>> low) ++ extractLsb' 0 low v) = v := by
   ext
   subst high
-  have vlt := v.isLt; simp_all only [Nat.sub_zero]
+  have vlt := v.isLt
   have := append_of_extract_general_nat (n - low) low n (BitVec.toNat v) vlt
   have low_le : low ≤ n := by omega
   simp_all [toNat_zeroExtend, Nat.sub_add_cancel, low_le]
@@ -649,17 +643,13 @@ theorem append_of_extract (n : Nat) (v : BitVec n)
     exact Nat.lt_of_le_of_lt (Nat.div_le_self _ _) vlt
   done
 
-theorem append_of_extract_general (v : BitVec n)
-  (low0 : 1 <= low)
-  (h1 : high = width)
-  (h2 : (high + low - 1 - 0 + 1) = (width + (low - 1 - 0 + 1))) :
-  BitVec.cast h1 (zeroExtend high (v >>> low)) ++ extractLsb (low - 1) 0 v =
-  BitVec.cast h2 (extractLsb (high + low - 1) 0 v) := by
+theorem append_of_extract_general (v : BitVec n) :
+  (zeroExtend high (v >>> low)) ++ extractLsb' 0 low v =
+  extractLsb' 0 (high + low) v := by
   ext
   have := append_of_extract_general_nat high low n (BitVec.toNat v)
-  have h_vlt := v.isLt; simp_all only [Nat.sub_zero, h1]
-  simp only [h_vlt, h1, forall_prop_of_true] at this
-  have low' : 1 ≤ width + low := Nat.le_trans low0 (Nat.le_add_left low width)
+  have h_vlt := v.isLt; simp_all only [Nat.sub_zero]
+  simp only [h_vlt, forall_prop_of_true] at this
   simp_all [toNat_zeroExtend, Nat.sub_add_cancel]
   rw [Nat.mod_eq_of_lt (b := 2 ^ n)] at this
   · rw [this]
@@ -788,7 +778,7 @@ def genBVPatMatchTest (var : Term) (pat : BVPat) : MacroM Term := do
   for c in pat.getComponents do
     let len := c.length
     if let some bv ← c.toBVLit? then
-      let test ← `(extractLsb $(quote (shift + (len - 1))) $(quote shift) $var == $bv)
+      let test ← `(extractLsb' $(quote shift) $(quote len) $var == $bv)
       result ← `($result && $test)
     shift := shift + len
   return result
@@ -810,7 +800,7 @@ def declBVPatVars (var : Term) (pat : BVPat) (rhs : Term) : MacroM Term := do
   for c in pat.getComponents do
     let len := c.length
     if let some y ← c.toBVVar? then
-      let rhs ← `(extractLsb $(quote (shift + (len - 1))) $(quote shift) $var)
+      let rhs ← `(extractLsb' $(quote shift) $(quote len) $var)
       result ← `(let $y := $rhs; $result)
     shift := shift + len
   return result
@@ -934,23 +924,28 @@ Definition to extract the `n`th least significant *Byte* from a bitvector.
 TODO: this should be named `getLsByte`, or `getLsbByte` (Shilpi prefers this).
 -/
 def extractLsByte (val : BitVec w₁) (n : Nat) : BitVec 8 :=
-  val.extractLsb ((n + 1) * 8 - 1) (n * 8) |> .cast (by omega)
+  val.extractLsb' (n * 8) 8
 
 theorem extractLsByte_def (val : BitVec w₁) (n : Nat) :
-    val.extractLsByte n = (val.extractLsb ((n + 1)*8 - 1) (n * 8) |>.cast (by omega)) := rfl
+    val.extractLsByte n = val.extractLsb' (n * 8) 8 := rfl
 
 -- TODO: upstream
-theorem extractLsb_or (x y : BitVec w₁) (n : Nat) :
-    (x ||| y).extractLsb n lo = (x.extractLsb n lo ||| y.extractLsb n lo) := by
+theorem extractLsb'_or (x y : BitVec w₁) (n : Nat) :
+    (x ||| y).extractLsb' lo n = (x.extractLsb' lo n ||| y.extractLsb' lo n) := by
   apply BitVec.eq_of_getLsbD_eq
   simp only [getLsbD_extract, getLsbD_or]
   intros i
-  by_cases h : (i : Nat) ≤ n - lo
-  · simp only [h, decide_True, Bool.true_and]
-  · simp only [h, decide_False, Bool.false_and, Bool.or_self]
+  simp only [getLsbD_extractLsb', Fin.is_lt, decide_True, getLsbD_or, Bool.true_and]
+
+-- TODO: upstream
+protected theorem extractLsb'_ofNat (x n : Nat) (l lo : Nat) :
+  extractLsb' lo l (BitVec.ofNat n x) = .ofNat l ((x % 2^n) >>> lo) := by
+  apply eq_of_getLsbD_eq
+  intro ⟨i, _lt⟩
+  simp [BitVec.ofNat]
 
 theorem extractLsByte_zero {w : Nat} : (0#w).extractLsByte i = 0#8 := by
-  simp only [extractLsByte, BitVec.extractLsb_ofNat, Nat.zero_mod, Nat.zero_shiftRight, cast_ofNat]
+  simp only [extractLsByte, BitVec.extractLsb'_ofNat, Nat.zero_mod, Nat.zero_shiftRight, cast_ofNat]
 
 theorem extractLsByte_ge (h : 8 * a ≥ w₁) (x : BitVec w₁) :
   x.extractLsByte a = 0#8 := by
@@ -958,7 +953,7 @@ theorem extractLsByte_ge (h : 8 * a ≥ w₁) (x : BitVec w₁) :
   intros i
   simp only [getLsbD_zero, extractLsByte_def,
     getLsbD_cast, getLsbD_extract, Bool.and_eq_false_imp, decide_eq_true_eq]
-  intros _
+  simp only [getLsbD_extractLsb', Fin.is_lt, decide_True, Bool.true_and]
   apply BitVec.getLsbD_ge
   omega
 
@@ -967,10 +962,13 @@ theorem getLsbD_extractLsByte (val : BitVec w₁) :
     ((BitVec.extractLsByte val n).getLsbD i) =
     (decide (i ≤ 7) && val.getLsbD (n * 8 + i)) := by
   simp only [extractLsByte, getLsbD_cast, getLsbD_extract]
-  rw [Nat.succ_mul]
-  simp only [Nat.add_one_sub_one,
-    Nat.add_sub_cancel_left]
-
+  simp only [getLsbD_extractLsb']
+  generalize val.getLsbD (n * 8 + i) = x
+  by_cases h : i < 8
+  · simp only [show (i : Nat) ≤ 7 by omega, decide_True, Bool.true_and,
+    Bool.and_iff_right_iff_imp, decide_eq_true_eq, h]
+  · simp only [show ¬(i : Nat) ≤ 7 by omega, decide_False, Bool.false_and,
+    Bool.and_eq_false_imp, decide_eq_true_eq, h]
 
 /--
 Two bitvectors of length `n*8` are equal if all their bytes are equal.
@@ -994,9 +992,7 @@ theorem eq_of_extractLsByte_eq (x y : BitVec (n * 8))
 @bollu: it's not clear if the definition for n=0 is desirable.
 -/
 def extractLsBytes (val : BitVec w) (base : Nat) (n : Nat) : BitVec (n * 8) :=
-  match h : n with
-  | 0 => 0#0
-  | x + 1 => val.extractLsb (base * 8 + n * 8 - 1) (base * 8) |>.cast (by omega)
+  extractLsb' (base * 8) (n * 8) val
 
 @[bitvec_rules]
 theorem getLsbD_extractLsBytes (val : BitVec w) (base : Nat) (n : Nat) (i : Nat) :
@@ -1009,10 +1005,9 @@ theorem getLsbD_extractLsBytes (val : BitVec w) (base : Nat) (n : Nat) (i : Nat)
     simp only [show ¬i < 0 by omega, decide_False, Bool.false_and]
   · simp only [extractLsBytes, getLsbD_cast, getLsbD_extract, Nat.zero_lt_succ, decide_True,
     Bool.true_and]
-    simp only [show base * 8 + (n + 1) * 8 - 1 - base * 8 = (n + 1) * 8 - 1 by omega]
     by_cases h : i < (n + 1) * 8
-    · simp only [show i ≤ (n + 1) * 8 - 1 by omega, decide_True, Bool.true_and, h]
-    · simp only [show ¬(i ≤ (n + 1) * 8 - 1) by omega, decide_False, Bool.false_and, h]
+    · simp only [getLsbD_extractLsb', h, decide_True, Bool.true_and]
+    · simp only [getLsbD_extractLsb', h, decide_False, Bool.false_and]
 
 theorem extractLsByte_extractLsBytes (val : BitVec w) (base : Nat) (n : Nat) (i : Nat) :
     (BitVec.extractLsBytes val base n).extractLsByte i =

--- a/Arm/Cosim.lean
+++ b/Arm/Cosim.lean
@@ -195,7 +195,7 @@ def sfp_list (s : ArmState) : List (BitVec 64) := Id.run do
   let mut acc := []
   for i in [0:32] do
     let reg := read_sfp 128 (BitVec.ofNat 5 i) s
-    acc := acc ++ [(extractLsb 63 0 reg), (extractLsb 127 64 reg)]
+    acc := acc ++ [(extractLsb' 0 64 reg), (extractLsb' 64 64 reg)]
   pure acc
 
 /-- Get the flags in an ArmState as a 4-bit bitvector.-/

--- a/Arm/Insts/BR/Cond_branch_imm.lean
+++ b/Arm/Insts/BR/Cond_branch_imm.lean
@@ -29,7 +29,7 @@ def Cond_branch_imm_inst.condition_holds
   let N := read_flag PFlag.N s
   let V := read_flag PFlag.V s
   let result :=
-    match (extractLsb 3 1 inst.cond) with
+    match (extractLsb' 1 3 inst.cond) with
     | 0b000#3 => Z = 1#1
     | 0b001#3 => C = 1#1
     | 0b010#3 => N = 1#1

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -129,7 +129,7 @@ def ConditionHolds (cond : BitVec 4) (s : ArmState) : Bool :=
 theorem sgt_iff_n_eq_v_and_z_eq_0_64 (x y : BitVec 64) :
   (((AddWithCarry x (~~~y) 1#1).snd.n = (AddWithCarry x (~~~y) 1#1).snd.v) ∧
    (AddWithCarry x (~~~y) 1#1).snd.z = 0#1) ↔ BitVec.slt y x := by
-  simp [AddWithCarry, make_pstate]
+  simp [AddWithCarry, make_pstate, lsb]
   split
   · bv_decide
   · bv_decide
@@ -138,7 +138,7 @@ theorem sgt_iff_n_eq_v_and_z_eq_0_64 (x y : BitVec 64) :
 theorem sgt_iff_n_eq_v_and_z_eq_0_32 (x y : BitVec 32) :
   (((AddWithCarry x (~~~y) 1#1).snd.n = (AddWithCarry x (~~~y) 1#1).snd.v) ∧
    (AddWithCarry x (~~~y) 1#1).snd.z = 0#1) ↔ BitVec.slt y x := by
-  simp [AddWithCarry, make_pstate]
+  simp [AddWithCarry, make_pstate, lsb]
   split
   · bv_decide
   · bv_decide
@@ -147,7 +147,7 @@ theorem sgt_iff_n_eq_v_and_z_eq_0_32 (x y : BitVec 32) :
 theorem sle_iff_not_n_eq_v_and_z_eq_0_64 (x y : BitVec 64) :
   (¬(((AddWithCarry x (~~~y) 1#1).snd.n = (AddWithCarry x (~~~y) 1#1).snd.v) ∧
    (AddWithCarry x (~~~y) 1#1).snd.z = 0#1)) ↔ BitVec.sle x y := by
-  simp [AddWithCarry, make_pstate]
+  simp [AddWithCarry, make_pstate, lsb]
   split
   · bv_decide
   · bv_decide
@@ -156,7 +156,7 @@ theorem sle_iff_not_n_eq_v_and_z_eq_0_64 (x y : BitVec 64) :
 theorem sle_iff_not_n_eq_v_and_z_eq_0_32 (x y : BitVec 32) :
   (¬(((AddWithCarry x (~~~y) 1#1).snd.n = (AddWithCarry x (~~~y) 1#1).snd.v) ∧
    (AddWithCarry x (~~~y) 1#1).snd.z = 0#1)) ↔ BitVec.sle x y := by
-  simp [AddWithCarry, make_pstate]
+  simp [AddWithCarry, make_pstate, lsb]
   split
   · bv_decide
   · bv_decide

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -109,7 +109,7 @@ def ConditionHolds (cond : BitVec 4) (s : ArmState) : Bool :=
   let C := read_flag C s
   let V := read_flag V s
   let result :=
-    match (extractLsb 3 1 cond) with
+    match (extractLsb' 1 3 cond) with
       | 0b000#3 => Z = 1#1           -- EQ or NE
       | 0b001#3 => C = 1#1           -- CS or CC
       | 0b010#3 => N = 1#1           -- MI or PL
@@ -174,12 +174,10 @@ theorem zero_iff_z_eq_one (x : BitVec 64) :
   · bv_decide
   done
 
+
 /-- `Aligned x a` witnesses that the bitvector `x` is `a`-bit aligned. -/
 def Aligned (x : BitVec n) (a : Nat) : Prop :=
-  -- (TODO @alex) Switch to using extractLsb' to unify the two cases.
-  match a with
-  | 0 => True
-  | a' + 1 => extractLsb a' 0 x = BitVec.zero _
+  extractLsb' 0 a x = BitVec.zero _
 
 /-- We need to prove why the Aligned predicate is Decidable. -/
 instance : Decidable (Aligned x a) := by
@@ -201,7 +199,7 @@ theorem Aligned_BitVecAdd_64_4 {x : BitVec 64} {y : BitVec 64}
 
 theorem Aligned_AddWithCarry_64_4 (x : BitVec 64) (y : BitVec 64) (carry_in : BitVec 1)
   (x_aligned : Aligned x 4)
-  (y_carry_in_aligned : Aligned (BitVec.add (extractLsb 3 0 y) (zeroExtend 4 carry_in)) 4)
+  (y_carry_in_aligned : Aligned (BitVec.add (extractLsb' 0 4 y) (zeroExtend 4 carry_in)) 4)
   : Aligned (AddWithCarry x y carry_in).fst 4 := by
   unfold AddWithCarry Aligned at *
   simp_all only [Nat.sub_zero, zero_eq, add_eq]
@@ -238,7 +236,7 @@ theorem CheckSPAligment_of_write_mem_bytes :
 @[state_simp_rules]
 theorem CheckSPAlignment_AddWithCarry_64_4 (st : ArmState) (y : BitVec 64) (carry_in : BitVec 1)
   (x_aligned : CheckSPAlignment st)
-  (y_carry_in_aligned : Aligned (BitVec.add (extractLsb 3 0 y) (zeroExtend 4 carry_in)) 4)
+  (y_carry_in_aligned : Aligned (BitVec.add (extractLsb' 0 4 y) (zeroExtend 4 carry_in)) 4)
   : Aligned (AddWithCarry (r (StateField.GPR 31#5) st) y carry_in).fst 4 := by
   simp_all only [CheckSPAlignment, read_gpr, zeroExtend_eq, Nat.sub_zero, add_eq,
     Aligned_AddWithCarry_64_4]
@@ -438,7 +436,7 @@ def decode_bit_masks (immN : BitVec 1) (imms : BitVec 6) (immr : BitVec 6)
     let r := immr &&& levels
     let diff := s - r
     let esize := 1 <<< len
-    let d := extractLsb (len - 1) 0 diff
+    let d := extractLsb' 0 len diff
     let welem := zeroExtend esize (allOnes (s.toNat + 1))
     let telem := zeroExtend esize (allOnes (d.toNat + 1))
     let wmask := replicate (M/esize) $ rotateRight welem r.toNat
@@ -502,14 +500,12 @@ def Vpart_read (n : BitVec 5) (part width : Nat) (s : ArmState) (H : width > 0)
   : BitVec width :=
   -- assert n >= 0 && n <= 31;
   -- assert part IN {0, 1};
-  have h1: width - 1 + 1 = width := by omega
-  have h2: (width * 2 - 1 - width + 1) = width := by omega
   if part = 0 then
     -- assert width < 128;
-    BitVec.cast h1 $ extractLsb (width-1) 0 $ read_sfp 128 n s
+    extractLsb' 0 width $ read_sfp 128 n s
   else
     -- assert width IN {32,64};
-    BitVec.cast h2 $ extractLsb (width*2-1) width $ read_sfp 128 n s
+    extractLsb' width width $ read_sfp 128 n s
 
 
 @[state_simp_rules]
@@ -522,7 +518,7 @@ def Vpart_write (n : BitVec 5) (part width : Nat) (val : BitVec width) (s : ArmS
     write_sfp width n val s
   else
     -- assert width == 64
-    let res := (extractLsb 63 0 val) ++ (read_sfp 64 n s)
+    let res := (extractLsb' 0 64 val) ++ (read_sfp 64 n s)
     write_sfp 128 n res s
 
 ----------------------------------------------------------------------
@@ -628,13 +624,10 @@ example : rev_vector 32 16 8 0xaabbccdd#32 (by decide)
 /-- Divide bv `vector` into elements, each of size `size`. This function gets
 the `e`'th element from the `vector`. -/
 @[state_simp_rules]
-def elem_get (vector : BitVec n) (e : Nat) (size : Nat)
-  (h: size > 0): BitVec size :=
+def elem_get (vector : BitVec n) (e : Nat) (size : Nat) : BitVec size :=
   -- assert (e+1)*size <= n
   let lo := e * size
-  let hi := lo + size - 1
-  have h : hi - lo + 1 = size := by simp only [hi, lo]; omega
-  BitVec.cast h $ extractLsb hi lo vector
+  extractLsb' lo size vector
 
 /-- Divide bv `vector` into elements, each of size `size`. This function sets
 the `e`'th element in the `vector`. -/
@@ -673,8 +666,7 @@ def RShr (unsigned : Bool) (value : Int) (shift : Nat) (round : Bool) (h : n > 0
       BitVec.ofInt (n + 1) rounded
     else
       BitVec.ofInt (n + 1) value
-  have h₀ : n - 1 - 0 + 1 = n := by omega
-  BitVec.cast h₀ $ extractLsb (n-1) 0 (fn rounded_bv shift)
+  extractLsb' 0 n (fn rounded_bv shift)
 
 @[state_simp_rules]
 def Int_with_unsigned (unsigned : Bool) (value : BitVec n) : Int :=
@@ -686,9 +678,9 @@ def shift_right_common_aux
   if h : info.elements ≤ e then
     result
   else
-    let elem := Int_with_unsigned info.unsigned $ elem_get operand e info.esize info.h
+    let elem := Int_with_unsigned info.unsigned $ elem_get operand e info.esize
     let shift_elem := RShr info.unsigned elem info.shift info.round info.h
-    let acc_elem := elem_get operand2 e info.esize info.h + shift_elem
+    let acc_elem := elem_get operand2 e info.esize + shift_elem
     let result := elem_set result e info.esize acc_elem info.h
     have _ : info.elements - (e + 1) < info.elements - e := by omega
     shift_right_common_aux (e + 1) info operand operand2 result
@@ -709,7 +701,7 @@ def shift_left_common_aux
   if h : info.elements ≤ e then
     result
   else
-    let elem := elem_get operand e info.esize info.h
+    let elem := elem_get operand e info.esize
     let shift_elem := elem <<< info.shift
     let result := elem_set result e info.esize shift_elem info.h
     have _ : info.elements - (e + 1) < info.elements - e := by omega

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -496,7 +496,7 @@ instance : ToString SIMDThreeSameLogicalType where toString a := toString (repr 
 ----------------------------------------------------------------------
 
 @[state_simp_rules]
-def Vpart_read (n : BitVec 5) (part width : Nat) (s : ArmState) (H : width > 0)
+def Vpart_read (n : BitVec 5) (part width : Nat) (s : ArmState)
   : BitVec width :=
   -- assert n >= 0 && n <= 31;
   -- assert part IN {0, 1};
@@ -656,7 +656,7 @@ deriving DecidableEq, Repr
 export ShiftInfo (esize elements shift unsigned round accumulate)
 
 @[state_simp_rules]
-def RShr (unsigned : Bool) (value : Int) (shift : Nat) (round : Bool) (h : n > 0)
+def RShr (unsigned : Bool) (value : Int) (shift : Nat) (round : Bool)
   : BitVec n :=
   -- assert shift > 0
   let fn := if unsigned then ushiftRight else sshiftRight
@@ -679,7 +679,7 @@ def shift_right_common_aux
     result
   else
     let elem := Int_with_unsigned info.unsigned $ elem_get operand e info.esize
-    let shift_elem := RShr info.unsigned elem info.shift info.round info.h
+    let shift_elem := RShr info.unsigned elem info.shift info.round
     let acc_elem := elem_get operand2 e info.esize + shift_elem
     let result := elem_set result e info.esize acc_elem info.h
     have _ : info.elements - (e + 1) < info.elements - e := by omega

--- a/Arm/Insts/DPI/Logical_imm.lean
+++ b/Arm/Insts/DPI/Logical_imm.lean
@@ -63,7 +63,7 @@ def MoveWidePreferred (sf immN : BitVec 1) (imms immr : BitVec 6) : Bool :=
       false
     -- NOTE: the second conjunct below is semantically equivalent to the ASL code
     -- !((immN:imms) IN {'00xxxxx'})
-    else if sf = 0#1 ∧ ¬(immN = 0#1 ∧ imms.extractLsb 5 5 = 0#1) then
+    else if sf = 0#1 ∧ ¬(immN = 0#1 ∧ imms.extractLsb' 5 1 = 0#1) then
       false
 
     -- for MOVZ must contain no more than 16 ones

--- a/Arm/Insts/DPR/Data_processing_one_source.lean
+++ b/Arm/Insts/DPR/Data_processing_one_source.lean
@@ -55,7 +55,7 @@ private theorem opc_and_sf_constraint (x : BitVec 2) (y : BitVec 1)
 @[state_simp_rules]
 def exec_data_processing_rev
   (inst : Data_processing_one_source_cls) (s : ArmState) : ArmState :=
-  let opc : BitVec 2 := extractLsb 1 0 inst.opcode
+  let opc : BitVec 2 := extractLsb' 0 2 inst.opcode
   if H₁ : opc = 0b11#2 ∧ inst.sf = 0b0#1 then
     write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
   else
@@ -65,16 +65,16 @@ def exec_data_processing_rev
     let esize := 8
     have opc_h₁ : opc.toNat ≥ 0 := by simp only [ge_iff_le, Nat.zero_le]
     have opc_h₂ : opc.toNat < 4 := by
-      refine BitVec.isLt (extractLsb 1 0 inst.opcode)
+      refine BitVec.isLt (extractLsb' 0 2 inst.opcode)
     have opc_sf_h : ¬(opc.toNat = 3 ∧ inst.sf.toNat = 0) := by
-      apply opc_and_sf_constraint (extractLsb 1 0 inst.opcode) inst.sf H₁
+      apply opc_and_sf_constraint (extractLsb' 0 2 inst.opcode) inst.sf H₁
     have h₀ : 0 < esize := by decide
     have h₁ : esize ≤ container_size := by apply shiftLeft_ge
     have h₂ : container_size ≤ datasize := by
       apply container_size_le_datasize opc.toNat inst.sf.toNat opc_h₁ opc_h₂ opc_sf_h
     have h₃ : esize ∣ container_size := by
       simp only [esize, container_size]
-      generalize BitVec.toNat (extractLsb 1 0 inst.opcode) = x
+      generalize BitVec.toNat (extractLsb' 0 2 inst.opcode) = x
       simp only [Nat.shiftLeft_eq]
       generalize 2 ^ x = n
       simp only [Nat.dvd_mul_right]

--- a/Arm/Insts/DPR/Data_processing_two_source.lean
+++ b/Arm/Insts/DPR/Data_processing_two_source.lean
@@ -19,7 +19,7 @@ open BitVec
 def exec_data_processing_shift
   (inst : Data_processing_two_source_cls) (s : ArmState) : ArmState :=
   let datasize := 32 <<< inst.sf.toNat
-  let shift_type := decode_shift $ extractLsb 1 0 inst.opcode
+  let shift_type := decode_shift $ extractLsb' 0 2 inst.opcode
   let operand2 := read_gpr_zr datasize inst.Rm s
   let amount := BitVec.ofInt 6 (operand2.toInt % datasize)
   let operand := read_gpr_zr datasize inst.Rn s

--- a/Arm/Insts/DPSFP/Advanced_simd_copy.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_copy.lean
@@ -39,7 +39,7 @@ def exec_dup_element (inst : Advanced_simd_copy_cls) (s : ArmState) : ArmState :
     let elements := datasize / esize
     let operand := read_sfp idxdsize inst.Rn s
     have h₀ : esize > 0 := by apply zero_lt_shift_left_pos (by decide)
-    let element := elem_get operand index esize h₀
+    let element := elem_get operand index esize
     let result := dup_aux 0 elements esize element (BitVec.zero datasize) h₀
     -- State Updates
     let s := write_pc ((read_pc s) + 4#64) s
@@ -76,7 +76,7 @@ def exec_ins_element (inst : Advanced_simd_copy_cls) (s : ArmState) : ArmState :
     let operand := read_sfp idxdsize inst.Rn s
     let result := read_sfp 128 inst.Rd s
     have h₀ : esize > 0 := by apply zero_lt_shift_left_pos (by decide)
-    let elem := elem_get operand src_index esize h₀
+    let elem := elem_get operand src_index esize
     let result := elem_set result dst_index esize elem h₀
     -- State Updates
     let s := write_pc ((read_pc s) + 4#64) s
@@ -118,7 +118,7 @@ def exec_smov_umov (inst : Advanced_simd_copy_cls) (s : ArmState) (signed : Bool
     -- if index == 0 then CheckFPEnabled64 else CheckFPAdvSIMDEnabled64
     let operand := read_sfp idxdsize inst.Rn s
     have h₀ : esize > 0 := by apply zero_lt_shift_left_pos (by decide)
-    let element := elem_get operand index esize h₀
+    let element := elem_get operand index esize
     let result := if signed then signExtend datasize element else zeroExtend datasize element
     -- State Updates
     let s := write_pc ((read_pc s) + 4#64) s

--- a/Arm/Insts/DPSFP/Advanced_simd_copy.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_copy.lean
@@ -117,7 +117,6 @@ def exec_smov_umov (inst : Advanced_simd_copy_cls) (s : ArmState) (signed : Bool
     let idxdsize := 64 <<< (lsb inst.imm5 4).toNat
     -- if index == 0 then CheckFPEnabled64 else CheckFPAdvSIMDEnabled64
     let operand := read_sfp idxdsize inst.Rn s
-    have h₀ : esize > 0 := by apply zero_lt_shift_left_pos (by decide)
     let element := elem_get operand index esize
     let result := if signed then signExtend datasize element else zeroExtend datasize element
     -- State Updates

--- a/Arm/Insts/DPSFP/Advanced_simd_copy.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_copy.lean
@@ -32,7 +32,7 @@ def exec_dup_element (inst : Advanced_simd_copy_cls) (s : ArmState) : ArmState :
   if size > 3 ∨ (size = 3 ∧ inst.Q = 0) then
     write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
   else
-    let index := (extractLsb 4 (size + 1) inst.imm5).toNat
+    let index := (extractLsb' (size + 1) (4 - size) inst.imm5).toNat
     let idxdsize := 64 <<< (lsb inst.imm5 4).toNat
     let esize := 8 <<< size
     let datasize := 64 <<< inst.Q.toNat
@@ -69,8 +69,8 @@ def exec_ins_element (inst : Advanced_simd_copy_cls) (s : ArmState) : ArmState :
   if size > 3 then
     write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
   else
-    let dst_index := (extractLsb 4 (size + 1) inst.imm5).toNat
-    let src_index := (extractLsb 3 size inst.imm4).toNat
+    let dst_index := (extractLsb' (size + 1) (4 - size) inst.imm5).toNat
+    let src_index := (extractLsb' size (4 - size) inst.imm4).toNat
     let idxdsize := 64 <<< (lsb inst.imm4 3).toNat
     let esize := 8 <<< size
     let operand := read_sfp idxdsize inst.Rn s
@@ -89,7 +89,7 @@ def exec_ins_general (inst : Advanced_simd_copy_cls) (s : ArmState) : ArmState :
   if size > 3 then
     write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
   else
-    let index := (extractLsb 4 (size + 1) inst.imm5).toNat
+    let index := (extractLsb' (size + 1) (4 - size) inst.imm5).toNat
     let esize := 8 <<< size
     let element := read_gpr esize inst.Rn s
     let result := read_sfp 128 inst.Rd s
@@ -113,7 +113,7 @@ def exec_smov_umov (inst : Advanced_simd_copy_cls) (s : ArmState) (signed : Bool
            (datasize = 32 ∧ esize >= 64)) then
      write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
   else
-    let index := (extractLsb 4 (size + 1) inst.imm5).toNat
+    let index := (extractLsb' (size + 1) (4 - size) inst.imm5).toNat
     let idxdsize := 64 <<< (lsb inst.imm5 4).toNat
     -- if index == 0 then CheckFPEnabled64 else CheckFPAdvSIMDEnabled64
     let operand := read_sfp idxdsize inst.Rn s

--- a/Arm/Insts/DPSFP/Advanced_simd_extract.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_extract.lean
@@ -31,12 +31,12 @@ def exec_advanced_simd_extract
     let hi := read_sfp datasize inst.Rm s
     let lo := read_sfp datasize inst.Rn s
     let concat := hi ++ lo
-    let result := extractLsb (position + datasize - 1) position concat
+    let result := extractLsb' position datasize concat
     have h_datasize : 1 <= datasize := by simp_all! [datasize]; split <;> decide
     have h : (position + datasize - 1 - position + 1) = datasize := by
       rw [Nat.add_sub_assoc, Nat.add_sub_self_left]
       exact Nat.sub_add_cancel h_datasize; trivial
-    let s := write_sfp datasize inst.Rd (BitVec.cast h result) s
+    let s := write_sfp datasize inst.Rd result s
     let s := write_pc ((read_pc s) + 4#64) s
     s
 

--- a/Arm/Insts/DPSFP/Advanced_simd_extract.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_extract.lean
@@ -32,10 +32,6 @@ def exec_advanced_simd_extract
     let lo := read_sfp datasize inst.Rn s
     let concat := hi ++ lo
     let result := extractLsb' position datasize concat
-    have h_datasize : 1 <= datasize := by simp_all! [datasize]; split <;> decide
-    have h : (position + datasize - 1 - position + 1) = datasize := by
-      rw [Nat.add_sub_assoc, Nat.add_sub_self_left]
-      exact Nat.sub_add_cancel h_datasize; trivial
     let s := write_sfp datasize inst.Rd result s
     let s := write_pc ((read_pc s) + 4#64) s
     s

--- a/Arm/Insts/DPSFP/Advanced_simd_permute.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_permute.lean
@@ -22,8 +22,8 @@ def trn_aux (p : Nat) (pairs : Nat) (esize : Nat) (part : Nat)
     result
   else
     let idx_from := 2 * p + part
-    let op1_part := elem_get operand1 idx_from esize h
-    let op2_part := elem_get operand2 idx_from esize h
+    let op1_part := elem_get operand1 idx_from esize
+    let op2_part := elem_get operand2 idx_from esize
     let result := elem_set result (2 * p) esize op1_part h
     let result := elem_set result (2 * p + 1) esize op2_part h
     have h₁ : pairs - (p + 1) < pairs - p := by omega

--- a/Arm/Insts/DPSFP/Advanced_simd_scalar_copy.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_scalar_copy.lean
@@ -28,7 +28,7 @@ def exec_advanced_simd_scalar_copy
     let esize := 8 <<< size
     let operand := read_sfp idxdsize inst.Rn s
     have h : esize > 0 := by apply zero_lt_shift_left_pos (by decide)
-    let result := elem_get operand index.toNat esize h
+    let result := elem_get operand index.toNat esize
     -- State Updates
     let s := write_pc ((read_pc s) + 4#64) s
     let s := write_sfp esize inst.Rd result s

--- a/Arm/Insts/DPSFP/Advanced_simd_scalar_copy.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_scalar_copy.lean
@@ -27,7 +27,6 @@ def exec_advanced_simd_scalar_copy
     let idxdsize := 64 <<< (lsb inst.imm5 4).toNat
     let esize := 8 <<< size
     let operand := read_sfp idxdsize inst.Rn s
-    have h : esize > 0 := by apply zero_lt_shift_left_pos (by decide)
     let result := elem_get operand index.toNat esize
     -- State Updates
     let s := write_pc ((read_pc s) + 4#64) s

--- a/Arm/Insts/DPSFP/Advanced_simd_scalar_copy.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_scalar_copy.lean
@@ -23,7 +23,7 @@ def exec_advanced_simd_scalar_copy
   if size > 3 ∨ inst.imm4 ≠ 0b0000#4 ∨ inst.op ≠ 0 then
     write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
   else
-    let index := extractLsb 4 (size + 1) inst.imm5
+    let index := extractLsb' (size + 1) (4 - size) inst.imm5
     let idxdsize := 64 <<< (lsb inst.imm5 4).toNat
     let esize := 8 <<< size
     let operand := read_sfp idxdsize inst.Rn s

--- a/Arm/Insts/DPSFP/Advanced_simd_table_lookup.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_table_lookup.lean
@@ -35,10 +35,10 @@ def tblx_aux (i : Nat) (elements : Nat) (indices : BitVec datasize)
     result
   else
     have h₁ : 8 > 0 := by decide
-    let index := (elem_get indices i 8 h₁).toNat
+    let index := (elem_get indices i 8).toNat
     let result :=
       if index < 16 * regs then
-        let val := elem_get table index 8 h₁
+        let val := elem_get table index 8
         elem_set result i 8 val h₁
       else
         result

--- a/Arm/Insts/DPSFP/Advanced_simd_three_different.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_three_different.lean
@@ -58,9 +58,8 @@ def exec_pmull (inst : Advanced_simd_three_different_cls) (s : ArmState) : ArmSt
     let datasize := 64
     let part := inst.Q.toNat
     let elements := datasize / esize
-    have h₁ : datasize > 0 := by decide
-    let operand1 := Vpart_read inst.Rn part datasize s h₁
-    let operand2 := Vpart_read inst.Rm part datasize s h₁
+    let operand1 := Vpart_read inst.Rn part datasize s
+    let operand2 := Vpart_read inst.Rm part datasize s
     let result :=
       pmull_op 0 esize elements operand1 operand2 (BitVec.zero (2*datasize)) h₀
     let s := write_sfp (datasize*2) inst.Rd result s

--- a/Arm/Insts/DPSFP/Advanced_simd_three_different.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_three_different.lean
@@ -37,8 +37,8 @@ def pmull_op (e : Nat) (esize : Nat) (elements : Nat) (x : BitVec n)
   if h₀ : elements <= e then
     result
   else
-    let element1 := elem_get x e esize H
-    let element2 := elem_get y e esize H
+    let element1 := elem_get x e esize
+    let element2 := elem_get y e esize
     let elem_result := polynomial_mult element1 element2
     have h₁ : esize + esize = 2 * esize := by omega
     have h₂ : 2 * esize > 0 := by omega

--- a/Arm/Insts/DPSFP/Advanced_simd_three_same.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_three_same.lean
@@ -25,8 +25,8 @@ def binary_vector_op_aux (e : Nat) (elems : Nat) (esize : Nat)
     result
   else
     have h₁ : e < elems := by omega
-    let element1 := elem_get x e esize H
-    let element2 := elem_get y e esize H
+    let element1 := elem_get x e esize
+    let element2 := elem_get y e esize
     let elem_result := op element1 element2
     let result := elem_set result e esize elem_result H
     have ht1 : elems - (e + 1) < elems - e := by omega

--- a/Arm/Insts/DPSFP/Crypto_aes.lean
+++ b/Arm/Insts/DPSFP/Crypto_aes.lean
@@ -53,7 +53,7 @@ def FFmul02 (b : BitVec 8) : BitVec 8 :=
     ]
   let lo := b.toNat * 8
   let hi := lo + 7
-  BitVec.cast (by omega) $ extractLsb hi lo $ BitVec.flatten FFmul_02
+  extractLsb' lo 8 $ BitVec.flatten FFmul_02
 
 def FFmul03 (b : BitVec 8) : BitVec 8 :=
   let FFmul_03 :=
@@ -76,8 +76,7 @@ def FFmul03 (b : BitVec 8) : BitVec 8 :=
       0x111217141D1E1B18090A0F0C05060300#128  -- 0
     ]
   let lo := b.toNat * 8
-  let hi := lo + 7
-  BitVec.cast (by omega) $ extractLsb hi lo $ BitVec.flatten FFmul_03
+  extractLsb' lo 8 $ BitVec.flatten FFmul_03
 
 def AESMixColumns (op : BitVec 128) : BitVec 128 :=
   AESCommon.MixColumns op FFmul02 FFmul03

--- a/Arm/Insts/DPSFP/Crypto_aes.lean
+++ b/Arm/Insts/DPSFP/Crypto_aes.lean
@@ -52,7 +52,6 @@ def FFmul02 (b : BitVec 8) : BitVec 8 :=
       0x1E1C1A18161412100E0C0A0806040200#128  -- 0
     ]
   let lo := b.toNat * 8
-  let hi := lo + 7
   extractLsb' lo 8 $ BitVec.flatten FFmul_02
 
 def FFmul03 (b : BitVec 8) : BitVec 8 :=

--- a/Arm/Insts/DPSFP/Crypto_three_reg_sha512.lean
+++ b/Arm/Insts/DPSFP/Crypto_three_reg_sha512.lean
@@ -21,14 +21,14 @@ open BitVec
 def sha512h (x : BitVec 128) (y : BitVec 128) (w : BitVec 128)
   : BitVec 128 :=
   open sha512_helpers in
-  let y_127_64    := extractLsb 127 64 y
-  let y_63_0      := extractLsb 63 0 y
+  let y_127_64    := extractLsb' 64 64 y
+  let y_63_0      := extractLsb' 0 64 y
   let msigma1     := sigma_big_1 y_127_64
-  let x_63_0      := extractLsb 63 0 x
-  let x_127_64    := extractLsb 127 64 x
+  let x_63_0      := extractLsb' 0 64 x
+  let x_127_64    := extractLsb' 64 64 x
   let vtmp_127_64 := ch y_127_64 x_63_0 x_127_64
-  let w_127_64    := extractLsb 127 64 w
-  let w_63_0      := extractLsb 63 0 w
+  let w_127_64    := extractLsb' 64 64 w
+  let w_63_0      := extractLsb' 0 64 w
   let vtmp_127_64 := vtmp_127_64 + msigma1 + w_127_64
   let tmp         := vtmp_127_64 + y_63_0
   let msigma1     := sigma_big_1 tmp
@@ -40,16 +40,16 @@ def sha512h (x : BitVec 128) (y : BitVec 128) (w : BitVec 128)
 def sha512h2 (x : BitVec 128) (y : BitVec 128) (w : BitVec 128) :
     BitVec 128 :=
     open sha512_helpers in
-    let y_63_0      := extractLsb 63 0 y
-    let y_127_64    := extractLsb 127 64 y
+    let y_63_0      := extractLsb' 0 64 y
+    let y_127_64    := extractLsb' 64 64 y
     let nsigma0     := sigma_big_0 y_63_0
-    let x_63_0      := extractLsb 63 0 x
+    let x_63_0      := extractLsb' 0 64 x
     let vtmp_127_64 := maj x_63_0 y_127_64 y_63_0
-    let w_127_64    := extractLsb 127 64 w
+    let w_127_64    := extractLsb' 64 64 w
     let vtmp_127_64 := vtmp_127_64 + nsigma0 + w_127_64
     let nsigma0     := sigma_big_0 vtmp_127_64
     let vtmp_63_0   := maj vtmp_127_64 y_63_0 y_127_64
-    let w_63_0      := extractLsb 63 0 w
+    let w_63_0      := extractLsb' 0 64 w
     let vtmp_63_0   := vtmp_63_0 + nsigma0 + w_63_0
     let result      := vtmp_127_64 ++ vtmp_63_0
     result
@@ -57,15 +57,15 @@ def sha512h2 (x : BitVec 128) (y : BitVec 128) (w : BitVec 128) :
 def sha512su1 (x : BitVec 128) (y : BitVec 128) (w : BitVec 128)
   : BitVec 128 :=
   open sha512_helpers in
-  let x_127_64    := extractLsb 127 64 x
+  let x_127_64    := extractLsb' 64 64 x
   let sig1        := sigma_1 x_127_64
-  let w_127_64    := extractLsb 127 64 w
-  let y_127_64    := extractLsb 127 64 y
+  let w_127_64    := extractLsb' 64 64 w
+  let y_127_64    := extractLsb' 64 64 y
   let vtmp_127_64 := w_127_64 + sig1 + y_127_64
-  let x_63_0      := extractLsb 63 0 x
+  let x_63_0      := extractLsb' 0 64 x
   let sig1        := sigma_1 x_63_0
-  let w_63_0      := extractLsb 63 0 w
-  let y_63_0      := extractLsb 63 0 y
+  let w_63_0      := extractLsb' 0 64 w
+  let y_63_0      := extractLsb' 0 64 y
   let vtmp_63_0   := w_63_0 + sig1 + y_63_0
   let result      := vtmp_127_64 ++ vtmp_63_0
   result

--- a/Arm/Insts/DPSFP/Crypto_two_reg_sha512.lean
+++ b/Arm/Insts/DPSFP/Crypto_two_reg_sha512.lean
@@ -19,10 +19,10 @@ open BitVec
 def sha512su0 (x : BitVec 128) (w : BitVec 128)
   : BitVec 128 :=
   open sha512_helpers in
-  let w_127_64    := extractLsb 127 64 w
-  let w_63_0      := extractLsb 63 0 w
+  let w_127_64    := extractLsb' 64 64 w
+  let w_63_0      := extractLsb' 0 64 w
   let sig0        := sigma_0 w_127_64
-  let x_63_0      := extractLsb 63 0 x
+  let x_63_0      := extractLsb' 0 64 x
   let vtmp_63_0   := w_63_0 + sig0
   let sig0        := sigma_0 x_63_0
   let vtmp_127_64 := w_127_64 + sig0

--- a/Arm/Insts/LDST/Reg_pair.lean
+++ b/Arm/Insts/LDST/Reg_pair.lean
@@ -40,7 +40,7 @@ def reg_pair_constrain_unpredictable (wback : Bool) (inst : Reg_pair_cls) : Bool
 @[state_simp_rules]
 def reg_pair_operation (inst : Reg_pair_cls) (inst_str : String) (signed : Bool)
   (datasize : Nat) (offset : BitVec 64) (s : ArmState)
-  (H1 : 8 ∣ datasize) (H2 : 0 < datasize) : ArmState :=
+  (H1 : 8 ∣ datasize): ArmState :=
   -- Note: we do not need to model the ASL function
   -- "CreateAccDescGPR" here, given the simplicity of our memory
   -- model
@@ -99,11 +99,8 @@ def exec_reg_pair_common (inst : Reg_pair_cls) (inst_str : String) (s : ArmState
     let offset := (signExtend 64 inst.imm7) <<< scale
     have H1 : 8 ∣ datasize := by
       simp_all! only [gt_iff_lt, Nat.shiftLeft_eq, Nat.dvd_mul_right, datasize]
-    have H2 : 0 < datasize := by
-      simp_all! only [datasize]
-      apply zero_lt_shift_left_pos (by decide)
     -- State Updates
-    let s' := reg_pair_operation inst inst_str signed datasize offset s H1 H2
+    let s' := reg_pair_operation inst inst_str signed datasize offset s H1
     let s' := write_pc ((read_pc s) + 4#64) s'
     s'
 

--- a/Arm/Insts/LDST/Reg_pair.lean
+++ b/Arm/Insts/LDST/Reg_pair.lean
@@ -64,18 +64,15 @@ def reg_pair_operation (inst : Reg_pair_cls) (inst_str : String) (signed : Bool)
         let full_data := data2 ++ data1
         write_mem_bytes (2 * (datasize / 8)) address (BitVec.cast h3 full_data) s
       | _ => -- LOAD
-        have h4 : datasize - 1 - 0 + 1 = datasize := by
-          simp; apply Nat.sub_add_cancel H2
-        have h5 : 2 * datasize - 1 - datasize + 1 = datasize := by omega
         let full_data := read_mem_bytes (2 * (datasize / 8)) address s
-        let data1 := extractLsb (datasize - 1) 0 full_data
-        let data2 := extractLsb ((2 * datasize) - 1) datasize full_data
+        let data1 := extractLsb' 0 datasize full_data
+        let data2 := extractLsb' datasize datasize full_data
         if not inst.SIMD? ∧ signed then
           let s := write_gpr 64 inst.Rt (signExtend 64 data1) s
           write_gpr 64 inst.Rt2 (signExtend 64 data2) s
         else
-          let s:= ldst_write inst.SIMD? datasize inst.Rt (BitVec.cast h4 data1) s
-          ldst_write inst.SIMD? datasize inst.Rt2 (BitVec.cast h5 data2) s
+          let s:= ldst_write inst.SIMD? datasize inst.Rt data1 s
+          ldst_write inst.SIMD? datasize inst.Rt2 data2 s
     if inst.wback then
       let address := if inst.postindex then address + offset else address
       write_gpr 64 inst.Rn address s

--- a/Arm/Insts/LDST/Reg_unscaled_imm.lean
+++ b/Arm/Insts/LDST/Reg_unscaled_imm.lean
@@ -17,7 +17,7 @@ open BitVec
 @[state_simp_rules]
 def exec_ldstur
   (inst : Reg_unscaled_imm_cls) (s : ArmState) : ArmState :=
-  let scale := (extractLsb 1 1 inst.opc ++ inst.size).toNat
+  let scale := (extractLsb' 1 1 inst.opc ++ inst.size).toNat
   if scale > 4 then
     write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
   else
@@ -44,9 +44,9 @@ def exec_ldstur
 @[state_simp_rules]
 def exec_reg_unscaled_imm
   (inst : Reg_unscaled_imm_cls) (s : ArmState) : ArmState :=
-  if inst.VR = 0b1#1 then 
+  if inst.VR = 0b1#1 then
     exec_ldstur inst s
-  else 
+  else
     write_err (StateError.Unimplemented s!"Unsupported instruction {inst} encountered!") s
 
 end LDST

--- a/Arm/Memory/MemoryProofs.lean
+++ b/Arm/Memory/MemoryProofs.lean
@@ -65,10 +65,9 @@ theorem append_byte_of_extract_rest_same_cast (n : Nat) (v : BitVec ((n + 1) * 8
   (hn0 : Nat.succ 0 ≤ n)
   (h : (n * 8 + 8) = (n + 1) * 8) :
   BitVec.cast h (zeroExtend (n * 8) (v >>> 8) ++ extractLsb' 0 8 v) = v := by
-  rw [BitVec.append_of_extract]
-  · simp only [BitVec.cast_cast, BitVec.cast_eq]
+  apply BitVec.append_of_extract
   · omega
-  · omega
+  done
 
 @[state_simp_rules]
 theorem read_mem_bytes_of_write_mem_bytes_same (hn1 : n <= 2^64) :

--- a/Arm/Memory/MemoryProofs.lean
+++ b/Arm/Memory/MemoryProofs.lean
@@ -862,14 +862,6 @@ theorem entire_memory_subset_legal_regions_eq_addr
   simp_all [mem_subset, mem_legal]
   bv_omega
 
-private theorem read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt_helper (val : BitVec (x * 8)):
-  val =
-    extractLsb' ((BitVec.toNat (addr2 - addr2)) * 8) (x * 8) val := by
-  ext
-  simp only [BitVec.sub_self, toNat_ofNat, Nat.zero_mod,
-    Nat.zero_mul, extractLsb'_toNat,
-    Nat.shiftRight_zero, toNat_mod_cancel]
-
 private theorem read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt
   (h0 : 0 < n1) (h1 : n1 <= my_pow 2 64) (h2 : 0 < n2) (h3 : n2 = my_pow 2 64)
   (h4 : mem_subset addr2 (addr2 + (BitVec.ofNat 64 (n2 - 1))) addr1 (addr1 + (BitVec.ofNat 64 (n1 - 1))))
@@ -883,7 +875,8 @@ private theorem read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt
     have l1 := @entire_memory_subset_legal_regions_eq_addr addr2 addr1 h4 h6 h5
     subst addr1
     rw [read_mem_bytes_of_write_mem_bytes_same]
-    · apply read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt_helper
+    · simp only [BitVec.sub_self, toNat_ofNat, Nat.reducePow, Nat.zero_mod, Nat.zero_mul]
+      exact Eq.symm (extractLsb'_eq val)
     · unfold my_pow; decide
 
 @[state_simp_rules]

--- a/Arm/Memory/MemoryProofs.lean
+++ b/Arm/Memory/MemoryProofs.lean
@@ -706,7 +706,7 @@ theorem read_mem_bytes_of_write_mem_bytes_subset_helper2
   (BitVec.toNat val >>> ((BitVec.toNat (addr2 - addr1) + 1) % 2 ^ 64 * 8) % 2 ^ (n * 8)) <<< 8 |||
       BitVec.toNat val >>> (BitVec.toNat (addr2 - addr1) * 8) % 2 ^ 8 =
     BitVec.toNat val >>> (BitVec.toNat (addr2 - addr1) * 8) %
-      2 ^ ((BitVec.toNat (addr2 - addr1) + (n + 1)) * 8 - 1 - BitVec.toNat (addr2 - addr1) * 8 + 1) := by
+      2 ^ ((n + 1) * 8) := by
   have h_a_size := (addr2 - addr1).isLt
   have h_v_size := val.isLt
   -- (FIXME) whnf timeout?
@@ -714,7 +714,7 @@ theorem read_mem_bytes_of_write_mem_bytes_subset_helper2
   -- generalize ha :  BitVec.toNat (addr2 - addr1) = a
   apply Nat.eq_of_testBit_eq; intro i
   simp only [Nat.testBit_mod_two_pow, Nat.testBit_shiftRight]
-  by_cases h₀ : (i < (BitVec.toNat (addr2 - addr1) + (n + 1)) * 8 - 1 - BitVec.toNat (addr2 - addr1) * 8 + 1)
+  by_cases h₀ : (i < ((n + 1) * 8))
   case pos =>
     simp only [h₀, decide_True, Bool.true_and, BitVec.toNat_ofNat,
                BitVec.toNat_append, Nat.testBit_or]
@@ -826,7 +826,7 @@ private theorem read_mem_bytes_of_write_mem_bytes_subset_n2_lt
                    toNat_ofNat, Nat.add_mod_mod, cast_ofNat, toNat_append]
         have := @addr_diff_upper_bound_lemma n1 n addr1 addr2 h0 h1
                  (by omega) (by omega) h6 h5 h4
-        rw [read_mem_bytes_of_write_mem_bytes_subset_helper2] <;> sorry
+        rw [read_mem_bytes_of_write_mem_bytes_subset_helper2] <;> assumption
       · omega
       · assumption
   done

--- a/Arm/Memory/MemoryProofs.lean
+++ b/Arm/Memory/MemoryProofs.lean
@@ -317,7 +317,7 @@ private theorem mem_subset_neq_first_addr_small_second_region
   cases h2
   · rename_i h
     simp only [BitVec.add_sub_self_left_64] at h
-    have l1 : n' = 18446744073709551615 := by      
+    have l1 : n' = 18446744073709551615 := by
       rw [BitVec.toNat_eq] at h
       simp only [toNat_ofNat, Nat.reducePow, Nat.reduceMod] at h
       omega

--- a/Arm/Memory/MemoryProofs.lean
+++ b/Arm/Memory/MemoryProofs.lean
@@ -63,11 +63,9 @@ theorem read_mem_of_write_mem_bytes_different (hn1 : n <= 2^64)
 
 theorem append_byte_of_extract_rest_same_cast (n : Nat) (v : BitVec ((n + 1) * 8))
   (hn0 : Nat.succ 0 ≤ n)
-  (h : (n * 8 + (7 - 0 + 1)) = (n + 1) * 8) :
-  BitVec.cast h (zeroExtend (n * 8) (v >>> 8) ++ extractLsb 7 0 v) = v := by
+  (h : (n * 8 + 8) = (n + 1) * 8) :
+  BitVec.cast h (zeroExtend (n * 8) (v >>> 8) ++ extractLsb' 0 8 v) = v := by
   apply BitVec.append_of_extract
-  · omega
-  · omega
   · omega
   done
 
@@ -85,7 +83,7 @@ theorem read_mem_bytes_of_write_mem_bytes_same (hn1 : n <= 2^64) :
    case base =>
      simp only [read_mem_bytes, write_mem_bytes,
                 read_mem_of_write_mem_same, BitVec.cast_eq]
-     have l1 := BitVec.extractLsb_eq v
+     have l1 := BitVec.extractLsb'_eq v
      simp only [Nat.reduceSucc, Nat.one_mul, Nat.succ_sub_succ_eq_sub,
                 Nat.sub_zero, Nat.reduceAdd, BitVec.cast_eq,
                 forall_const] at l1
@@ -431,7 +429,7 @@ private theorem write_mem_bytes_of_write_mem_bytes_shadow_general_n2_eq
       rename_i n n_ih
       conv in write_mem_bytes (Nat.succ n) .. => simp only [write_mem_bytes]
       have n_ih' := @n_ih (addr1 + 1#64) val2 (zeroExtend (n * 8) (val1 >>> 8))
-                   (write_mem addr1 (extractLsb 7 0 val1) s)
+                   (write_mem addr1 (extractLsb' 0 8 val1) s)
                    (by omega)
       simp only [Nat.succ_sub_succ_eq_sub, Nat.sub_zero] at h3
       by_cases h₁ : n = 0
@@ -483,7 +481,7 @@ theorem write_mem_bytes_of_write_mem_bytes_shadow_general
 theorem read_mem_of_write_mem_bytes_same_first_address
   (h0 : 0 < n) (h1 : n <= 2^64) (h : 7 - 0 + 1 = 8) :
   read_mem addr (write_mem_bytes n addr val s) =
-  BitVec.cast h (extractLsb 7 0 val) := by
+  BitVec.cast h (extractLsb' 0 8 val) := by
   unfold write_mem_bytes; simp only [Nat.sub_zero, BitVec.cast_eq]
   split
   · contradiction
@@ -495,18 +493,16 @@ theorem read_mem_of_write_mem_bytes_same_first_address
 -- (FIXME) Argh, it's annoying to need this lemma, but using
 -- BitVec.cast_eq directly was cumbersome.
 theorem cast_of_extract_eq (v : BitVec p)
-  (h1 : hi1 = hi2) (h2 : lo1 = lo2)
-  (h : hi1 - lo1 + 1 = hi2 - lo2 + 1) :
-  BitVec.cast h (extractLsb hi1 lo1 v) = (extractLsb hi2 lo2 v) := by
+  (h1 : n1 = n2) (h2 : lo1 = lo2):
+  BitVec.cast h (extractLsb' lo1 n1 v) = (extractLsb' lo2 n2 v) := by
   subst_vars
   simp only [Nat.sub_zero, BitVec.cast_eq]
 
 theorem read_mem_bytes_of_write_mem_bytes_subset_same_first_address
   (h0 : 0 < n1) (h1 : n1 <= 2^64) (h2 : 0 < n2) (h3 : n2 <= 2^64)
-  (h4 : mem_subset addr (addr + (BitVec.ofNat 64 (n2 - 1))) addr (addr + (BitVec.ofNat 64 (n1 - 1))))
-  (h : n2 * 8 - 1 - 0 + 1 = n2 * 8) :
+  (h4 : mem_subset addr (addr + (BitVec.ofNat 64 (n2 - 1))) addr (addr + (BitVec.ofNat 64 (n1 - 1)))):
   read_mem_bytes n2 addr (write_mem_bytes n1 addr val s) =
-  BitVec.cast h (extractLsb ((n2 * 8) - 1) 0 val) := by
+  extractLsb' 0 (n2 * 8) val := by
   have rm_lemma := @read_mem_of_write_mem_bytes_same_first_address n1 addr val s h0 h1
   simp only [Nat.sub_zero, Nat.reduceAdd, BitVec.cast_eq, forall_const] at rm_lemma
   induction n2, h2 using Nat.le_induction generalizing n1 addr val s
@@ -543,21 +539,20 @@ theorem read_mem_bytes_of_write_mem_bytes_subset_same_first_address
           erw [Nat.mod_eq_of_lt h3] at hn
           erw [Nat.mod_eq_of_lt h1] at hn
           exact hn
-        rw [n_ih (by omega) (by omega) (by omega) _ (by omega)]
-        · rw [BitVec.extract_lsb_of_zeroExtend (v >>> 8)]
-          · have l1 := @BitVec.append_of_extract_general ((n1_1 + 1) * 8) 8 (n*8-1+1) (n*8) v
+        rw [n_ih (by omega) (by omega) (by omega) _]
+        · rw [BitVec.extractLsb'_of_zeroExtend (v >>> 8)]
+          · have l1 := @BitVec.append_of_extract_general ((n1_1 + 1) * 8) (n*8) 8 v
             simp (config := { decide := true }) only [Nat.zero_lt_succ,
               Nat.mul_pos_iff_of_pos_left, Nat.succ_sub_succ_eq_sub,
               Nat.sub_zero, Nat.reduceAdd, Nat.succ.injEq, forall_const] at l1
-            rw [l1 (by omega) (by omega)]
-            · simp only [Nat.add_eq, Nat.sub_zero, BitVec.cast_cast]
-              apply @cast_of_extract_eq ((n1_1 + 1) * 8) (n * 8 - 1 + 1 + 7) ((n + 1) * 8 - 1) 0 0 <;>
+            rw [l1]
+            · apply @cast_of_extract_eq ((n1_1 + 1) * 8) (n * 8 + 8) ((n + 1) * 8) 0 0 <;>
               omega
           · omega
         · have rw_lemma2 := @read_mem_of_write_mem_bytes_same_first_address
                               n1_1 (addr + 1#64)
                               (zeroExtend (n1_1 * 8) (v >>> 8))
-                              (write_mem addr (extractLsb 7 0 v) s)
+                              (write_mem addr (extractLsb' 0 8 v) s)
           simp only [Nat.reducePow, Nat.sub_zero, Nat.reduceAdd,
                      BitVec.cast_eq, forall_const] at rw_lemma2
           rw [rw_lemma2 (by omega) (by simp only [Nat.reducePow] at h1; omega)]
@@ -636,22 +631,15 @@ theorem BitVec.to_nat_zero_lt_sub_64 (x y : BitVec 64) (h : ¬x = y) :
 
 theorem read_mem_of_write_mem_bytes_subset
   (h0 : 0 < n) (h1 : n <= 2^64)
-  (h2 : mem_subset addr2 addr2 addr1 (addr1 + (BitVec.ofNat 64 (n - 1))))
-  (h : ((BitVec.toNat (addr2 - addr1) + 1) * 8 - 1 -
-          BitVec.toNat (addr2 - addr1) * 8 + 1) = 8) :
+  (h2 : mem_subset addr2 addr2 addr1 (addr1 + (BitVec.ofNat 64 (n - 1)))):
   read_mem addr2 (write_mem_bytes n addr1 val s) =
-  BitVec.cast h
-    (extractLsb
-      ((BitVec.toNat (addr2 - addr1) + 1) * 8 - 1)
-      (BitVec.toNat (addr2 - addr1) * 8)
-      val) := by
+  extractLsb' (BitVec.toNat (addr2 - addr1) * 8) 8 val := by
   induction n generalizing addr1 addr2 s
   case zero => contradiction
   case succ =>
     rename_i n' n_ih
     simp_all only [write_mem_bytes, Nat.succ.injEq, Nat.zero_lt_succ,
                    Nat.succ_sub_succ_eq_sub, Nat.sub_zero]
-    have cast_lemma := @cast_of_extract_eq
     by_cases h₀ : n' = 0
     case pos =>
       simp_all only [Nat.lt_irrefl, Nat.zero_le, Nat.zero_sub,
@@ -659,20 +647,22 @@ theorem read_mem_of_write_mem_bytes_subset
                      false_implies, implies_true]
       subst_vars
       simp only [write_mem_bytes, read_mem_of_write_mem_same]
-      rw [←cast_lemma] <;> bv_omega
+      simp only [Nat.reduceAdd, Nat.reduceMul, BitVec.sub_self,
+        toNat_ofNat, Nat.reducePow, Nat.zero_mod, Nat.zero_mul]
     case neg => -- (n' ≠ 0)
       by_cases h₁ : addr2 = addr1
       case pos => -- (n' ≠ 0) and (addr2 = addr1)
         subst_vars
         rw [read_mem_of_write_mem_bytes_different (by omega)]
         · simp only [read_mem_of_write_mem_same]
-          rw [←cast_lemma] <;> bv_omega
+          simp only [BitVec.sub_self, toNat_ofNat, Nat.reducePow,
+            Nat.zero_mod, Nat.zero_mul]
         · rw [mem_separate_contiguous_regions_one_address _ (by omega)]
       case neg => -- (addr2 ≠ addr1)
         rw [n_ih]
         · ext
           -- simp only [bv_toNat]
-          simp only [toNat_cast, extractLsb, extractLsb', toNat_zeroExtend]
+          simp only [toNat_cast, extractLsb', toNat_zeroExtend]
           simp only [toNat_ushiftRight]
           simp_all only [toNat_ofNat, toNat_ofNatLt]
           simp only [BitVec.sub_of_add_is_sub_sub, Nat.succ_sub_succ_eq_sub,
@@ -700,7 +690,6 @@ theorem read_mem_of_write_mem_bytes_subset
         · omega
         · rw [addr_add_one_add_m_sub_one _ _ (by omega) (by omega)]
           rw [mem_subset_one_addr_neq h₁ h2]
-        · omega
     done
 
 theorem read_mem_bytes_of_write_mem_bytes_subset_helper1 (a i : Nat)
@@ -785,35 +774,26 @@ private theorem read_mem_bytes_of_write_mem_bytes_subset_n2_lt
   (h0 : 0 < n1) (h1 : n1 <= 2^64) (h2 : 0 < n2) (h3 : n2 < 2^64)
   (h4 : mem_subset addr2 (addr2 + (BitVec.ofNat 64 (n2 - 1))) addr1 (addr1 + (BitVec.ofNat 64 (n1 - 1))))
   (h5 : mem_legal addr2 (addr2 + (BitVec.ofNat 64 (n2 - 1))))
-  (h6 : mem_legal addr1 (addr1 + (BitVec.ofNat 64 (n1 - 1))))
-  (h : ((BitVec.toNat (addr2 - addr1) + n2) * 8 - 1 - BitVec.toNat (addr2 - addr1) * 8 + 1)
-        = n2 * 8) :
+  (h6 : mem_legal addr1 (addr1 + (BitVec.ofNat 64 (n1 - 1)))) :
   read_mem_bytes n2 addr2 (write_mem_bytes n1 addr1 val s) =
-   BitVec.cast h
-    (extractLsb ((((addr2 - addr1).toNat + n2) * 8) - 1) ((addr2 - addr1).toNat * 8) val) := by
+   extractLsb' ((addr2 - addr1).toNat * 8) (n2 * 8) val := by
   induction n2, h2 using Nat.le_induction generalizing addr1 addr2 val s
   case base =>
     simp only [Nat.reduceSucc, Nat.succ_sub_succ_eq_sub,
                Nat.sub_self, BitVec.add_zero] at h4
-    simp_all only [read_mem_bytes, BitVec.cast_eq]
-    have h' : (BitVec.toNat (addr2 - addr1) + 1) * 8 - 1 - BitVec.toNat (addr2 - addr1) * 8 + 1 = 8 := by
-      omega
-    rw [read_mem_of_write_mem_bytes_subset h0 h1 h4 h']
+    simp_all only [read_mem_bytes]
+    rw [read_mem_of_write_mem_bytes_subset h0 h1 h4]
     apply BitVec.empty_bitvector_append_left
-    decide
   case succ =>
     rename_i n h2' n_ih
     by_cases h_addr : addr1 = addr2
     case pos => -- (addr1 = addr2)
       subst addr2
-      have h' : (n + 1) * 8 - 1 - 0 + 1 = (n + 1) * 8 := by omega
       have := @read_mem_bytes_of_write_mem_bytes_subset_same_first_address n1 (n + 1) addr1 val s
-               h0 h1 (by omega) (by omega) h4 h'
+               h0 h1 (by omega) (by omega) h4
       rw [this]
-      ext
-      simp only [Nat.sub_zero, BitVec.cast_eq, extractLsb_toNat,
-                 Nat.shiftRight_zero, toNat_cast, BitVec.sub_self,
-                 toNat_ofNat, Nat.zero_mod, Nat.zero_mul, Nat.zero_add]
+      simp only [BitVec.sub_self, toNat_ofNat, Nat.reducePow,
+        Nat.zero_mod, Nat.zero_mul]
     case neg => -- (addr1 ≠ addr2)
       simp only [read_mem_bytes, Nat.add_eq, Nat.add_zero]
       simp only [Nat.succ_sub_succ_eq_sub, Nat.sub_zero] at h4
@@ -832,25 +812,21 @@ private theorem read_mem_bytes_of_write_mem_bytes_subset_n2_lt
       have l2 := @first_address_is_subset_of_region addr2 (BitVec.ofNat 64 n)
       have l3 := mem_subset_trans l2 h4
       simp only [l3, forall_const] at l1
-      rw [l1 (by omega)]
+      rw [l1]
       simp only [Nat.succ_sub_succ_eq_sub, Nat.sub_zero] at h5
       have n_ih' := @n_ih (addr2 + 1#64) addr1 val s (by omega)
       simp only [h_sub, forall_const] at n_ih'
       rw [mem_legal_lemma h2'] at n_ih'
-      · simp only [forall_const] at n_ih'
-        have h' : (BitVec.toNat (addr2 + 1#64 - addr1) + n) * 8 - 1 -
-                  BitVec.toNat (addr2 + 1#64 - addr1) * 8 + 1 =
-                  n * 8 := by
-             omega
-        rw [n_ih' h6 h']
+      · simp only [h6, true_implies] at n_ih'
+        rw [n_ih']
         ext
-        simp only [extractLsb, extractLsb', toNat_ofNat, toNat_cast,
+        simp only [extractLsb', toNat_ofNat, toNat_cast,
                    BitVec.add_of_sub_sub_of_add]
         simp only [toNat_add (addr2 - addr1) 1#64, Nat.add_eq, Nat.add_zero,
                    toNat_ofNat, Nat.add_mod_mod, cast_ofNat, toNat_append]
         have := @addr_diff_upper_bound_lemma n1 n addr1 addr2 h0 h1
                  (by omega) (by omega) h6 h5 h4
-        rw [read_mem_bytes_of_write_mem_bytes_subset_helper2] <;> assumption
+        rw [read_mem_bytes_of_write_mem_bytes_subset_helper2] <;> sorry
       · omega
       · assumption
   done
@@ -886,37 +862,21 @@ theorem entire_memory_subset_legal_regions_eq_addr
   simp_all [mem_subset, mem_legal]
   bv_omega
 
-private theorem read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt_helper (val : BitVec (x * 8))
-  (h0 : 0 < x)
-  (h : (BitVec.toNat (addr2 - addr2) + x) * 8 - 1 -
-         BitVec.toNat (addr2 - addr2) * 8 + 1
-        =
-       x * 8) :
+private theorem read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt_helper (val : BitVec (x * 8)):
   val =
-    BitVec.cast h
-      (extractLsb ((BitVec.toNat (addr2 - addr2) + x) * 8 - 1)
-        (BitVec.toNat (addr2 - addr2) * 8) val) := by
+    extractLsb' ((BitVec.toNat (addr2 - addr2)) * 8) (x * 8) val := by
   ext
-  simp only [extractLsb, extractLsb', BitVec.sub_self, toNat_ofNat,
-             Nat.zero_mod, Nat.zero_mul, Nat.shiftRight_zero,
-             ofNat_toNat, toNat_cast, toNat_truncate, Nat.zero_add,
-             Nat.sub_zero]
-  rw [Nat.mod_eq_of_lt]
-  rw [Nat.sub_add_cancel]
-  · exact val.isLt
-  · omega
-  done
+  simp only [BitVec.sub_self, toNat_ofNat, Nat.zero_mod,
+    Nat.zero_mul, extractLsb'_toNat,
+    Nat.shiftRight_zero, toNat_mod_cancel]
 
 private theorem read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt
   (h0 : 0 < n1) (h1 : n1 <= my_pow 2 64) (h2 : 0 < n2) (h3 : n2 = my_pow 2 64)
   (h4 : mem_subset addr2 (addr2 + (BitVec.ofNat 64 (n2 - 1))) addr1 (addr1 + (BitVec.ofNat 64 (n1 - 1))))
   (h5 : mem_legal addr2 (addr2 + (BitVec.ofNat 64 (n2 - 1))))
-  (h6 : mem_legal addr1 (addr1 + (BitVec.ofNat 64 (n1 - 1))))
-  (h : ((BitVec.toNat (addr2 - addr1) + n2) * 8 - 1 - BitVec.toNat (addr2 - addr1) * 8 + 1)
-        = n2 * 8) :
+  (h6 : mem_legal addr1 (addr1 + (BitVec.ofNat 64 (n1 - 1)))):
   read_mem_bytes n2 addr2 (write_mem_bytes n1 addr1 val s) =
-   BitVec.cast h
-    (extractLsb ((((addr2 - addr1).toNat + n2) * 8) - 1) ((addr2 - addr1).toNat * 8) val) := by
+   extractLsb' ((addr2 - addr1).toNat * 8) (n2 * 8) val := by
     subst n2
     have l0 := @entire_memory_subset_of_only_itself n1 addr2 addr1 h1 h4
     subst n1
@@ -924,7 +884,6 @@ private theorem read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt
     subst addr1
     rw [read_mem_bytes_of_write_mem_bytes_same]
     · apply read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt_helper
-      simp [my_pow_2_gt_zero]
     · unfold my_pow; decide
 
 @[state_simp_rules]
@@ -932,19 +891,16 @@ theorem read_mem_bytes_of_write_mem_bytes_subset
   (h0 : 0 < n1) (h1 : n1 <= 2^64) (h2 : 0 < n2) (h3 : n2 <= 2^64)
   (h4 : mem_subset addr2 (addr2 + (BitVec.ofNat 64 (n2 - 1))) addr1 (addr1 + (BitVec.ofNat 64 (n1 - 1))))
   (h5 : mem_legal addr2 (addr2 + (BitVec.ofNat 64 (n2 - 1))))
-  (h6 : mem_legal addr1 (addr1 + (BitVec.ofNat 64 (n1 - 1))))
-  (h : ((BitVec.toNat (addr2 - addr1) + n2) * 8 - 1 -
-         BitVec.toNat (addr2 - addr1) * 8 + 1)
-        = n2 * 8) :
+  (h6 : mem_legal addr1 (addr1 + (BitVec.ofNat 64 (n1 - 1)))):
   read_mem_bytes n2 addr2 (write_mem_bytes n1 addr1 val s) =
-   BitVec.cast h
-  (extractLsb
-    ((((addr2 - addr1).toNat + n2) * 8) - 1)
+  (extractLsb'
     ((addr2 - addr1).toNat * 8)
+    (n2 * 8)
     val) := by
   by_cases h₀ : n2 = 2^64
   case pos =>
-    apply read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt h0
+    apply read_mem_bytes_of_write_mem_bytes_subset_n2_eq_alt
+    · exact h0
     · unfold my_pow; exact h1
     · exact h2
     · unfold my_pow; exact h₀
@@ -988,8 +944,8 @@ private theorem write_mem_bytes_irrelevant_helper (h : n * 8 + 8 = (n + 1) * 8) 
   done
 
 private theorem extract_byte_of_read_mem_bytes_succ (n : Nat) :
-  extractLsb 7 0 (read_mem_bytes (n + 1) addr s) = read_mem addr s := by
-  simp only [read_mem_bytes, Nat.add_eq, Nat.add_zero, toNat_eq, extractLsb_toNat,
+  extractLsb' 0 8 (read_mem_bytes (n + 1) addr s) = read_mem addr s := by
+  simp only [read_mem_bytes, Nat.add_eq, Nat.add_zero, toNat_eq, extractLsb'_toNat,
              toNat_cast, toNat_append, Nat.shiftRight_zero, Nat.reduceAdd]
   generalize read_mem addr s = y
   generalize (read_mem_bytes n (addr + 1#64) s) = x

--- a/Arm/Memory/MemoryProofs.lean
+++ b/Arm/Memory/MemoryProofs.lean
@@ -65,9 +65,10 @@ theorem append_byte_of_extract_rest_same_cast (n : Nat) (v : BitVec ((n + 1) * 8
   (hn0 : Nat.succ 0 ≤ n)
   (h : (n * 8 + 8) = (n + 1) * 8) :
   BitVec.cast h (zeroExtend (n * 8) (v >>> 8) ++ extractLsb' 0 8 v) = v := by
-  apply BitVec.append_of_extract
+  rw [BitVec.append_of_extract]
+  · simp only [BitVec.cast_cast, BitVec.cast_eq]
   · omega
-  done
+  · omega
 
 @[state_simp_rules]
 theorem read_mem_bytes_of_write_mem_bytes_same (hn1 : n <= 2^64) :

--- a/Arm/State.lean
+++ b/Arm/State.lean
@@ -677,7 +677,7 @@ def write_mem_bytes (n : Nat) (addr : BitVec 64) (val : BitVec (n * 8)) (s : Arm
   match n with
   | 0 => s
   | n' + 1 =>
-    let byte := BitVec.extractLsb 7 0 val
+    let byte := BitVec.extractLsb' 0 8 val
     let s := write_mem addr byte s
     let val_rest := BitVec.zeroExtend (n' * 8) (val >>> 8)
     write_mem_bytes n' (addr + 1#64) val_rest s

--- a/Arm/State.lean
+++ b/Arm/State.lean
@@ -964,7 +964,7 @@ def write_bytes (n : Nat) (addr : BitVec 64)
   match n with
   | 0 => m
   | n' + 1 =>
-    let byte := BitVec.extractLsb 7 0 val
+    let byte := BitVec.extractLsb' 0 8 val
     let m := m.write addr byte
     let val_rest := BitVec.zeroExtend (n' * 8) (val >>> 8)
     m.write_bytes n' (addr + 1#64) val_rest
@@ -990,7 +990,7 @@ and then recursing to write the rest.
 -/
 theorem write_bytes_succ {mem : Memory} :
     mem.write_bytes (n + 1) addr val =
-    let byte := BitVec.extractLsb 7 0 val
+    let byte := BitVec.extractLsb' 0 8 val
     let mem := mem.write addr byte
     let val_rest := BitVec.zeroExtend (n * 8) (val >>> 8)
     mem.write_bytes n (addr + 1#64) val_rest := rfl

--- a/Proofs/Bit_twiddling.lean
+++ b/Proofs/Bit_twiddling.lean
@@ -253,7 +253,7 @@ def parity32_spec_rec (i : Nat) (x : BitVec 32) : Bool :=
   match i with
   | 0 => false
   | i' + 1 =>
-    let bit_idx := BitVec.getLsb x i'
+    let bit_idx := BitVec.getLsbD x i'
     -- let bv_idx := (BitVec.zeroExtend 32 (BitVec.ofBool bit_idx))
     Bool.xor bit_idx (parity32_spec_rec i' x)
 
@@ -268,7 +268,7 @@ def parity32_impl (x : BitVec 32) : BitVec 32 :=
   (0x00006996#32 >>> x4) &&& 1#32
 
 theorem parity32_correct (x : BitVec 32) :
-  (parity32_spec x) = ((parity32_impl x).getLsb 0) := by
+  (parity32_spec x) = ((parity32_impl x).getLsbD 0) := by
   unfold parity32_spec parity32_impl
   repeat (unfold parity32_spec_rec)
   bv_decide

--- a/Proofs/Bit_twiddling.lean
+++ b/Proofs/Bit_twiddling.lean
@@ -216,7 +216,7 @@ def popcount32_spec_rec (i : Nat) (x : BitVec 32) : (BitVec 32) :=
   match i with
   | 0 => BitVec.zero 32
   | i' + 1 =>
-    let bit_idx := BitVec.extractLsb i' i' x
+    let bit_idx := BitVec.extractLsb' i' 1 x
     let bv_idx := (BitVec.zeroExtend 32 bit_idx)
     (bv_idx + (popcount32_spec_rec i' x))
 

--- a/Proofs/Experiments/Abs/Abs.lean
+++ b/Proofs/Experiments/Abs/Abs.lean
@@ -24,7 +24,7 @@ def spec (x : BitVec 32) : BitVec 32 :=
   -- BitVec.ofNat 32 x.toInt.natAbs
   -- because the above has functions like `toInt` that do not play well with
   -- bitblasting/LeanSAT.
-  let msb := BitVec.extractLsb 31 31 x
+  let msb := BitVec.extractLsb' 31 1 x
   if msb == 0#1 then
     x
   else

--- a/Proofs/Experiments/Abs/AbsVCG.lean
+++ b/Proofs/Experiments/Abs/AbsVCG.lean
@@ -39,7 +39,7 @@ def spec (x : BitVec 32) : BitVec 32 :=
   -- BitVec.ofNat 32 x.toInt.natAbs
   -- because the above has functions like `toInt` that do not play well with
   -- bitblasting/LeanSAT.
-  let msb := BitVec.extractLsb 31 31 x
+  let msb := BitVec.extractLsb' 31 1 x
   if msb == 0#1 then
     x
   else
@@ -205,12 +205,12 @@ theorem effects_of_nextc_from_0x4005d0 (h_pre : abs_pre s0)
   r (StateField.GPR 0#5) sn =
     BitVec.zeroExtend 64
       (AddWithCarry (BitVec.zeroExtend 32 (r (StateField.GPR 0x0#5) s0))
-          (BitVec.replicate 32 (BitVec.extractLsb 31 31 (BitVec.zeroExtend 32 (r (StateField.GPR 0x0#5) s0))) &&&
+          (BitVec.replicate 32 (BitVec.extractLsb' 31 1 (BitVec.zeroExtend 32 (r (StateField.GPR 0x0#5) s0))) &&&
               0xfffffffe#32 |||
             (BitVec.zeroExtend 32 (r (StateField.GPR 0x0#5) s0)).rotateRight 31 &&& 0xffffffff#32 &&& 0x1#32)
           0x0#1).fst ^^^
     (BitVec.zeroExtend 64
-          (BitVec.replicate 32 (BitVec.extractLsb 31 31 (BitVec.zeroExtend 32 (r (StateField.GPR 0x0#5) s0)))) &&&
+          (BitVec.replicate 32 (BitVec.extractLsb' 31 1 (BitVec.zeroExtend 32 (r (StateField.GPR 0x0#5) s0)))) &&&
         0xfffffffe#64 |||
       BitVec.zeroExtend 64 ((BitVec.zeroExtend 32 (r (StateField.GPR 0x0#5) s0)).rotateRight 31) &&& 0xffffffff#64 &&&
         0x1#64) ∧

--- a/Proofs/Experiments/Abs/AbsVCGTandem.lean
+++ b/Proofs/Experiments/Abs/AbsVCGTandem.lean
@@ -37,7 +37,7 @@ def spec (x : BitVec 32) : BitVec 32 :=
   -- BitVec.ofNat 32 x.toInt.natAbs
   -- because the above has functions like `toInt` that do not play well with
   -- bitblasting/LeanSAT.
-  let msb := BitVec.extractLsb 31 31 x
+  let msb := BitVec.extractLsb' 31 1 x
   if msb == 0#1 then
     x
   else
@@ -124,7 +124,7 @@ theorem program.stepi_0x4005d4_cut (s sn : ArmState)
   abs_cut sn = false  ∧
   r (StateField.GPR 0#5) sn =
     (BitVec.zeroExtend 64
-            (BitVec.replicate 32 (BitVec.extractLsb 31 31 (BitVec.zeroExtend 32 (r (StateField.GPR 0x0#5) s)))) &&&
+            (BitVec.replicate 32 (BitVec.extractLsb' 31 1 (BitVec.zeroExtend 32 (r (StateField.GPR 0x0#5) s)))) &&&
           0xfffffffe#64 |||
         BitVec.zeroExtend 64 ((BitVec.zeroExtend 32 (r (StateField.GPR 0x0#5) s)).rotateRight 31) &&& 0xffffffff#64 &&&
           0x1#64) ∧

--- a/Proofs/Experiments/Memcpy/MemCpyVCG.lean
+++ b/Proofs/Experiments/Memcpy/MemCpyVCG.lean
@@ -268,11 +268,10 @@ theorem program.step_8e4_8e8_of_wellformed_of_stepped (scur snext : ArmState)
   obtain h_sp_aligned := hscur.h_sp_aligned
 
   have := program.stepi_eq_0x8e4 h_program h_pc h_err
-  simp [BitVec.extractLsb] at this
   obtain ⟨h_step⟩ := hstep
   subst h_step
   constructor <;> simp only [*, cut, state_simp_rules, minimal_theory, bitvec_rules]
-  · constructor <;> simp [*, state_simp_rules, minimal_theory, BitVec.extractLsb]
+  · constructor <;> simp [*, state_simp_rules, minimal_theory]
 
 -- 3/7 (0x8e8#64, 0x3c810444#32),  /- str q4, [x2], #16        -/
 structure Step_8e8_8ec (scur : ArmState) (snext : ArmState) extends WellFormedAtPc snext 0x8ec : Prop where
@@ -296,7 +295,6 @@ theorem program.step_8e8_8ec_of_wellformed (scur snext : ArmState)
   obtain h_sp_aligned := hscur.h_sp_aligned
 
   have := program.stepi_eq_0x8e8 h_program h_pc h_err
-  simp [BitVec.extractLsb] at this
   obtain ⟨h_step⟩ := hstep
   subst h_step
   constructor
@@ -335,11 +333,10 @@ theorem program.step_8ec_8f0_of_wellformed (scur snext : ArmState)
   obtain h_sp_aligned := hs.h_sp_aligned
 
   have := program.stepi_eq_0x8ec h_program h_pc h_err
-  simp [BitVec.extractLsb] at this
   obtain ⟨h_step⟩ := hstep
   subst h_step
   constructor <;> simp (config := { ground := true, decide := true}) [*,
-      state_simp_rules, minimal_theory, BitVec.extractLsb, fst_AddWithCarry_eq_sub_neg, memory_rules]
+      state_simp_rules, minimal_theory, fst_AddWithCarry_eq_sub_neg, memory_rules]
   · constructor <;> simp [*, state_simp_rules, minimal_theory, bitvec_rules, memory_rules]
 
 -- 5/7 (0x8f0#64, 0xf100001f#32),  /- cmp x0, #0x0             -/
@@ -364,7 +361,7 @@ theorem program.step_8f0_8f4_of_wellformed (scur snext : ArmState)
   obtain h_sp_aligned := hs.h_sp_aligned
 
   have := program.stepi_eq_0x8f0 h_program h_pc h_err
-  simp (config := { ground := true, decide := true}) [BitVec.extractLsb,
+  simp (config := { ground := true, decide := true}) [
     fst_AddWithCarry_eq_sub_neg,
     fst_AddWithCarry_eq_add] at this
   obtain ⟨h_step⟩ := hstep
@@ -396,14 +393,14 @@ theorem program.step_8f4_8e4_of_wellformed_of_z_eq_0 (scur snext : ArmState)
   obtain h_sp_aligned := hs.h_sp_aligned
 
   have := program.stepi_eq_0x8f4 h_program h_pc h_err
-  simp (config := { ground := true, decide := true}) [BitVec.extractLsb,
+  simp (config := { ground := true, decide := true}) [
     fst_AddWithCarry_eq_sub_neg,
     fst_AddWithCarry_eq_add] at this
   obtain ⟨h_step⟩ := hstep
   subst h_step
   constructor <;> solve
     | simp (config := { ground := true, decide := true}) [*,
-      state_simp_rules, minimal_theory, BitVec.extractLsb, fst_AddWithCarry_eq_sub_neg]
+      state_simp_rules, minimal_theory, fst_AddWithCarry_eq_sub_neg]
   · constructor <;> simp [*, state_simp_rules, minimal_theory, bitvec_rules]
 
 -- 6/7 (0x8f4#64, 0x54ffff81#32),  /- b.ne 8e4 <mem_copy_loop> -/
@@ -426,14 +423,14 @@ theorem program.step_8f4_8f8_of_wellformed_of_z_eq_1 (scur snext : ArmState)
   obtain h_sp_aligned := hs.h_sp_aligned
 
   have := program.stepi_eq_0x8f4 h_program h_pc h_err
-  simp (config := { ground := true, decide := true}) [BitVec.extractLsb,
+  simp (config := { ground := true, decide := true}) [
     fst_AddWithCarry_eq_sub_neg,
     fst_AddWithCarry_eq_add] at this
   obtain ⟨h_step⟩ := hstep
   subst h_step
   constructor <;>
     simp (config := { ground := true, decide := true}) [*, state_simp_rules, h_z,
-      minimal_theory, BitVec.extractLsb, fst_AddWithCarry_eq_sub_neg, cut]
+      minimal_theory, fst_AddWithCarry_eq_sub_neg, cut]
   · constructor <;> simp [*, h_z, state_simp_rules, minimal_theory, bitvec_rules, cut]
 
 end CutTheorems

--- a/Proofs/SHA512/SHA512Prelude.lean
+++ b/Proofs/SHA512/SHA512Prelude.lean
@@ -124,7 +124,7 @@ theorem sha512_block_armv8_prelude (s0 sf : ArmState)
     /-
     (FIXME) The `rw` below fails with:
     tactic 'rewrite' failed, did not find instance of the pattern in the target expression
-    extractLsb 3 0 (?m.1887 + ?m.1888)
+    extractLsb' 0 4 (?m.1887 + ?m.1888)
 
     Why is `Aligned` opened up here?
     -/

--- a/Specs/AESArm.lean
+++ b/Specs/AESArm.lean
@@ -112,9 +112,7 @@ protected def InitKey {Param : KBR} (i : Nat) (key : BitVec Param.key_len)
   (acc : KeySchedule) : KeySchedule :=
   if h₀ : Param.Nk ≤ i then acc
   else
-    have h₁ : i * 32 + 32 - 1 - i * 32 + 1 = WordSize := by
-      simp only [WordSize]; omega
-    let wd := BitVec.cast h₁ $ extractLsb (i * 32 + 32 - 1) (i * 32) key
+    let wd := extractLsb' (i * 32) 32 key
     let (x:KeySchedule) := [wd]
     have _ : Param.Nk - (i + 1) < Param.Nk - i := by omega
     AESArm.InitKey (Param := Param) (i + 1) key (acc ++ x)

--- a/Specs/AESArm.lean
+++ b/Specs/AESArm.lean
@@ -139,7 +139,7 @@ protected def KeyExpansion_helper {Param : KBR} (i : Nat) (ks : KeySchedule)
 def KeyExpansion {Param : KBR} (key : BitVec Param.key_len)
   : KeySchedule :=
   let seeded := AESArm.InitKey (Param := Param) Param.Nk key []
-  AESArm.KeyExpansion_helper (Param := Param) Param.Nk seeded
+  AESArm.KeyExpansion_helper (Param := Param) (4 * Param.Nr + 4 - Param.Nk) seeded
 
 def SubBytes {Param : KBR} (state : BitVec Param.block_size)
   : BitVec Param.block_size :=
@@ -227,7 +227,7 @@ def AES_encrypt_with_ks {Param : KBR} (input : BitVec Param.block_size)
   -- have h₀ : WordSize + WordSize + WordSize + WordSize = Param.block_size := by
   --   simp only [WordSize, BlockSize, Param.h]
   let state := AddRoundKey input $ (AESArm.getKey 0 w)
-  let state := AESArm.AES_encrypt_with_ks_loop (Param := Param) 1 state w
+  let state := AESArm.AES_encrypt_with_ks_loop (Param := Param) (Param.Nr - 1) state w
   let state := SubBytes (Param := Param) state
   let state := ShiftRows (Param := Param) state
   AddRoundKey state $ AESArm.getKey Param.Nr w

--- a/Specs/AESArm.lean
+++ b/Specs/AESArm.lean
@@ -113,10 +113,8 @@ protected def InitKey {Param : KBR} (i : Nat) (key : BitVec Param.key_len)
   match i with
   | 0 => acc
   | i' + 1 =>
-    let i := Param.Nk - i
-    let wd := extractLsb' (i * 32) 32 key
-    let (x:KeySchedule) := [wd]
-    AESArm.InitKey (Param := Param) i' key (acc ++ x)
+    let wd := extractLsb' ((i - 1) * 32) 32 key
+    AESArm.InitKey (Param := Param) i' key (wd :: acc)
 
 protected def KeyExpansion_helper {Param : KBR} (i : Nat) (ks : KeySchedule)
   : KeySchedule :=

--- a/Specs/AESCommon.lean
+++ b/Specs/AESCommon.lean
@@ -33,84 +33,81 @@ def SBOX :=
   ]
 
 def ShiftRows (op : BitVec 128) : BitVec 128 :=
-  extractLsb 95 88 op ++ extractLsb 55 48 op ++
-  extractLsb 15 8 op ++ extractLsb 103 96 op ++
-  extractLsb 63 56 op ++ extractLsb 23 16 op ++
-  extractLsb 111 104 op ++ extractLsb 71 64 op ++
-  extractLsb 31 24 op ++ extractLsb 119 112 op ++
-  extractLsb 79 72 op ++ extractLsb 39 32 op ++
-  extractLsb 127 120 op ++ extractLsb 87 80 op ++
-  extractLsb 47 40 op ++ extractLsb 7 0 op
+  extractLsb' 88 8 op ++ extractLsb' 48 8 op ++
+  extractLsb' 8 8 op ++ extractLsb' 96 8 op ++
+  extractLsb' 56 8 op ++ extractLsb' 16 8 op ++
+  extractLsb' 104 8 op ++ extractLsb' 64 8 op ++
+  extractLsb' 24 8 op ++ extractLsb' 112 8 op ++
+  extractLsb' 72 8 op ++ extractLsb' 32 8 op ++
+  extractLsb' 120 8 op ++ extractLsb' 80 8 op ++
+  extractLsb' 40 8 op ++ extractLsb' 0 8 op
 
 def SubBytes_aux (i : Nat) (op : BitVec 128) (out : BitVec 128)
   : BitVec 128 :=
-  if h₀ : 16 <= i then
-    out
-  else
-    let idx := (extractLsb (i * 8 + 7) (i * 8) op).toNat
-    let val := extractLsb (idx * 8 + 7) (idx * 8) $ BitVec.flatten SBOX
-    have h₁ : idx * 8 + 7 - idx * 8 + 1 = i * 8 + 7 - i * 8 + 1 := by omega
+  match i with
+  | 0 => out
+  | i' + 1 =>
+    let i := 16 - i
+    let idx := (extractLsb' (i * 8) 8 op).toNat
+    let val := extractLsb' (idx * 8) 8 $ BitVec.flatten SBOX
+    have h₁ : 8 = i * 8 + 7 - i * 8 + 1 := by omega
     let out := BitVec.partInstall (i * 8 + 7) (i * 8) (BitVec.cast h₁ val) out
-    have _ : 15 - i < 16 - i := by omega
-    SubBytes_aux (i + 1) op out
-  termination_by (16 - i)
+    SubBytes_aux i' op out
 
 def SubBytes (op : BitVec 128) : BitVec 128 :=
-  SubBytes_aux 0 op (BitVec.zero 128)
+  SubBytes_aux 16 op (BitVec.zero 128)
 
 def MixColumns_aux (c : Nat)
   (in0 : BitVec 32) (in1 : BitVec 32) (in2 : BitVec 32) (in3 : BitVec 32)
   (out0 : BitVec 32) (out1 : BitVec 32) (out2 : BitVec 32) (out3 : BitVec 32)
   (FFmul02 : BitVec 8 -> BitVec 8) (FFmul03 : BitVec 8 -> BitVec 8)
   : BitVec 32 × BitVec 32 × BitVec 32 × BitVec 32 :=
-  if h₀ : 4 <= c then
-    (out0, out1, out2, out3)
-  else
-    let lo := c * 8
+  match c with
+  | 0 => (out0, out1, out2, out3)
+  | c' + 1 =>
+    let lo := (4 - c) * 8
     let hi := lo + 7
-    have h₁ : hi - lo + 1 = 8 := by omega
-    let in0_byte := BitVec.cast h₁ $ extractLsb hi lo in0
-    let in1_byte := BitVec.cast h₁ $ extractLsb hi lo in1
-    let in2_byte := BitVec.cast h₁ $ extractLsb hi lo in2
-    let in3_byte := BitVec.cast h₁ $ extractLsb hi lo in3
-    let val0 := BitVec.cast h₁.symm $ (FFmul02 in0_byte ^^^ FFmul03 in1_byte ^^^ in2_byte ^^^ in3_byte)
+    let in0_byte := extractLsb' lo 8 in0
+    let in1_byte := extractLsb' lo 8 in1
+    let in2_byte := extractLsb' lo 8 in2
+    let in3_byte := extractLsb' lo 8 in3
+    have h : 8 = hi - lo + 1 := by omega
+    let val0 := BitVec.cast h $ FFmul02 in0_byte ^^^ FFmul03 in1_byte ^^^ in2_byte ^^^ in3_byte
     let out0 := BitVec.partInstall hi lo val0 out0
-    let val1 := BitVec.cast h₁.symm $ (FFmul02 in1_byte ^^^ FFmul03 in2_byte ^^^ in3_byte ^^^ in0_byte)
+    let val1 := BitVec.cast h $ FFmul02 in1_byte ^^^ FFmul03 in2_byte ^^^ in3_byte ^^^ in0_byte
     let out1 := BitVec.partInstall hi lo val1 out1
-    let val2 := BitVec.cast h₁.symm $ (FFmul02 in2_byte ^^^ FFmul03 in3_byte ^^^ in0_byte ^^^ in1_byte)
+    let val2 := BitVec.cast h $ FFmul02 in2_byte ^^^ FFmul03 in3_byte ^^^ in0_byte ^^^ in1_byte
     let out2 := BitVec.partInstall hi lo val2 out2
-    let val3 := BitVec.cast h₁.symm $ (FFmul02 in3_byte ^^^ FFmul03 in0_byte ^^^ in1_byte ^^^ in2_byte)
+    let val3 := BitVec.cast h $ FFmul02 in3_byte ^^^ FFmul03 in0_byte ^^^ in1_byte ^^^ in2_byte
     let out3 := BitVec.partInstall hi lo val3 out3
-    have _ : 3 - c < 4 - c := by omega
-    MixColumns_aux (c + 1) in0 in1 in2 in3 out0 out1 out2 out3 FFmul02 FFmul03
-  termination_by (4 - c)
+    MixColumns_aux c' in0 in1 in2 in3 out0 out1 out2 out3 FFmul02 FFmul03
 
 def MixColumns (op : BitVec 128) (FFmul02 : BitVec 8 -> BitVec 8)
   (FFmul03 : BitVec 8 -> BitVec 8) : BitVec 128 :=
   let in0 :=
-    extractLsb 103 96 op ++ extractLsb 71 64 op ++
-    extractLsb 39 32 op ++ extractLsb 7 0 op
+    extractLsb' 96 8 op ++ extractLsb' 64 8 op ++
+    extractLsb' 32 8 op ++ extractLsb' 0 8 op
   let in1 :=
-    extractLsb 111 104 op ++ extractLsb 79 72 op ++
-    extractLsb 47 40 op ++ extractLsb 15 8 op
+    extractLsb' 104 8 op ++ extractLsb' 72 8 op ++
+    extractLsb' 40 8 op ++ extractLsb' 8 8 op
   let in2 :=
-    extractLsb 119 112 op ++ extractLsb 87 80 op ++
-    extractLsb 55 48 op ++ extractLsb 23 16 op
+    extractLsb' 112 8 op ++ extractLsb' 80 8 op ++
+    extractLsb' 48 8 op ++ extractLsb' 16 8 op
   let in3 :=
-    extractLsb 127 120 op ++ extractLsb 95 88 op ++
-    extractLsb 63 56 op ++ extractLsb 31 24 op
+    extractLsb' 120 8 op ++ extractLsb' 88 8 op ++
+    extractLsb' 56 8 op ++ extractLsb' 24 8 op
   let (out0, out1, out2, out3) :=
     (BitVec.zero 32, BitVec.zero 32,
      BitVec.zero 32, BitVec.zero 32)
   let (out0, out1, out2, out3) :=
-    MixColumns_aux 0 in0 in1 in2 in3 out0 out1 out2 out3 FFmul02 FFmul03
-  extractLsb 31 24 out3 ++ extractLsb 31 24 out2 ++
-  extractLsb 31 24 out1 ++ extractLsb 31 24 out0 ++
-  extractLsb 23 16 out3 ++ extractLsb 23 16 out2 ++
-  extractLsb 23 16 out1 ++ extractLsb 23 16 out0 ++
-  extractLsb 15 8 out3 ++ extractLsb 15 8 out2 ++
-  extractLsb 15 8 out1 ++ extractLsb 15 8 out0 ++
-  extractLsb 7 0 out3 ++ extractLsb 7 0 out2 ++
-  extractLsb 7 0 out1 ++ extractLsb 7 0 out0
+    MixColumns_aux 4 in0 in1 in2 in3 out0 out1 out2 out3 FFmul02 FFmul03
+  extractLsb' 24 8 out3 ++ extractLsb' 24 8 out2 ++
+  extractLsb' 24 8 out1 ++ extractLsb' 24 8 out0 ++
+  extractLsb' 16 8 out3 ++ extractLsb' 16 8 out2 ++
+  extractLsb' 16 8 out1 ++ extractLsb' 16 8 out0 ++
+  extractLsb' 8 8 out3 ++ extractLsb' 8 8 out2 ++
+  extractLsb' 8 8 out1 ++ extractLsb' 8 8 out0 ++
+  extractLsb' 0 8 out3 ++ extractLsb' 0 8 out2 ++
+  extractLsb' 0 8 out1 ++ extractLsb' 0 8 out0
 
 end AESCommon

--- a/Specs/AESV8.lean
+++ b/Specs/AESV8.lean
@@ -111,6 +111,8 @@ def AESHWCtr32EncryptBlocks_helper {Param : AESArm.KBR} (in_blocks : BitVec m)
   if i >= len then acc
   else
     let lo := m - (i + 1) * 128
+    let hi := lo + 127
+    have h5 : hi - lo + 1 = 128 := by omega
     let curr_block : BitVec 128 := BitVec.extractLsb' lo 128 in_blocks
     have h4 : 128 = Param.block_size := by
       cases h3

--- a/Specs/AESV8.lean
+++ b/Specs/AESV8.lean
@@ -111,10 +111,7 @@ def AESHWCtr32EncryptBlocks_helper {Param : AESArm.KBR} (in_blocks : BitVec m)
   if i >= len then acc
   else
     let lo := m - (i + 1) * 128
-    let hi := lo + 127
-    have h5 : hi - lo + 1 = 128 := by omega
-    let curr_block : BitVec 128 :=
-      BitVec.cast h5 $ BitVec.extractLsb hi lo in_blocks
+    let curr_block : BitVec 128 := BitVec.extractLsb' lo 128 in_blocks
     have h4 : 128 = Param.block_size := by
       cases h3
       · rename_i h; simp only [h, AESArm.AES128KBR, AESArm.BlockSize]

--- a/Specs/GCM.lean
+++ b/Specs/GCM.lean
@@ -22,7 +22,7 @@ def R : (BitVec 128) := 0b11100001#8 ++ 0b0#120
 abbrev Cipher {n : Nat} {m : Nat} :=  BitVec n → BitVec m → BitVec n
 
 /-- The s-bit incrementing function -/
-def inc_s (s : Nat) (X : BitVec l) (H₀ : 0 < s) (H₁ : s < l) : BitVec l :=
+def inc_s (s : Nat) (X : BitVec l) (H₀ : s < l) : BitVec l :=
   let upper := extractLsb' s (l - s) X
   let lower := (extractLsb' 0 s X) + 0b1#s
   have h : l - s + s = l := by omega
@@ -72,7 +72,7 @@ def GCTR_aux (CIPH : Cipher (n := 128) (m := m))
     let Xi := extractLsb' lo 128 X
     let Yi := Xi ^^^ CIPH ICB K
     let Y := BitVec.partInstall hi lo (BitVec.cast h Yi) Y
-    let ICB := inc_s 32 ICB (by omega) (by omega)
+    let ICB := inc_s 32 ICB (by omega)
     GCTR_aux CIPH (i + 1) n K ICB X Y
   termination_by (n - i)
 
@@ -130,7 +130,7 @@ def GCM_AE (CIPH : Cipher (n := 128) (m := m))
   : (BitVec p) × (BitVec t) :=
   let H := CIPH (BitVec.zero 128) K
   let J0 : BitVec 128 := GCM.initialize_J0 H IV
-  let ICB := inc_s 32 J0 (by decide) (by decide)
+  let ICB := inc_s 32 J0 (by decide)
   let C := GCTR (m := m) CIPH K ICB P
   let u := GCM.ceiling_in_bits p - p
   let v := GCM.ceiling_in_bits a - a
@@ -165,7 +165,7 @@ def GCM_AD (CIPH : Cipher (n := 128) (m := m))
   else
     let H := CIPH (BitVec.zero 128) K
     let J0 := GCM.initialize_J0 H IV
-    let ICB := inc_s 32 J0 (by decide) (by decide)
+    let ICB := inc_s 32 J0 (by decide)
     let P := GCTR (m := m) CIPH K ICB C
     let u := GCM.ceiling_in_bits c - c
     let v := GCM.ceiling_in_bits a - a

--- a/Specs/GCMV8.lean
+++ b/Specs/GCMV8.lean
@@ -21,10 +21,10 @@ open BitVec
 ------------------------------------------------------------------------------
 
 def hi (x : BitVec 128) : BitVec 64 :=
-  extractLsb 127 64 x
+  extractLsb' 64 64 x
 
 def lo (x : BitVec 128) : BitVec 64 :=
-  extractLsb 63 0 x
+  extractLsb' 0 64 x
 
 ------------------------------------------------------------------------------
 -- Functions related to galois field operations

--- a/Tests/AES-GCM/AESV8ProgramTests.lean
+++ b/Tests/AES-GCM/AESV8ProgramTests.lean
@@ -360,28 +360,28 @@ def final_state1 : ArmState :=
   aes_hw_ctr32_encrypt_blocks_test 88 1 in_block rounds key_schedule ivec
 def final_buf1 : BitVec 640 := read_mem_bytes 80 out_address final_state1
 example : read_err final_state1 = StateError.None := by native_decide
-example: final_buf1 = (BitVec.zero 512) ++ (extractLsb 127 0 (revflat buf_res_128)) := by native_decide
+example: final_buf1 = (BitVec.zero 512) ++ (extractLsb' 0 128 (revflat buf_res_128)) := by native_decide
 
 -- -- len = 2
 def final_state2 : ArmState :=
   aes_hw_ctr32_encrypt_blocks_test 89 2 in_block rounds key_schedule ivec
 def final_buf2 : BitVec 640 := read_mem_bytes 80 out_address final_state2
 example : read_err final_state2 = StateError.None := by native_decide
-example: final_buf2 = (BitVec.zero 384) ++ (extractLsb 255 0 (revflat buf_res_128)) := by native_decide
+example: final_buf2 = (BitVec.zero 384) ++ (extractLsb' 0 256 (revflat buf_res_128)) := by native_decide
 
 -- len = 3
 def final_state3 : ArmState :=
   aes_hw_ctr32_encrypt_blocks_test 128 3 in_block rounds key_schedule ivec
 def final_buf3 : BitVec 640 := read_mem_bytes 80 out_address final_state3
 example : read_err final_state3 = StateError.None := by native_decide
-example: final_buf3 = (BitVec.zero 256) ++ (extractLsb 383 0 (revflat buf_res_128)) := by native_decide
+example: final_buf3 = (BitVec.zero 256) ++ (extractLsb' 0 384 (revflat buf_res_128)) := by native_decide
 
 -- len = 4
 def final_state4 : ArmState :=
   aes_hw_ctr32_encrypt_blocks_test 190 4 in_block rounds key_schedule ivec
 def final_buf4 : BitVec 640 := read_mem_bytes 80 out_address final_state4
 example : read_err final_state4 = StateError.None := by native_decide
-example: final_buf4 = (BitVec.zero 127) ++ (extractLsb 512 0 (revflat buf_res_128)) := by native_decide
+example: final_buf4 = (BitVec.zero 128) ++ (extractLsb' 0 512 (revflat buf_res_128)) := by native_decide
 
 -- len = 5
 def final_state5 : ArmState :=

--- a/Tests/AES-GCM/GCMSpecTests.lean
+++ b/Tests/AES-GCM/GCMSpecTests.lean
@@ -14,8 +14,8 @@ namespace GCMInitV8SpecTest
 def flatten_H := BitVec.flatten GCMProgramTestParams.H
 def spec_table := GCMV8.GCMInitV8 flatten_H
 
-example : extractLsb (12 * 128) 0 (revflat spec_table)
-        = extractLsb (12 * 128) 0 (revflat GCMProgramTestParams.Htable)
+example : extractLsb' 0 (12 * 128) (revflat spec_table)
+        = extractLsb' 0 (12 * 128) (revflat GCMProgramTestParams.Htable)
         := by native_decide
 
 end GCMInitV8SpecTest

--- a/Tests/Tactics/CSE.lean
+++ b/Tests/Tactics/CSE.lean
@@ -234,19 +234,20 @@ warning: declaration uses 'sorry'
 info: a b c d : BitVec 64
 x1 x2 : BitVec 128
 hx1 : x2 <<< 64 = x1
-x3 : BitVec (127 - 64 + 1)
-hx3 : BitVec.extractLsb 127 64 c = x3
+x3 : BitVec 64
+hx3 : BitVec.extractLsb' 64 64 c = x3
 hx2 : BitVec.zeroExtend 128 x3 = x2
-⊢ BitVec.zeroExtend 128 (BitVec.extractLsb 63 0 x1) ||| BitVec.zeroExtend 128 (BitVec.extractLsb 127 64 x1) =
+⊢ BitVec.zeroExtend 128 (BitVec.extractLsb' 0 64 x1) ||| BitVec.zeroExtend 128 (BitVec.extractLsb' 64 64 x1) =
     sorryAx (BitVec 128)
 -/
+
 #guard_msgs in theorem bitvec_subexpr  (a b c d : BitVec 64) : (zeroExtend 128
-              (extractLsb 63 0
+              (extractLsb' 0 64
                   (
-                    zeroExtend 128 (extractLsb 127 64 c) <<< 64)) |||
+                    zeroExtend 128 (extractLsb' 64 64 c) <<< 64)) |||
           zeroExtend 128
-              (extractLsb 127 64
-                  (zeroExtend 128 (extractLsb 127 64 c) <<< 64))) = sorry := by
+              (extractLsb' 64 64
+                  (zeroExtend 128 (extractLsb' 64 64 c) <<< 64))) = sorry := by
   cse
   trace_state
   all_goals sorry
@@ -268,82 +269,81 @@ hx2 : x9 + x3 = x2
 x10 x11 : BitVec 128
 hx4 : x10 ||| x11 = x4
 x12 : BitVec 128
-hx10 : x12 &&& 18446744073709551615#128 = x10
+hx11 : x12 <<< 64 = x11
 x13 : BitVec 128
-hx11 : x13 <<< 64 = x11
+hx10 : x13 &&& 18446744073709551615#128 = x10
 x14 : BitVec 64
-hx13 : BitVec.zeroExtend 128 x14 = x13
+hx12 : BitVec.zeroExtend 128 x14 = x12
 x15 : BitVec 64
-hx12 : BitVec.zeroExtend 128 x15 = x12
+hx13 : BitVec.zeroExtend 128 x15 = x13
 x16 x17 : BitVec 64
 x18 : BitVec 128
-hx16 : BitVec.extractLsb' 64 64 x18 = x16
-hx17 : BitVec.extractLsb' 0 64 x18 = x17
+hx16 : BitVec.extractLsb' 0 64 x18 = x16
+hx17 : BitVec.extractLsb' 64 64 x18 = x17
 x19 x20 : BitVec 64
 hx8 : x19 + x20 = x8
 x21 : BitVec 64
 hx9 : x20 + x21 = x9
-x22 : BitVec 128
-x23 : BitVec 64
-x24 : BitVec 128
-hx18 : x22 ||| x24 = x18
+x22 x23 : BitVec 128
+hx18 : x22 ||| x23 = x18
+x24 : BitVec 64
 x25 : BitVec 128
-hx22 : x25 &&& 18446744073709551615#128 = x22
-x26 : BitVec 64
-x27 : BitVec 128
-hx24 : x27 <<< 64 = x24
-x28 : BitVec 64
-hx27 : BitVec.zeroExtend 128 x28 = x27
+hx23 : x25 <<< 64 = x23
+x26 : BitVec 128
+hx22 : x26 &&& 18446744073709551615#128 = x22
+x27 x28 : BitVec 64
+hx25 : BitVec.zeroExtend 128 x28 = x25
 x29 : BitVec 64
-hx25 : BitVec.zeroExtend 128 x29 = x25
+hx20 : x29 ^^^ x27 = x20
 x30 : BitVec 64
-hx20 : x30 ^^^ x26 = x20
-x31 x32 : BitVec 64
-hx21 : x23 ^^^ x32 = x21
-x33 x34 : BitVec 64
-hx23 : x31 ^^^ x34 = x23
-x35 : BitVec 64
+hx26 : BitVec.zeroExtend 128 x30 = x26
+x31 : BitVec 64
+hx21 : x24 ^^^ x31 = x21
+x32 x33 : BitVec 64
+hx24 : x33 ^^^ x32 = x24
+x34 x35 : BitVec 64
 hx35 : BitVec.extractLsb' 0 64 a = x35
 x36 : BitVec 64
-hx36 : BitVec.extractLsb' 0 64 c = x36
+hx36 : BitVec.extractLsb' 64 64 a = x36
+hx27 : x34 &&& x36 = x27
 x37 : BitVec 64
 hx37 : BitVec.extractLsb' 0 64 b = x37
 hx1 : x2 + x37 = x1
 hx5 : x37 + x6 = x5
 x38 : BitVec 64
-hx38 : BitVec.extractLsb' 64 64 e = x38
-hx6 : x7 + x38 = x6
-hx14 : x16 + x38 = x14
+hx38 : BitVec.extractLsb' 0 64 e = x38
+hx15 : x16 + x38 = x15
 x39 : BitVec 64
-hx39 : BitVec.extractLsb' 64 64 a = x39
-hx26 : x33 &&& x39 = x26
+hx39 : BitVec.extractLsb' 64 64 b = x39
+hx31 : x39.rotateRight 41 = x31
+hx32 : x39.rotateRight 18 = x32
+hx33 : x39.rotateRight 14 = x33
+hx34 : ~~~x39 = x34
+hx29 : x39 &&& x35 = x29
 x40 : BitVec 64
-hx40 : BitVec.extractLsb' 64 64 b = x40
-hx31 : x40.rotateRight 14 = x31
-hx32 : x40.rotateRight 41 = x32
-hx33 : ~~~x40 = x33
-hx34 : x40.rotateRight 18 = x34
-hx30 : x40 &&& x35 = x30
+hx40 : BitVec.extractLsb' 64 64 c = x40
+hx19 : x40 + x21 = x19
 x41 : BitVec 64
 hx41 : BitVec.extractLsb' 64 64 d = x41
 hx7 : x8 + x41 = x7
+hx28 : x40 + x41 = x28
 x42 : BitVec 64
-hx42 : BitVec.extractLsb' 64 64 c = x42
-hx19 : x42 + x21 = x19
-hx28 : x42 + x41 = x28
+hx42 : BitVec.extractLsb' 64 64 e = x42
+hx6 : x7 + x42 = x6
+hx14 : x17 + x42 = x14
 x43 : BitVec 64
 hx43 : BitVec.extractLsb' 0 64 d = x43
-hx29 : x36 + x43 = x29
 x44 : BitVec 64
-hx44 : BitVec.extractLsb' 0 64 e = x44
-hx15 : x17 + x44 = x15
+hx44 : BitVec.extractLsb' 0 64 c = x44
+hx30 : x44 + x43 = x30
 ⊢ x2 ++
-      ((x1 &&& x40 ^^^ ~~~x1 &&& x35) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
+      ((x1 &&& x39 ^^^ ~~~x1 &&& x35) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
         BitVec.extractLsb' 0 64 x4) =
     x6 ++
-      (x36 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x40 ^^^ ~~~x5 &&& x35) + x43 +
-        x44)
+      (x44 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x39 ^^^ ~~~x5 &&& x35) + x43 +
+        x38)
 -/
+
 #guard_msgs in theorem sha512h_rule_1 (a b c d e : BitVec 128) :
   let elements := 2
   let esize := 64
@@ -388,20 +388,19 @@ x4 : BitVec 128
 hx3 : BitVec.extractLsb' 64 64 x4 = x3
 x5 : BitVec 64
 x6 x7 : BitVec 128
-hx6 : x7 <<< 64 = x6
+hx4 : x7 ||| x6 = x4
 x8 : BitVec 128
-hx4 : x8 ||| x6 = x4
+hx6 : x8 <<< 64 = x6
 x9 : BitVec 64
-hx7 : BitVec.zeroExtend 128 x9 = x7
+hx8 : BitVec.zeroExtend 128 x9 = x8
 x10 : BitVec 64
-hx8 : BitVec.zeroExtend 128 x10 = x8
-x11 x12 x13 : BitVec 64
-x14 : BitVec 128
-hx12 : BitVec.extractLsb' 64 64 x14 = x12
-hx13 : BitVec.extractLsb' 0 64 x14 = x13
-x15 : BitVec 64
+hx7 : BitVec.zeroExtend 128 x10 = x7
+x11 x12 x13 x14 : BitVec 64
+x15 : BitVec 128
+hx12 : BitVec.extractLsb' 64 64 x15 = x12
+hx13 : BitVec.extractLsb' 0 64 x15 = x13
 x16 : BitVec 256
-hx14 : BitVec.extractLsb' 64 128 x16 = x14
+hx15 : BitVec.extractLsb' 64 128 x16 = x15
 x17 x18 : BitVec 64
 hx2 : x18 + x3 = x2
 x19 : BitVec 128
@@ -410,64 +409,66 @@ x20 x21 : BitVec 64
 hx17 : x20 + x21 = x17
 x22 : BitVec 64
 hx18 : x21 + x22 = x18
-x23 : BitVec 128
-x24 : BitVec 64
-x25 : BitVec 128
-hx23 : x25 <<< 64 = x23
+x23 : BitVec 64
+x24 : BitVec 128
+x25 : BitVec 64
 x26 : BitVec 128
-hx19 : x26 ||| x23 = x19
-x27 x28 : BitVec 64
-hx21 : x28 ^^^ x27 = x21
+hx19 : x26 ||| x24 = x19
+x27 : BitVec 128
+hx24 : x27 <<< 64 = x24
+x28 : BitVec 64
+hx26 : BitVec.zeroExtend 128 x28 = x26
 x29 : BitVec 64
-hx25 : BitVec.zeroExtend 128 x29 = x25
+hx21 : x29 ^^^ x25 = x21
 x30 : BitVec 64
-hx26 : BitVec.zeroExtend 128 x30 = x26
-x31 x32 : BitVec 64
-hx24 : x32 ^^^ x31 = x24
-x33 : BitVec 64
-hx22 : x24 ^^^ x33 = x22
-x34 x35 : BitVec 64
-hx35 : BitVec.extractLsb' 64 64 a = x35
-hx27 : x34 &&& x35 = x27
+hx27 : BitVec.zeroExtend 128 x30 = x27
+x31 x32 x33 : BitVec 64
+hx22 : x23 ^^^ x33 = x22
+x34 : BitVec 64
+hx23 : x34 ^^^ x31 = x23
+x35 : BitVec 64
+hx35 : BitVec.extractLsb' 64 64 e = x35
 x36 : BitVec 64
-hx36 : BitVec.extractLsb' 0 64 a = x36
+hx36 : BitVec.extractLsb' 64 64 b = x36
+hx31 : x36.rotateRight 18 = x31
+hx32 : ~~~x36 = x32
+hx33 : x36.rotateRight 41 = x33
+hx34 : x36.rotateRight 14 = x34
 x37 : BitVec 64
-hx37 : BitVec.extractLsb' 0 64 e = x37
-hx11 : x15 + x37 = x11
+hx37 : BitVec.extractLsb' 0 64 c = x37
+hx10 : x37 + x13 = x10
 x38 : BitVec 64
-hx38 : BitVec.extractLsb' 64 64 d = x38
+hx38 : BitVec.extractLsb' 0 64 d = x38
+hx14 : x17 + x38 = x14
 x39 : BitVec 64
-hx39 : BitVec.extractLsb' 0 64 b = x39
-hx1 : x2 + x39 = x1
-hx5 : x39 + x11 = x5
+hx39 : BitVec.extractLsb' 64 64 c = x39
+hx9 : x39 + x12 = x9
+hx20 : x39 + x22 = x20
 x40 : BitVec 64
-hx40 : BitVec.extractLsb' 0 64 c = x40
-hx10 : x40 + x13 = x10
+hx40 : BitVec.extractLsb' 0 64 e = x40
+hx11 : x14 + x40 = x11
+hx28 : x38 + x40 = x28
 x41 : BitVec 64
-hx41 : BitVec.extractLsb' 64 64 e = x41
-hx29 : x38 + x41 = x29
+hx41 : BitVec.extractLsb' 0 64 b = x41
+hx1 : x2 + x41 = x1
+hx5 : x41 + x11 = x5
 x42 : BitVec 64
-hx42 : BitVec.extractLsb' 64 64 b = x42
-hx31 : x42.rotateRight 18 = x31
-hx32 : x42.rotateRight 14 = x32
-hx33 : x42.rotateRight 41 = x33
-hx34 : ~~~x42 = x34
-hx28 : x42 &&& x36 = x28
+hx42 : BitVec.extractLsb' 64 64 d = x42
+hx30 : x42 + x35 = x30
 x43 : BitVec 64
-hx43 : BitVec.extractLsb' 0 64 d = x43
-hx15 : x17 + x43 = x15
-hx30 : x43 + x37 = x30
+hx43 : BitVec.extractLsb' 0 64 a = x43
+hx29 : x36 &&& x43 = x29
 x44 : BitVec 64
-hx44 : BitVec.extractLsb' 64 64 c = x44
-hx9 : x44 + x12 = x9
-hx20 : x44 + x22 = x20
+hx44 : BitVec.extractLsb' 64 64 a = x44
+hx25 : x32 &&& x44 = x25
 ⊢ x2 ++
-      ((x1 &&& x42 ^^^ ~~~x1 &&& x36) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
+      ((x1 &&& x36 ^^^ ~~~x1 &&& x43) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
         BitVec.extractLsb' 0 64 x4) =
     x11 ++
-      (x40 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x42 ^^^ ~~~x5 &&& x36) + x38 +
-        x41)
+      (x37 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x36 ^^^ ~~~x5 &&& x43) + x42 +
+        x35)
 -/
+
 #guard_msgs in theorem sha512h_rule_2 (a b c d e : BitVec 128) :
   let a0 := extractLsb'  0 64 a
   let a1 := extractLsb' 64 64 a

--- a/Tests/Tactics/CSE.lean
+++ b/Tests/Tactics/CSE.lean
@@ -260,10 +260,9 @@ warning: declaration uses 'sorry'
 ---
 info: H : 64 > 0
 a b c d e : BitVec 128
-x1 x2 : BitVec 64
-x3 : BitVec (127 - 64 + 1)
+x1 x2 x3 : BitVec 64
 x4 : BitVec 128
-hx3 : BitVec.extractLsb 127 64 x4 = x3
+hx3 : BitVec.extractLsb' 64 64 x4 = x3
 x5 x6 x7 x8 x9 : BitVec 64
 hx2 : x9 + x3 = x2
 x10 x11 : BitVec 128
@@ -273,14 +272,13 @@ hx10 : x12 &&& 18446744073709551615#128 = x10
 x13 : BitVec 128
 hx11 : x13 <<< 64 = x11
 x14 : BitVec 64
-hx12 : BitVec.zeroExtend 128 x14 = x12
+hx13 : BitVec.zeroExtend 128 x14 = x13
 x15 : BitVec 64
-hx13 : BitVec.zeroExtend 128 x15 = x13
-x16 : BitVec (63 - 0 + 1)
-x17 : BitVec (127 - 64 + 1)
+hx12 : BitVec.zeroExtend 128 x15 = x12
+x16 x17 : BitVec 64
 x18 : BitVec 128
-hx16 : BitVec.extractLsb 63 0 x18 = x16
-hx17 : BitVec.extractLsb 127 64 x18 = x17
+hx16 : BitVec.extractLsb' 64 64 x18 = x16
+hx17 : BitVec.extractLsb' 0 64 x18 = x17
 x19 x20 : BitVec 64
 hx8 : x19 + x20 = x8
 x21 : BitVec 64
@@ -289,61 +287,61 @@ x22 : BitVec 128
 x23 : BitVec 64
 x24 : BitVec 128
 hx18 : x22 ||| x24 = x18
-x25 : BitVec 64
-x26 : BitVec 128
-hx22 : x26 &&& 18446744073709551615#128 = x22
+x25 : BitVec 128
+hx22 : x25 &&& 18446744073709551615#128 = x22
+x26 : BitVec 64
 x27 : BitVec 128
 hx24 : x27 <<< 64 = x24
 x28 : BitVec 64
 hx27 : BitVec.zeroExtend 128 x28 = x27
 x29 : BitVec 64
-hx20 : x29 ^^^ x25 = x20
+hx25 : BitVec.zeroExtend 128 x29 = x25
 x30 : BitVec 64
-hx26 : BitVec.zeroExtend 128 x30 = x26
+hx20 : x30 ^^^ x26 = x20
 x31 x32 : BitVec 64
-hx23 : x31 ^^^ x32 = x23
+hx21 : x23 ^^^ x32 = x21
 x33 x34 : BitVec 64
-hx21 : x23 ^^^ x34 = x21
-x35 : BitVec (127 - 64 + 1)
-hx35 : BitVec.extractLsb 127 64 d = x35
-hx7 : x8 + x35 = x7
-x36 : BitVec (63 - 0 + 1)
-hx36 : BitVec.extractLsb 63 0 a = x36
-x37 : BitVec (63 - 0 + 1)
-hx37 : BitVec.extractLsb 63 0 c = x37
-x38 : BitVec (127 - 64 + 1)
-hx38 : BitVec.extractLsb 127 64 c = x38
-hx19 : x38 + x21 = x19
-hx28 : x38 + x35 = x28
-x39 : BitVec (127 - 64 + 1)
-hx39 : BitVec.extractLsb 127 64 e = x39
-hx6 : x7 + x39 = x6
-hx15 : x17 + x39 = x15
-x40 : BitVec (63 - 0 + 1)
-hx40 : BitVec.extractLsb 63 0 b = x40
-hx1 : x2 + x40 = x1
-hx5 : x40 + x6 = x5
-x41 : BitVec (63 - 0 + 1)
-hx41 : BitVec.extractLsb 63 0 d = x41
-hx30 : x37 + x41 = x30
-x42 : BitVec (127 - 64 + 1)
-hx42 : BitVec.extractLsb 127 64 a = x42
-hx25 : x33 &&& x42 = x25
-x43 : BitVec (127 - 64 + 1)
-hx43 : BitVec.extractLsb 127 64 b = x43
-hx31 : x43.rotateRight 14 = x31
-hx32 : x43.rotateRight 18 = x32
-hx33 : ~~~x43 = x33
-hx34 : x43.rotateRight 41 = x34
-hx29 : x43 &&& x36 = x29
-x44 : BitVec (63 - 0 + 1)
-hx44 : BitVec.extractLsb 63 0 e = x44
-hx14 : x16 + x44 = x14
+hx23 : x31 ^^^ x34 = x23
+x35 : BitVec 64
+hx35 : BitVec.extractLsb' 0 64 a = x35
+x36 : BitVec 64
+hx36 : BitVec.extractLsb' 0 64 c = x36
+x37 : BitVec 64
+hx37 : BitVec.extractLsb' 0 64 b = x37
+hx1 : x2 + x37 = x1
+hx5 : x37 + x6 = x5
+x38 : BitVec 64
+hx38 : BitVec.extractLsb' 64 64 e = x38
+hx6 : x7 + x38 = x6
+hx14 : x16 + x38 = x14
+x39 : BitVec 64
+hx39 : BitVec.extractLsb' 64 64 a = x39
+hx26 : x33 &&& x39 = x26
+x40 : BitVec 64
+hx40 : BitVec.extractLsb' 64 64 b = x40
+hx31 : x40.rotateRight 14 = x31
+hx32 : x40.rotateRight 41 = x32
+hx33 : ~~~x40 = x33
+hx34 : x40.rotateRight 18 = x34
+hx30 : x40 &&& x35 = x30
+x41 : BitVec 64
+hx41 : BitVec.extractLsb' 64 64 d = x41
+hx7 : x8 + x41 = x7
+x42 : BitVec 64
+hx42 : BitVec.extractLsb' 64 64 c = x42
+hx19 : x42 + x21 = x19
+hx28 : x42 + x41 = x28
+x43 : BitVec 64
+hx43 : BitVec.extractLsb' 0 64 d = x43
+hx29 : x36 + x43 = x29
+x44 : BitVec 64
+hx44 : BitVec.extractLsb' 0 64 e = x44
+hx15 : x17 + x44 = x15
 ⊢ x2 ++
-      ((x1 &&& x43 ^^^ ~~~x1 &&& x36) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
-        BitVec.extractLsb 63 0 x4) =
+      ((x1 &&& x40 ^^^ ~~~x1 &&& x35) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
+        BitVec.extractLsb' 0 64 x4) =
     x6 ++
-      (x37 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x43 ^^^ ~~~x5 &&& x36) + x41 +
+      (x36 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x40 ^^^ ~~~x5 &&& x35) + x43 +
         x44)
 -/
 #guard_msgs in theorem sha512h_rule_1 (a b c d e : BitVec 128) :
@@ -351,16 +349,16 @@ hx14 : x16 + x44 = x14
   let esize := 64
   let inner_sum := (binary_vector_op_aux 0 elements esize BitVec.add c d (BitVec.zero 128) H)
   let outer_sum := (binary_vector_op_aux 0 elements esize BitVec.add inner_sum e (BitVec.zero 128) H)
-  let a0 := extractLsb 63 0   a
-  let a1 := extractLsb 127 64 a
-  let b0 := extractLsb 63 0   b
-  let b1 := extractLsb 127 64 b
-  let c0 := extractLsb 63 0   c
-  let c1 := extractLsb 127 64 c
-  let d0 := extractLsb 63 0   d
-  let d1 := extractLsb 127 64 d
-  let e0 := extractLsb 63 0   e
-  let e1 := extractLsb 127 64 e
+  let a0 := extractLsb'  0 64 a
+  let a1 := extractLsb' 64 64 a
+  let b0 := extractLsb'  0 64 b
+  let b1 := extractLsb' 64 64 b
+  let c0 := extractLsb'  0 64 c
+  let c1 := extractLsb' 64 64 c
+  let d0 := extractLsb'  0 64 d
+  let d1 := extractLsb' 64 64 d
+  let e0 := extractLsb'  0 64 e
+  let e1 := extractLsb' 64 64 e
   let hi64_spec := compression_update_t1 b1 a0 a1 c1 d1 e1
   let lo64_spec := compression_update_t1 (b0 + hi64_spec) b1 a0 c0 d0 e0
   sha512h a b outer_sum = hi64_spec ++ lo64_spec := by
@@ -385,28 +383,25 @@ warning: declaration uses 'sorry'
 ---
 info: h1 h2 : 64 > 0
 a b c d e : BitVec 128
-x1 x2 : BitVec 64
-x3 : BitVec (127 - 64 + 1)
+x1 x2 x3 : BitVec 64
 x4 : BitVec 128
-hx3 : BitVec.extractLsb 127 64 x4 = x3
+hx3 : BitVec.extractLsb' 64 64 x4 = x3
 x5 : BitVec 64
 x6 x7 : BitVec 128
-hx4 : x7 ||| x6 = x4
+hx6 : x7 <<< 64 = x6
 x8 : BitVec 128
-hx6 : x8 <<< 64 = x6
+hx4 : x8 ||| x6 = x4
 x9 : BitVec 64
 hx7 : BitVec.zeroExtend 128 x9 = x7
 x10 : BitVec 64
 hx8 : BitVec.zeroExtend 128 x10 = x8
-x11 : BitVec 64
-x12 : BitVec (127 - 64 + 1)
-x13 : BitVec (63 - 0 + 1)
-x14 : BitVec 64
-x15 : BitVec (191 - 64 + 1)
-hx12 : BitVec.extractLsb 127 64 x15 = x12
-hx13 : BitVec.extractLsb 63 0 x15 = x13
+x11 x12 x13 : BitVec 64
+x14 : BitVec 128
+hx12 : BitVec.extractLsb' 64 64 x14 = x12
+hx13 : BitVec.extractLsb' 0 64 x14 = x13
+x15 : BitVec 64
 x16 : BitVec 256
-hx15 : BitVec.extractLsb 191 64 x16 = x15
+hx14 : BitVec.extractLsb' 64 128 x16 = x14
 x17 x18 : BitVec 64
 hx2 : x18 + x3 = x2
 x19 : BitVec 128
@@ -418,75 +413,75 @@ hx18 : x21 + x22 = x18
 x23 : BitVec 128
 x24 : BitVec 64
 x25 : BitVec 128
-hx19 : x25 ||| x23 = x19
+hx23 : x25 <<< 64 = x23
 x26 : BitVec 128
-hx23 : x26 <<< 64 = x23
+hx19 : x26 ||| x23 = x19
 x27 x28 : BitVec 64
-hx25 : BitVec.zeroExtend 128 x28 = x25
+hx21 : x28 ^^^ x27 = x21
 x29 : BitVec 64
-hx26 : BitVec.zeroExtend 128 x29 = x26
+hx25 : BitVec.zeroExtend 128 x29 = x25
 x30 : BitVec 64
-hx21 : x30 ^^^ x27 = x21
-x31 : BitVec 64
-hx22 : x24 ^^^ x31 = x22
-x32 x33 x34 : BitVec 64
-hx24 : x33 ^^^ x34 = x24
-x35 : BitVec (63 - 0 + 1)
-hx35 : BitVec.extractLsb 63 0 b = x35
-hx1 : x2 + x35 = x1
-hx5 : x35 + x11 = x5
-x36 : BitVec (63 - 0 + 1)
-hx36 : BitVec.extractLsb 63 0 a = x36
-x37 : BitVec (127 - 64 + 1)
-hx37 : BitVec.extractLsb 127 64 b = x37
-hx31 : x37.rotateRight 41 = x31
-hx32 : ~~~x37 = x32
-hx33 : x37.rotateRight 14 = x33
-hx34 : x37.rotateRight 18 = x34
-hx30 : x37 &&& x36 = x30
-x38 : BitVec (127 - 64 + 1)
-hx38 : BitVec.extractLsb 127 64 a = x38
-hx27 : x32 &&& x38 = x27
-x39 : BitVec (127 - 64 + 1)
-hx39 : BitVec.extractLsb 127 64 e = x39
-x40 : BitVec (63 - 0 + 1)
-hx40 : BitVec.extractLsb 63 0 c = x40
-hx9 : x40 + x13 = x9
-x41 : BitVec (127 - 64 + 1)
-hx41 : BitVec.extractLsb 127 64 d = x41
-hx29 : x41 + x39 = x29
-x42 : BitVec (63 - 0 + 1)
-hx42 : BitVec.extractLsb 63 0 e = x42
-hx11 : x14 + x42 = x11
-x43 : BitVec (127 - 64 + 1)
-hx43 : BitVec.extractLsb 127 64 c = x43
-hx10 : x43 + x12 = x10
-hx20 : x43 + x22 = x20
-x44 : BitVec (63 - 0 + 1)
-hx44 : BitVec.extractLsb 63 0 d = x44
-hx14 : x17 + x44 = x14
-hx28 : x44 + x42 = x28
+hx26 : BitVec.zeroExtend 128 x30 = x26
+x31 x32 : BitVec 64
+hx24 : x32 ^^^ x31 = x24
+x33 : BitVec 64
+hx22 : x24 ^^^ x33 = x22
+x34 x35 : BitVec 64
+hx35 : BitVec.extractLsb' 64 64 a = x35
+hx27 : x34 &&& x35 = x27
+x36 : BitVec 64
+hx36 : BitVec.extractLsb' 0 64 a = x36
+x37 : BitVec 64
+hx37 : BitVec.extractLsb' 0 64 e = x37
+hx11 : x15 + x37 = x11
+x38 : BitVec 64
+hx38 : BitVec.extractLsb' 64 64 d = x38
+x39 : BitVec 64
+hx39 : BitVec.extractLsb' 0 64 b = x39
+hx1 : x2 + x39 = x1
+hx5 : x39 + x11 = x5
+x40 : BitVec 64
+hx40 : BitVec.extractLsb' 0 64 c = x40
+hx10 : x40 + x13 = x10
+x41 : BitVec 64
+hx41 : BitVec.extractLsb' 64 64 e = x41
+hx29 : x38 + x41 = x29
+x42 : BitVec 64
+hx42 : BitVec.extractLsb' 64 64 b = x42
+hx31 : x42.rotateRight 18 = x31
+hx32 : x42.rotateRight 14 = x32
+hx33 : x42.rotateRight 41 = x33
+hx34 : ~~~x42 = x34
+hx28 : x42 &&& x36 = x28
+x43 : BitVec 64
+hx43 : BitVec.extractLsb' 0 64 d = x43
+hx15 : x17 + x43 = x15
+hx30 : x43 + x37 = x30
+x44 : BitVec 64
+hx44 : BitVec.extractLsb' 64 64 c = x44
+hx9 : x44 + x12 = x9
+hx20 : x44 + x22 = x20
 ⊢ x2 ++
-      ((x1 &&& x37 ^^^ ~~~x1 &&& x36) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
-        BitVec.extractLsb 63 0 x4) =
+      ((x1 &&& x42 ^^^ ~~~x1 &&& x36) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
+        BitVec.extractLsb' 0 64 x4) =
     x11 ++
-      (x40 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x37 ^^^ ~~~x5 &&& x36) + x41 +
-        x39)
+      (x40 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x42 ^^^ ~~~x5 &&& x36) + x38 +
+        x41)
 -/
 #guard_msgs in theorem sha512h_rule_2 (a b c d e : BitVec 128) :
-  let a0 := extractLsb 63 0   a
-  let a1 := extractLsb 127 64 a
-  let b0 := extractLsb 63 0   b
-  let b1 := extractLsb 127 64 b
-  let c0 := extractLsb 63 0   c
-  let c1 := extractLsb 127 64 c
-  let d0 := extractLsb 63 0   d
-  let d1 := extractLsb 127 64 d
-  let e0 := extractLsb 63 0   e
-  let e1 := extractLsb 127 64 e
+  let a0 := extractLsb'  0 64 a
+  let a1 := extractLsb' 64 64 a
+  let b0 := extractLsb'  0 64 b
+  let b1 := extractLsb' 64 64 b
+  let c0 := extractLsb'  0 64 c
+  let c1 := extractLsb' 64 64 c
+  let d0 := extractLsb'  0 64 d
+  let d1 := extractLsb' 64 64 d
+  let e0 := extractLsb'  0 64 e
+  let e1 := extractLsb' 64 64 e
   let inner_sum := binary_vector_op_aux 0 2 64 BitVec.add d e (BitVec.zero 128) h1
   let concat := inner_sum ++ inner_sum
-  let operand := extractLsb 191 64 concat
+  let operand := extractLsb' 64 128 concat
   let hi64_spec := compression_update_t1 b1 a0 a1 c1 d0 e0
   let lo64_spec := compression_update_t1 (b0 + hi64_spec) b1 a0 c0 d1 e1
   sha512h a b (binary_vector_op_aux 0 2 64 BitVec.add c operand (BitVec.zero 128) h2) =


### PR DESCRIPTION
## Description:

This PR refactors to use `extractLsb'` instead of `extractLsb` in the whole repository. Doing so, we are able to simplify the proofs and remove unnecessary hypothesis inputs to several functions.

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine? Yes.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
