### PR TITLE
Syntax for stating register and memory frame conditions

### DIFF
--- a/Arm/State.lean
+++ b/Arm/State.lean
@@ -342,6 +342,8 @@ These mnemonics make it much easier to read and write theorems about assembly pr
 -/
 
 @[state_simp_rules] abbrev ArmState.x0 (s : ArmState) : BitVec 64 := r (StateField.GPR 0) s
+@[state_simp_rules] abbrev ArmState.w0 (s : ArmState) : BitVec 32 :=
+  (r (StateField.GPR 0) s).zeroExtend 32
 
 @[state_simp_rules] abbrev ArmState.x1 (s : ArmState) : BitVec 64 := r (StateField.GPR 1) s
 

--- a/Arm/Syntax.lean
+++ b/Arm/Syntax.lean
@@ -17,24 +17,25 @@ macro_rules | `($s[$base,$n]) => `(read_mem_bytes $n $base $s)
 
 
 /-! Notation to specify the frame condition for non-memory state components. E.g.,
-`REGS_UNCHANGED_EXCEPT [[.GPR 0, .PC]] (sf, s0)` is sugar for
+`REGS_UNCHANGED_EXCEPT [.GPR 0, .PC] (sf, s0)` is sugar for
 `∀ f, f ∉ [.GPR 0, .PC] → r f sf = r f s0`
 -/
-syntax:max "REGS_UNCHANGED_EXCEPT" "[" withoutPosition(term) "]"
+syntax:max "REGS_UNCHANGED_EXCEPT" "[" term,* "]"
             "(" withoutPosition(term) "," withoutPosition(term) ")" : term
-macro_rules |
-  `(REGS_UNCHANGED_EXCEPT [$regs] ($sf, $s0)) => `(∀ f, f ∉ $regs → r f $sf = r f $s0)
+macro_rules
+| `(REGS_UNCHANGED_EXCEPT [$regs:term,*] ($sf, $s0)) =>
+    `(∀ f, f ∉ [$regs,*] → r f $sf = r f $s0)
 
 /-! Notation to specify the frame condition for memory regions. E.g.,
 `MEM_UNCHANGED_EXCEPT [(x, m), (y, k)] (sf, s0)` is sugar for
 `∀ n addr, Memory.Region.pairwiseSeparate [(addr, n), (x, m), (y, k)] → sf[addr, n] = s0[addr, n]`
 -/
-syntax:max "MEM_UNCHANGED_EXCEPT" "[" sepBy(term, ",") "]"
+syntax:max "MEM_UNCHANGED_EXCEPT" "[" term,* "]"
             "(" withoutPosition(term) "," withoutPosition(term) ")" : term
 macro_rules |
