### PR TITLE
feat: search for reads of *any* register when building an initial `SymContext`

### DIFF
--- a/Benchmarks/SHA512_150.lean
+++ b/Benchmarks/SHA512_150.lean
@@ -12,6 +12,5 @@ open Benchmarks
 benchmark sha512_150_instructions : SHA512Bench 150 := fun s0 _ h => by
   intros
   sym_n 150
-  simp only [h, bitvec_rules]
   · exact (sorry : Aligned ..)
   done

--- a/Benchmarks/SHA512_225.lean
+++ b/Benchmarks/SHA512_225.lean
@@ -12,6 +12,5 @@ open Benchmarks
 benchmark sha512_225_instructions : SHA512Bench 225 := fun s0 _ h => by
   intros
   sym_n 225
-  simp only [h, bitvec_rules]
   · exact (sorry : Aligned ..)
   done

--- a/Benchmarks/SHA512_400.lean
+++ b/Benchmarks/SHA512_400.lean
@@ -12,6 +12,5 @@ open Benchmarks
 benchmark sha512_400_instructions : SHA512Bench 400 := fun s0 _ h => by
   intros
   sym_n 400
-  simp only [h, bitvec_rules]
   · exact (sorry : Aligned ..)
   done

--- a/Tactics/Common.lean
+++ b/Tactics/Common.lean
@@ -150,7 +150,7 @@ def reflectPFLag (e : Expr) : MetaM PFlag :=
 
 /-- Reflect a concrete `StateField` -/
 def reflectStateField (e : Expr) : MetaM StateField :=
-  match_expr e with
+  match_expr e.consumeMData with
     | StateField.GPR x  => StateField.GPR <$> reflectBitVecLiteral _ x
     | StateField.SFP x  => StateField.SFP <$> reflectBitVecLiteral _ x
     | StateField.PC     => pure StateField.PC
@@ -258,6 +258,24 @@ def mkEqArmState (x y : Expr) : Expr :=
 /-- Return a proof of type `x = x`, where `x : ArmState` -/
 def mkEqReflArmState (x : Expr) : Expr :=
   mkApp2 (.const ``Eq.refl [1]) mkArmState x
+
+/-- Return `x = y` given expressions `x, y : StateField <field>` -/
+def mkEqStateValue (field x y : Expr) : Expr :=
+  let ty := mkApp (mkConst ``state_value) field
+  mkApp3 (.const ``Eq [1]) ty x y
+
+/-- Return `r <field> <state> = <value>` -/
+def mkEqReadField (field state value : Expr) : Expr :=
+  let r := mkApp2 (mkConst ``r) field state
+  mkEqStateValue field r value
+
+/-- If expression `e` is `r ?field ?state = ?value`, return
+`some (field, state, value)`, else return `none` -/
+def Lean.Expr.eqReadField? (e : Expr) : Option (Expr × Expr × Expr) := do
+  let (_ty, lhs, value) ← e.eq?
+  let_expr r field state := lhs
+    | none
+  some (field, state, value)
 
 /-! ## Tracing helpers -/
 


### PR DESCRIPTION
### Description:

Stacked on #189, we use the more powerful search capabilities to include hypotheses that describe reads from *any* `StateField` into the initial AxEffects.

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine? Yes

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
