### PR TITLE
refactor: remove `SymContext.h_sp?`, replacing uses with the corresponding `AxEffects` field

### DIFF
--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -279,19 +279,18 @@ def sym1 (whileTac : TSyntax `tactic) : SymM Unit := do
     -- `simp` here
     withMainContext' <| do
       let hStep ← SymContext.findFromUserName h_step.getId
-      let lctx ← getLCtx
-      let decls := (← getThe SymContext).h_sp?.bind lctx.findFromUserName?
+      let decls := (← getThe AxEffects).stackAlignmentProof?
       let decls := decls.toArray
       -- If we know SP is aligned, `simp` with that fact
 
       if !decls.isEmpty then
         trace[Tactic.sym] "simplifying {hStep.toExpr} \
-          with {decls.map (·.toExpr)}"
+          with {decls}"
         -- If `decls` is empty, we have no more knowledge than before, so
         -- everything that could've been `simp`ed, already should have been
         let some goal ← do
             let (ctx, simprocs) ← LNSymSimpContext
-              (config := {decide := false}) (decls := decls)
+              (config := {decide := false}) (exprs := decls)
             let goal ← getMainGoal
             LNSymSimp goal ctx simprocs hStep.fvarId
           | throwError "internal error: simp closed goal unexpectedly"

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -277,18 +277,14 @@ def sym1 (whileTac : TSyntax `tactic) : SymM Unit := do
     -- `simp` here
     withMainContext' <| do
       let hStep ← SymContext.findFromUserName h_step.getId
-      let decls := (← getThe AxEffects).stackAlignmentProof?
-      let decls := decls.toArray
-      -- If we know SP is aligned, `simp` with that fact
 
-      if !decls.isEmpty then
+      -- If we know SP is aligned, `simp` with that fact
+      if let some hSp := (← getThe AxEffects).stackAlignmentProof? then
         trace[Tactic.sym] "simplifying {hStep.toExpr} \
-          with {decls}"
-        -- If `decls` is empty, we have no more knowledge than before, so
-        -- everything that could've been `simp`ed, already should have been
+          with {hSp}"
         let some goal ← do
             let (ctx, simprocs) ← LNSymSimpContext
-              (config := {decide := false}) (exprs := decls)
+              (config := {decide := false}) (exprs := #[hSp])
             let goal ← getMainGoal
             LNSymSimp goal ctx simprocs hStep.fvarId
           | throwError "internal error: simp closed goal unexpectedly"

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -182,10 +182,8 @@ def explodeStep (hStep : Expr) : SymM Unit :=
     eff ← eff.withProgramEq c.effects.programProof
     eff ← eff.withField (← c.effects.getField .ERR).proof
 
-    if let some h_sp := c.h_sp? then
-      let hSp ← SymContext.findFromUserName h_sp
-      -- let effWithSp?
-      eff ← match ← eff.withStackAlignment? hSp.toExpr with
+    if let some hSp := c.effects.stackAlignmentProof? then
+      eff ← match ← eff.withStackAlignment? hSp with
         | some newEff => pure newEff
         | none => do
             trace[Tactic.sym] "failed to show stack alignment"
@@ -210,7 +208,7 @@ def explodeStep (hStep : Expr) : SymM Unit :=
               let (ctx, simprocs) ←
                 LNSymSimpContext
                   (config := {failIfUnchanged := false, decide := true})
-                  (decls := #[hSp])
+                  (exprs := #[hSp])
               LNSymSimp subGoal ctx simprocs
 
             if let some subGoal := subGoal? then

--- a/Tactics/Sym/Context.lean
+++ b/Tactics/Sym/Context.lean
@@ -77,9 +77,6 @@ structure SymContext where
   and we assume that no overflow happens
   (i.e., `base - x` can never be equal to `base + y`) -/
   pc : BitVec 64
-  /-- `h_sp?`, if present, is a local hypothesis of the form
-  `CheckSPAlignment state` -/
-  h_sp?  : Option Name
 
   /-- The `simp` context used for effect aggregation.
   This collects references to all (non-)effect hypotheses of the intermediate
@@ -197,14 +194,12 @@ end
 This is not a `ToMessageData` instance because we need access to `MetaM` -/
 def toMessageData (c : SymContext) : MetaM MessageData := do
   let h_run ← userNameToMessageData c.h_run
-  let h_sp?  ← c.h_sp?.mapM userNameToMessageData
 
   return m!"\{ finalState := {c.finalState},
   runSteps? := {c.runSteps?},
   h_run := {h_run},
   program := {c.program},
   pc := {c.pc},
-  h_sp? := {h_sp?},
   state_prefix := {c.state_prefix},
   curr_state_number := {c.currentStateNumber},
   effects := {c.effects} }"
@@ -265,7 +260,6 @@ private def initial (state : Expr) : MetaM SymContext := do
       instructions := ∅
     }
     pc := 0
-    h_sp? := none
     aggregateSimpCtx,
     aggregateSimprocs,
     effects := AxEffects.initial state
@@ -401,9 +395,6 @@ protected def searchFor : SearchLCtxForM SymM Unit := do
       modifyThe AxEffects ({ · with
         stackAlignmentProof? := some decl.toExpr
       })
-      modifyThe SymContext ({· with
-        h_sp? := decl.userName
-      })
     )
 
   /- TODO(@alexkeizer): search for any other hypotheses of the form
@@ -458,7 +449,6 @@ evaluation:
   * the `currentStateNumber` is incremented
 -/
 def prepareForNextStep : SymM Unit := do
-  let s ← getNextStateName
   let pc ← do
     let { value, ..} ← AxEffects.getFieldM .PC
     try
@@ -469,7 +459,6 @@ def prepareForNextStep : SymM Unit := do
 
   modifyThe SymContext (fun c => { c with
     pc
-    h_sp?       := c.h_sp?.map (fun _ => .mkSimple s!"h_{s}_sp_aligned")
     runSteps?   := (· - 1) <$> c.runSteps?
     currentStateNumber := c.currentStateNumber + 1
   })


### PR DESCRIPTION
### Description:

Benchmarks suggest this could be marginally slower than before (the SHA512_400 benchmark slowed down from 19.0 to 19.2 second, i.e., within noise levels).

Still, it's a good change to make, because it will make effect aggregation easier.

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine? Yes

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