-  `(MEM_UNCHANGED_EXCEPT [$mem] ($sf, $s0)) =>
+  `(MEM_UNCHANGED_EXCEPT [$mem:term,*] ($sf, $s0)) =>
             `(∀ (n : Nat) (addr : BitVec 64),
-                  Memory.Region.pairwiseSeparate (List.cons (addr, n) $mem) →
+                  Memory.Region.pairwiseSeparate (List.cons (addr, n) [$mem,*]) →
                   read_mem_bytes n addr $sf = read_mem_bytes n addr $s0)
 
 end ArmStateNotation

--- a/Arm/Syntax.lean
+++ b/Arm/Syntax.lean
@@ -6,6 +6,7 @@ Author(s): Siddharth Bhat
 Provide convenient syntax for writing down state manipulation in Arm programs.
 -/
 import Arm.State
+import Arm.Memory.Separate
 
 namespace ArmStateNotation
 
@@ -13,4 +14,27 @@ namespace ArmStateNotation
 @[inherit_doc read_mem_bytes]
 syntax:max term noWs "[" withoutPosition(term)  ","  withoutPosition(term) noWs "]" : term
 macro_rules | `($s[$base,$n]) => `(read_mem_bytes $n $base $s)
+
+
+/-! Notation to specify the frame condition for non-memory state components. E.g.,
+`REGS_UNCHANGED_EXCEPT [[.GPR 0, .PC]] (sf, s0)` is sugar for
+`∀ f, f ∉ [.GPR 0, .PC] → r f sf = r f s0`
+-/
+syntax:max "REGS_UNCHANGED_EXCEPT" "[" withoutPosition(term) "]"
+            "(" withoutPosition(term) "," withoutPosition(term) ")" : term
+macro_rules |
+  `(REGS_UNCHANGED_EXCEPT [$regs] ($sf, $s0)) => `(∀ f, f ∉ $regs → r f $sf = r f $s0)
+
+/-! Notation to specify the frame condition for memory regions. E.g.,
+`MEM_UNCHANGED_EXCEPT [(x, m), (y, k)] (sf, s0)` is sugar for
+`∀ n addr, Memory.Region.pairwiseSeparate [(addr, n), (x, m), (y, k)] → sf[addr, n] = s0[addr, n]`
+-/
+syntax:max "MEM_UNCHANGED_EXCEPT" "[" sepBy(term, ",") "]"
+            "(" withoutPosition(term) "," withoutPosition(term) ")" : term
+macro_rules |
+  `(MEM_UNCHANGED_EXCEPT [$mem] ($sf, $s0)) =>
+            `(∀ (n : Nat) (addr : BitVec 64),
+                  Memory.Region.pairwiseSeparate (List.cons (addr, n) $mem) →
+                  read_mem_bytes n addr $sf = read_mem_bytes n addr $s0)
+
 end ArmStateNotation

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -14,6 +14,7 @@ import Tactics.StepThms
 section popcount32
 
 open BitVec
+open ArmState
 
 /-!
 Source: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
@@ -24,19 +25,18 @@ int popcount_32 (unsigned int v) {
   v = ((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
   return(v);
 }
-
 -/
 
-def popcount32_spec_rec (i : Nat) (x : BitVec 32) : (BitVec 32) :=
+def popcount32_spec_rec (i : Nat) (x : BitVec 32) : BitVec 32 :=
   match i with
   | 0 => 0#32
   | i' + 1 =>
     let bit_idx := BitVec.getLsbD x i'
-    ((BitVec.zeroExtend 32 (BitVec.ofBool bit_idx)) + (popcount32_spec_rec i' x))
+    (BitVec.ofBool bit_idx).zeroExtend 32 +
+     popcount32_spec_rec i' x
 
 def popcount32_spec (x : BitVec 32) : BitVec 32 :=
   popcount32_spec_rec 32 x
-
 
 def popcount32_program : Program :=
   def_program
@@ -68,37 +68,43 @@ def popcount32_program : Program :=
    (0x400618#64 , 0x910043ff#32), -- add sp, sp, #0x10
    (0x40061c#64 , 0xd65f03c0#32)] -- ret
 
-
 #genStepEqTheorems popcount32_program
 
-theorem popcount32_sym_meets_spec (s0 s_final : ArmState)
-  (h_s0_pc : read_pc s0 = 0x4005b4#64)
-  (h_s0_program : s0.program = popcount32_program)
+theorem popcount32_sym_meets_spec (s0 sf : ArmState)
+  (h_s0_pc         : read_pc s0 = 0x4005b4#64)
+  (h_s0_program    : s0.program = popcount32_program)
   (h_s0_sp_aligned : CheckSPAlignment s0)
-  (h_s0_err : read_err s0 = StateError.None)
-  (h_run : s_final = run 27 s0) :
-  read_gpr 32 0#5 s_final = popcount32_spec (read_gpr 32 0#5 s0) ∧
-  read_err s_final = StateError.None ∧
-  (∀ f, f ≠ (.GPR 0#5) ∧ f ≠ (.GPR 1#5) ∧ f ≠ (.GPR 31#5) ∧ f ≠ .PC →
-       r f s_final = r f s0) ∧
-  (∀ (n : Nat) (addr : BitVec 64),
-    mem_separate' addr n (r (.GPR 31) s0 - 16#64) 16 →
-    s_final[addr, n] = s0[addr, n]) := by
-  simp_all only [state_simp_rules, -h_run] -- prelude
-  sym_n 27 -- Symbolic simulation
-  repeat' apply And.intro -- split conjunction.
-  · simp only [popcount32_spec, popcount32_spec_rec]
+  (h_s0_err        : read_err s0 = StateError.None)
+  (h_run           : sf = run 27 s0) :
+  -- The final state `sf` is error-free.
+  read_err sf = StateError.None ∧
+  -- Register `w0` in `sf` contains the correct value.
+  w0 sf = popcount32_spec (w0 s0) ∧
+  -- The frame condition describes which state components are not affected by
+  -- this program's execution.
+  REGS_UNCHANGED_EXCEPT [[(.GPR 0), (.GPR 1), .SP, .PC]] (sf, s0) ∧
+  MEM_UNCHANGED_EXCEPT  [[((r .SP s0 - 16#64), 16)]]     (sf, s0) := by
+  -- Prelude
+  simp_all only [state_simp_rules, -h_run]
+  -- Symbolic simulation
+  sym_n 27
+   -- TODO(@bollu): automation for SP alignment
+  case h_s1_sp_aligned =>
+    apply Aligned_BitVecSub_64_4 (by assumption) (by decide)
+  case h_s26_sp_aligned =>
+    apply Aligned_BitVecAdd_64_4 (by assumption) (by decide)
+  -- Split the conclusion
+  repeat' apply And.intro
+  · -- Functional Correctness
+    simp only [popcount32_spec, popcount32_spec_rec]
     bv_decide
-  · sym_aggregate
-  · intro n addr h_separate
+  · -- Register Frame Condition
+    simp; sym_aggregate
+  · -- Memory Frame Condition
+    intro n addr h_separate
     simp only [memory_rules] at *
     repeat (simp_mem (config := { useOmegaToClose := false }); sym_aggregate)
-  · apply Aligned_BitVecSub_64_4 -- TODO(@bollu): automation
-    · assumption
-    · decide
-  · apply Aligned_BitVecAdd_64_4
-    · assumption
-    · decide
+  done
 
 /--
 info: 'popcount32_sym_meets_spec' depends on axioms:
@@ -107,21 +113,5 @@ info: 'popcount32_sym_meets_spec' depends on axioms:
 #guard_msgs in #print axioms popcount32_sym_meets_spec
 
 -------------------------------------------------------------------------------
-
-/-! ## Tests for step theorem generation -/
-section Tests
-
-/--
-info: popcount32_program.stepi_eq_0x4005c0 {s : ArmState} (h_program : s.program = popcount32_program)
-  (h_pc : r StateField.PC s = 4195776#64) (h_err : r StateField.ERR s = StateError.None) :
-  stepi s =
-    w StateField.PC (4195780#64)
-      (w (StateField.GPR 0#5)
-        (zeroExtend 64 ((zeroExtend 32 (r (StateField.GPR 0#5) s)).rotateRight 1) &&& 4294967295#64 &&& 2147483647#64)
-        s)
--/
-#guard_msgs in #check popcount32_program.stepi_eq_0x4005c0
-
-end Tests
 
 end popcount32

--- a/Proofs/Popcount32.lean
+++ b/Proofs/Popcount32.lean
@@ -82,8 +82,8 @@ theorem popcount32_sym_meets_spec (s0 sf : ArmState)
   w0 sf = popcount32_spec (w0 s0) ∧
   -- The frame condition describes which state components are not affected by
   -- this program's execution.
-  REGS_UNCHANGED_EXCEPT [[(.GPR 0), (.GPR 1), .SP, .PC]] (sf, s0) ∧
-  MEM_UNCHANGED_EXCEPT  [[((r .SP s0 - 16#64), 16)]]     (sf, s0) := by
+  REGS_UNCHANGED_EXCEPT [(.GPR 0), (.GPR 1), .SP, .PC] (sf, s0) ∧
+  MEM_UNCHANGED_EXCEPT  [((r .SP s0 - 16#64), 16)]     (sf, s0) := by
   -- Prelude
   simp_all only [state_simp_rules, -h_run]
   -- Symbolic simulation
@@ -99,7 +99,7 @@ theorem popcount32_sym_meets_spec (s0 sf : ArmState)
     simp only [popcount32_spec, popcount32_spec_rec]
     bv_decide
   · -- Register Frame Condition
-    simp; sym_aggregate
+    simp only [List.mem_cons, List.mem_singleton, not_or, and_imp]; sym_aggregate
   · -- Memory Frame Condition
     intro n addr h_separate
     simp only [memory_rules] at *

--- a/Tactics/StepThms.lean
+++ b/Tactics/StepThms.lean
@@ -204,6 +204,7 @@ def genStepEqTheorems : StepThmsM Unit := do
       name, type, value,
       levelParams := []
     }
+    trace[gen_step.print_names] "[genStepEqTheorems] Theorem added: {name}"
     trace[gen_step.debug.timing] "[genStepEqTheorems] added to environment in: {(← IO.monoMsNow) - startTime}ms"
 
 /-- `#genProgramInfo program` ensures the `ProgramInfo` for `program`


### PR DESCRIPTION
### Description:

Introduce syntax for stating register and memory frame conditions, which specify exactly which state components are not affected by the program's execution.

The popcount proof is modified to use this new syntax.

Also: use `gen_step.print_names` option to print generated stepi theorems' names.

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine?

Yes

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
