### PR TITLE
chore: fix geomean computation

### DIFF
--- a/Benchmarks/Command.lean
+++ b/Benchmarks/Command.lean
@@ -13,6 +13,9 @@ elab "benchmark" id:ident declSig:optDeclSig val:declVal : command => do
   let n := 5
   let mut runTimes := #[]
   let mut totalRunTime := 0
+  -- geomean = exp(log((a₁ a₂ ... aₙ)^1/n)) = 
+  -- exp(1/n * (log a₁ + log a₂ + log aₙ)).
+  let mut totalRunTimeLog := 0
   for _ in [0:n] do
     let start ← IO.monoMsNow
     elabCommand stx
@@ -20,9 +23,10 @@ elab "benchmark" id:ident declSig:optDeclSig val:declVal : command => do
     let runTime := endTime - start
     runTimes := runTimes.push runTime
     totalRunTime := totalRunTime + runTime
+    totalRunTimeLog := totalRunTimeLog + Float.log runTime.toFloat
 
   let avg := totalRunTime.toFloat / n.toFloat / 1000
-  let geomean := (totalRunTime.toFloat.pow (1.0 / n.toFloat)) / 1000.0
+  let geomean := (Float.exp (totalRunTimeLog / n.toFloat)) / 1000.0
   logInfo m!"\
 {id}:
   average runtime over {n} runs:


### PR DESCRIPTION
### Description:

The `geomean` computation that was incorrectly suggested by @bollu failed to take into account that the `TotalRunTime` counter was adding the real runtimes, not multiplying them as one should for geomean.

We change the `geomean` computation algorithm, to accumulate the `log` of the runtimes, and then divide by `n` followed by exponentiation as a final step for better numerical accuracy.

$$
g \equiv (t_1 \times t_2 \times \dots \times t_n)^{1/n} = \exp \bigg(\frac{\log t_1 + \log t_2 + \dots \log t_n}{n} \bigg)
$$

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine?

Conformance succeeds.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
