### PR TITLE
BLOCKED: feat: `withInstantiatMainGoal` combinator to eagerly instantiate goal metavariables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /lake-packages/*
 /.lake/*
 *.log
+/data/*

--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -221,19 +221,31 @@ def CheckSPAlignment (s : ArmState) : Prop :=
 instance : Decidable (CheckSPAlignment s) := by unfold CheckSPAlignment; infer_instance
 
 @[state_simp_rules]
-theorem CheckSPAligment_of_w_different (h : StateField.GPR 31#5 ≠ fld) :
+theorem CheckSPAligment_w_different_eq (h : StateField.GPR 31#5 ≠ fld) :
   CheckSPAlignment (w fld v s) = CheckSPAlignment s := by
   simp_all only [CheckSPAlignment, state_simp_rules, minimal_theory, bitvec_rules]
+
+theorem CheckSPAligment_w_of_ne_sp_of (h : StateField.GPR 31#5 ≠ fld) :
+    CheckSPAlignment s → CheckSPAlignment (w fld v s) := by
+  simp only [CheckSPAligment_w_different_eq h, imp_self]
 
 @[state_simp_rules]
 theorem CheckSPAligment_of_w_sp :
   CheckSPAlignment (w (StateField.GPR 31#5) v s) = (Aligned v 4) := by
   simp_all only [CheckSPAlignment, state_simp_rules, minimal_theory, bitvec_rules]
 
+theorem CheckSPAligment_w_sp_of (h : Aligned v 4) :
+    CheckSPAlignment (w (StateField.GPR 31#5) v s) := by
+  simp only [CheckSPAlignment, read_gpr, r_of_w_same, zeroExtend_eq, h]
+
 @[state_simp_rules]
-theorem CheckSPAligment_of_write_mem_bytes :
+theorem CheckSPAligment_write_mem_bytes_eq :
   CheckSPAlignment (write_mem_bytes n addr v s) = CheckSPAlignment s := by
   simp_all only [CheckSPAlignment, state_simp_rules, minimal_theory, bitvec_rules]
+
+theorem CheckSPAligment_write_mem_bytes_of :
+  CheckSPAlignment s → CheckSPAlignment (write_mem_bytes n addr v s) := by
+  simp only [CheckSPAligment_write_mem_bytes_eq, imp_self]
 
 @[state_simp_rules]
 theorem CheckSPAlignment_AddWithCarry_64_4 (st : ArmState) (y : BitVec 64) (carry_in : BitVec 1)

--- a/Benchmarks.lean
+++ b/Benchmarks.lean
@@ -3,6 +3,11 @@ Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author(s): Alex Keizer
 -/
+import Benchmarks.SHA512_75
+import Benchmarks.SHA512_75_noKernel_noLint
 import Benchmarks.SHA512_150
+import Benchmarks.SHA512_150_noKernel_noLint
 import Benchmarks.SHA512_225
+import Benchmarks.SHA512_225_noKernel_noLint
 import Benchmarks.SHA512_400
+import Benchmarks.SHA512_400_noKernel_noLint

--- a/Benchmarks/Command.lean
+++ b/Benchmarks/Command.lean
@@ -60,6 +60,7 @@ elab "benchmark" id:ident declSig:optDeclSig val:declVal : command => do
 
   if (← getBoolOption `profiler) then
     opts := opts.setBool `trace.profiler true
+    opts := opts.setNat `trace.profiler.threshold 1
     n := 1 -- only run once, if `profiler` is set to true
   else
     opts := opts.setBool `trace.benchmark true

--- a/Benchmarks/SHA512_150_noKernel_noLint.lean
+++ b/Benchmarks/SHA512_150_noKernel_noLint.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
+import Tactics.Sym
+import Benchmarks.Command
+import Benchmarks.SHA512
+
+open Benchmarks
+
+disable_linters in
+set_option debug.skipKernelTC true in
+benchmark sha512_150_noKernel_noLint : SHA512Bench 150 := fun s0 _ h => by
+  intros
+  sym_n 150
+  simp only [h, bitvec_rules]
+  · exact (sorry : Aligned ..)
+  done

--- a/Benchmarks/SHA512_225_noKernel_noLint.lean
+++ b/Benchmarks/SHA512_225_noKernel_noLint.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
+import Tactics.Sym
+import Benchmarks.Command
+import Benchmarks.SHA512
+
+open Benchmarks
+
+disable_linters in
+set_option debug.skipKernelTC true in
+benchmark sha512_225_noKernel_noLint : SHA512Bench 225 := fun s0 _ h => by
+  intros
+  sym_n 225
+  simp only [h, bitvec_rules]
+  · exact (sorry : Aligned ..)
+  done

--- a/Benchmarks/SHA512_400_noKernel_noLint.lean
+++ b/Benchmarks/SHA512_400_noKernel_noLint.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
+import Tactics.Sym
+import Benchmarks.Command
+import Benchmarks.SHA512
+
+open Benchmarks
+
+disable_linters in
+set_option debug.skipKernelTC true in
+benchmark sha512_400_noKernel_noLint : SHA512Bench 400 := fun s0 _ h => by
+  intros
+  sym_n 400
+  simp only [h, bitvec_rules]
+  · exact (sorry : Aligned ..)
+  done

--- a/Benchmarks/SHA512_75.lean
+++ b/Benchmarks/SHA512_75.lean
@@ -1,0 +1,17 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
+import Tactics.Sym
+import Benchmarks.Command
+import Benchmarks.SHA512
+
+open Benchmarks
+
+benchmark sha512_75 : SHA512Bench 75 := fun s0 _ h => by
+  intros
+  sym_n 75
+  simp only [h, bitvec_rules]
+  · exact (sorry : Aligned ..)
+  done

--- a/Benchmarks/SHA512_75_noKernel_noLint.lean
+++ b/Benchmarks/SHA512_75_noKernel_noLint.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
+import Tactics.Sym
+import Benchmarks.Command
+import Benchmarks.SHA512
+
+open Benchmarks
+
+disable_linters in
+set_option debug.skipKernelTC true in
+benchmark sha512_75_noKernel_noLint : SHA512Bench 75 := fun s0 _ h => by
+  intros
+  sym_n 75
+  simp only [h, bitvec_rules]
+  · exact (sorry : Aligned ..)
+  done

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 SHELL := /bin/bash
 
 LAKE = lake
+LEAN = $(LAKE) env lean
+GIT = git
 
 NUM_TESTS?=3
 VERBOSE?=--verbose
@@ -37,9 +39,22 @@ awslc_elf:
 cosim:
 	time -p lake exe lnsym $(VERBOSE) --num-tests $(NUM_TESTS)
 
+BENCHMARKS = Benchmarks/SHA512_75.lean \
+	Benchmarks/SHA512_75_noKernel_noLint.lean \
+	Benchmarks/SHA512_150.lean \
+	Benchmarks/SHA512_150_noKernel_noLint.lean \
+	Benchmarks/SHA512_225.lean \
+	Benchmarks/SHA512_225_noKernel_noLint.lean \
+	Benchmarks/SHA512_400.lean \
+	Benchmarks/SHA512_400_noKernel_noLint.lean
+
 .PHONY: benchmarks
 benchmarks:
-	$(LAKE) build Benchmarks
+	./scripts/benchmark.sh $(BENCHMARKS)
+
+.PHONY: profile
+profile:
+	./scripts/profile.sh $(BENCHMARKS)
 
 .PHONY: clean clean_all
 clean:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ native-code programs of interest.
 
 `benchmarks`: run benchmarks for the symbolic simulator.
 
+`profiler`: run a single round of each benchmark, with the profiler enabled
+
 ### Makefile variables that can be passed in at the command line
 
 `VERBOSE`: Verbose mode; prints disassembly of the instructions being

--- a/Tactics/Attr.lean
+++ b/Tactics/Attr.lean
@@ -9,8 +9,11 @@ open Lean
 initialize
   -- CSE tactic's non-verbose summary logging.
   registerTraceClass `Tactic.cse.summary
+
   -- enable tracing for `sym_n` tactic and related components
   registerTraceClass `Tactic.sym
+  -- enable verbose tracing
+  registerTraceClass `Tactic.sym.debug
 
   -- enable tracing for heartbeat usage of `sym_n`
   registerTraceClass `Tactic.sym.heartbeats

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -279,19 +279,18 @@ def sym1 (whileTac : TSyntax `tactic) : SymM Unit := do
     -- `simp` here
     withMainContext' <| do
       let hStep ← SymContext.findFromUserName h_step.getId
-      let lctx ← getLCtx
-      let decls := (← getThe SymContext).h_sp?.bind lctx.findFromUserName?
+      let decls := (← getThe AxEffects).stackAlignmentProof?
       let decls := decls.toArray
       -- If we know SP is aligned, `simp` with that fact
 
       if !decls.isEmpty then
         trace[Tactic.sym] "simplifying {hStep.toExpr} \
-          with {decls.map (·.toExpr)}"
+          with {decls}"
         -- If `decls` is empty, we have no more knowledge than before, so
         -- everything that could've been `simp`ed, already should have been
         let some goal ← do
             let (ctx, simprocs) ← LNSymSimpContext
-              (config := {decide := false}) (decls := decls)
+              (config := {decide := false}) (exprs := decls)
             let goal ← getMainGoal
             LNSymSimp goal ctx simprocs hStep.fvarId
           | throwError "internal error: simp closed goal unexpectedly"

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -277,18 +277,14 @@ def sym1 (whileTac : TSyntax `tactic) : SymM Unit := do
     -- `simp` here
     withMainContext' <| do
       let hStep ← SymContext.findFromUserName h_step.getId
-      let decls := (← getThe AxEffects).stackAlignmentProof?
-      let decls := decls.toArray
-      -- If we know SP is aligned, `simp` with that fact
 
-      if !decls.isEmpty then
+      -- If we know SP is aligned, `simp` with that fact
+      if let some hSp := (← getThe AxEffects).stackAlignmentProof? then
         trace[Tactic.sym] "simplifying {hStep.toExpr} \
-          with {decls}"
-        -- If `decls` is empty, we have no more knowledge than before, so
-        -- everything that could've been `simp`ed, already should have been
+          with {hSp}"
         let some goal ← do
             let (ctx, simprocs) ← LNSymSimpContext
-              (config := {decide := false}) (exprs := decls)
+              (config := {decide := false}) (exprs := #[hSp])
             let goal ← getMainGoal
             LNSymSimp goal ctx simprocs hStep.fvarId
           | throwError "internal error: simp closed goal unexpectedly"

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -367,7 +367,8 @@ in which case a new goal of the appropriate type will be added.
 The other hypotheses *must* be present,
 since we infer required information from their types. -/
 elab "sym_n" whileTac?:(sym_while)? n:num s:(sym_at)? : tactic =>
-  withTraceNode "" (tag := "sym_n") <| do
+  withTraceNode "" (tag := "sym_n") <|
+  withInstantiateMainGoal <| do
   traceHeartbeats "initial heartbeats"
 
   let s ← s.mapM fun
@@ -386,7 +387,6 @@ elab "sym_n" whileTac?:(sym_while)? n:num s:(sym_at)? : tactic =>
 
   let c ← SymContext.fromMainContext s
   SymM.run' c <|
-  withInstantiateMainGoal <|
   withMainContext' <|  do
     -- Check pre-conditions
     assertStepTheoremsGenerated

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -182,10 +182,8 @@ def explodeStep (hStep : Expr) : SymM Unit :=
     eff ← eff.withProgramEq c.effects.programProof
     eff ← eff.withField (← c.effects.getField .ERR).proof
 
-    if let some h_sp := c.h_sp? then
-      let hSp ← SymContext.findFromUserName h_sp
-      -- let effWithSp?
-      eff ← match ← eff.withStackAlignment? hSp.toExpr with
+    if let some hSp := c.effects.stackAlignmentProof? then
+      eff ← match ← eff.withStackAlignment? hSp with
         | some newEff => pure newEff
         | none => do
             trace[Tactic.sym] "failed to show stack alignment"
@@ -210,7 +208,7 @@ def explodeStep (hStep : Expr) : SymM Unit :=
               let (ctx, simprocs) ←
                 LNSymSimpContext
                   (config := {failIfUnchanged := false, decide := true})
-                  (decls := #[hSp])
+                  (exprs := #[hSp])
               LNSymSimp subGoal ctx simprocs
 
             if let some subGoal := subGoal? then

--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -233,6 +233,7 @@ context `c`, returning the context for the next step in simulation. -/
 def sym1 (whileTac : TSyntax `tactic) : SymM Unit := do
   let stateNumber ← getCurrentStateNumber
   withTraceNode m!"(sym1): simulating step {stateNumber}" (tag:="sym1") <|
+  withInstantiateMainGoal <|
   withMainContext' do
     withVerboseTraceNode "verbose context" (tag := "infoDump") <| do
       traceSymContext
@@ -365,7 +366,8 @@ Hypotheses `h_err` and `h_sp` may be missing,
 in which case a new goal of the appropriate type will be added.
 The other hypotheses *must* be present,
 since we infer required information from their types. -/
-elab "sym_n" whileTac?:(sym_while)? n:num s:(sym_at)? : tactic => do
+elab "sym_n" whileTac?:(sym_while)? n:num s:(sym_at)? : tactic =>
+  withTraceNode "" (tag := "sym_n") <| do
   traceHeartbeats "initial heartbeats"
 
   let s ← s.mapM fun
@@ -383,7 +385,9 @@ elab "sym_n" whileTac?:(sym_while)? n:num s:(sym_at)? : tactic => do
         ))
 
   let c ← SymContext.fromMainContext s
-  SymM.run' c <| withMainContext' <|  do
+  SymM.run' c <|
+  withInstantiateMainGoal <|
+  withMainContext' <|  do
     -- Check pre-conditions
     assertStepTheoremsGenerated
     let n ← ensureAtMostRunSteps n.getNat

--- a/Tactics/Sym/AxEffects.lean
+++ b/Tactics/Sym/AxEffects.lean
@@ -78,6 +78,10 @@ structure AxEffects where
   However, if SP is written to, no effort is made to prove alignment of the
   new value; the field will be set to `none` -/
   stackAlignmentProof? : Option Expr
+
+  /-- `sideContitions` are proof obligations that come up during effect
+  characterization. -/
+  sideConditions : List MVarId
   deriving Repr
 
 namespace AxEffects
@@ -141,6 +145,7 @@ def initial (state : Expr) : AxEffects where
       mkConst ``Program,
       mkApp (mkConst ``ArmState.program) state]
   stackAlignmentProof? := none
+  sideConditions := []
 
 /-! ## ToMessageData -/
 
@@ -304,6 +309,11 @@ private def update_write_mem (eff : AxEffects) (n addr val : Expr) :
         #[eff.currentState, n, addr, val])
       eff.programProof
 
+  -- Update the stack alignment proof
+  let stackAlignmentProof? := eff.stackAlignmentProof?.map fun proof =>
+    mkAppN (mkConst ``CheckSPAligment_write_mem_bytes_of)
+      #[eff.currentState, n, addr, val, proof]
+
   -- Assemble the result
   let addWrite (e : Expr) :=
     -- `@write_mem_bytes <n> <addr> <val> <e>`
@@ -315,6 +325,7 @@ private def update_write_mem (eff : AxEffects) (n addr val : Expr) :
     memoryEffect    := addWrite eff.memoryEffect
     memoryEffectProof
     programProof
+    stackAlignmentProof?
   }
   withTraceNode `Tactic.sym (fun _ => pure "new state") <| do
       trace[Tactic.sym] "{eff}"
@@ -398,6 +409,24 @@ private def update_w (eff : AxEffects) (fld val : Expr) :
       (mkAppN (mkConst ``w_program) #[fld, val, eff.currentState])
       eff.programProof
 
+  -- Update the stack alignment proof
+  let mut sideConditions := eff.sideConditions
+  let mut stackAlignmentProof? := eff.stackAlignmentProof?
+  if let some proof := stackAlignmentProof? then
+    if rField ≠ StateField.SP then
+      let hNeq ← mkDecideProof <|
+        mkApp3 (.const ``Ne [1])
+          (mkConst ``StateField) (toExpr StateField.SP) fld
+      stackAlignmentProof? := mkAppN (mkConst ``CheckSPAligment_w_of_ne_sp_of)
+        #[fld, eff.currentState, val, hNeq, proof]
+    else
+      let hAligned ← mkFreshExprMVar (some <|
+        mkApp3 (mkConst ``Aligned) (toExpr 64) val (toExpr 4)
+      )
+      sideConditions := hAligned.mvarId! :: sideConditions
+      stackAlignmentProof? := mkAppN (mkConst ``CheckSPAligment_w_sp_of)
+        #[val, eff.currentState, hAligned]
+
   -- Assemble the result
   let eff := { eff with
     currentState    := mkApp3 (mkConst ``w) fld val eff.currentState
@@ -406,6 +435,8 @@ private def update_w (eff : AxEffects) (fld val : Expr) :
     -- memory effects are unchanged
     memoryEffectProof
     programProof
+    stackAlignmentProof?
+    sideConditions
   }
   eff.traceCurrentState "new state"
   return eff
@@ -477,9 +508,12 @@ def adjustCurrentStateWithEq (eff : AxEffects) (s eq : Expr) :
     -- ^^ TODO: what happens if `memoryEffect` is the same as `currentState`?
     --    Presumably, we would *not* want to encapsulate `memoryEffect` here
     let programProof ← rewriteType eff.programProof eq
+    let stackAlignmentProof? ← eff.stackAlignmentProof?.mapM
+      (rewriteType · eq)
 
     return { eff with
-      currentState, fields, nonEffectProof, memoryEffectProof, programProof
+      currentState, fields, nonEffectProof, memoryEffectProof, programProof,
+      stackAlignmentProof?
     }
 
 /-- Given a proof `eq : ?s = <sequence of w/write_mem to eff.currentState>`,
@@ -503,10 +537,14 @@ def updateWithEq (eff : AxEffects) (eq : Expr) : MetaM AxEffects :=
 where `?s` and `?s0` are arbitrary `ArmState`s,
 return an `AxEffect` with `?s0` as the initial state,
 the rhs of the equality as the current state,
-and the (non-)effects updated accordingly -/
-def fromEq (eq : Expr) : MetaM AxEffects := do
+and the (non-)effects updated accordingly
+
+One can optionally pass in a proof that `?s0` has a well-aligned stack pointer.
+-/
+def fromEq (eq : Expr) (stackAlignmentProof? : Option Expr := none) :
+    MetaM AxEffects := do
   let s0 ← mkFreshExprMVar mkArmState
-  let eff := initial s0
+  let eff := { initial s0 with stackAlignmentProof? }
   let eff ← eff.updateWithEq eq
   return { eff with initialState := ← instantiateMVars eff.initialState}
 
@@ -569,34 +607,6 @@ def withField (eff : AxEffects) (eq : Expr) : MetaM AxEffects := do
       let proof ← mkEqMP valEq fieldEff.proof
       let fields := eff.fields.insert field { value, proof }
       return { eff with fields }
-
-/-- Given a proof of `CheckSPAlignment <initialState>`,
-attempt to transport it to a proof of `CheckSPAlignment <currentState>`
-and store that proof in `stackAlignmentProof?`.
-
-Returns `none` if the proof failed to be transported,
-i.e., if SP was written to. -/
-def withStackAlignment? (eff : AxEffects) (spAlignment : Expr) :
-    MetaM (Option AxEffects) := do
-  let msg := m!"withInitialStackAlignment? {spAlignment}"
-  withTraceNode `Tactic.sym (fun _ => pure msg) <| do
-    eff.traceCurrentState
-
-    let { value, proof } ← eff.getField StateField.SP
-    let expected :=
-      mkApp2 (mkConst ``r) (toExpr <| StateField.SP) eff.initialState
-    trace[Tactic.sym] "checking whether value:\n  {value}\n\
-      is syntactically equal to expected value\n  {expected}"
-    if value != expected then
-      trace[Tactic.sym] "failed to transport proof:
-        expected value to be {expected}, but found {value}"
-      return none
-
-    let stackAlignmentProof? := some <|
-      mkAppN (mkConst ``CheckSPAlignment_of_r_sp_eq)
-        #[eff.initialState, eff.currentState, proof, spAlignment]
-    trace[Tactic.sym] "constructed stackAlignmentProof: {stackAlignmentProof?}"
-    return some { eff with stackAlignmentProof? }
 
 /-! ## Composition -/
 

--- a/Tactics/Sym/Context.lean
+++ b/Tactics/Sym/Context.lean
@@ -77,9 +77,6 @@ structure SymContext where
   and we assume that no overflow happens
   (i.e., `base - x` can never be equal to `base + y`) -/
   pc : BitVec 64
-  /-- `h_sp?`, if present, is a local hypothesis of the form
-  `CheckSPAlignment state` -/
-  h_sp?  : Option Name
 
   /-- The `simp` context used for effect aggregation.
   This collects references to all (non-)effect hypotheses of the intermediate
@@ -197,14 +194,12 @@ end
 This is not a `ToMessageData` instance because we need access to `MetaM` -/
 def toMessageData (c : SymContext) : MetaM MessageData := do
   let h_run ← userNameToMessageData c.h_run
-  let h_sp?  ← c.h_sp?.mapM userNameToMessageData
 
   return m!"\{ finalState := {c.finalState},
   runSteps? := {c.runSteps?},
   h_run := {h_run},
   program := {c.program},
   pc := {c.pc},
-  h_sp? := {h_sp?},
   state_prefix := {c.state_prefix},
   curr_state_number := {c.currentStateNumber},
   effects := {c.effects} }"
@@ -265,7 +260,6 @@ private def initial (state : Expr) : MetaM SymContext := do
       instructions := ∅
     }
     pc := 0
-    h_sp? := none
     aggregateSimpCtx,
     aggregateSimprocs,
     effects := AxEffects.initial state
@@ -401,9 +395,6 @@ protected def searchFor : SearchLCtxForM SymM Unit := do
       modifyThe AxEffects ({ · with
         stackAlignmentProof? := some decl.toExpr
       })
-      modifyThe SymContext ({· with
-        h_sp? := decl.userName
-      })
     )
 
   /- TODO(@alexkeizer): search for any other hypotheses of the form
@@ -458,7 +449,6 @@ evaluation:
   * the `currentStateNumber` is incremented
 -/
 def prepareForNextStep : SymM Unit := do
-  let s ← getNextStateName
   let pc ← do
     let { value, ..} ← AxEffects.getFieldM .PC
     try
@@ -469,7 +459,6 @@ def prepareForNextStep : SymM Unit := do
 
   modifyThe SymContext (fun c => { c with
     pc
-    h_sp?       := c.h_sp?.map (fun _ => .mkSimple s!"h_{s}_sp_aligned")
     runSteps?   := (· - 1) <$> c.runSteps?
     currentStateNumber := c.currentStateNumber + 1
   })

--- a/Tactics/Sym/Context.lean
+++ b/Tactics/Sym/Context.lean
@@ -146,6 +146,26 @@ end SymM
 
 namespace SymContext
 
+/-! ## Trace Nodes -/
+section Tracing
+variable {α : Type} {m : Type → Type} [Monad m] [MonadTrace m] [MonadLiftT IO m]
+  [MonadRef m] [AddMessageContext m] [MonadOptions m] {ε : Type}
+  [MonadAlwaysExcept ε m] [MonadLiftT BaseIO m]
+
+def withTraceNode (msg : MessageData) (k : m α)
+    (collapsed : Bool := true)
+    (tag : String := "")
+    : m α := do
+  Lean.withTraceNode `Tactic.sym (fun _ => pure msg) k collapsed tag
+
+def withVerboseTraceNode (msg : MessageData) (k : m α)
+    (collapsed : Bool := true)
+    (tag : String := "")
+    : m α := do
+  Lean.withTraceNode `Tactic.sym.verbose (fun _ => pure msg) k collapsed tag
+
+end Tracing
+
 /-! ## Simple projections -/
 section
 open Lean (Ident mkIdent)
@@ -156,10 +176,11 @@ def program : Name := c.programInfo.name
 
 /-- Find the local declaration that corresponds to a given name,
 or throw an error if no local variable of that name exists -/
-def findFromUserName (name : Name) : MetaM LocalDecl := do
-  let some decl := (← getLCtx).findFromUserName? name
-    | throwError "Unknown local variable `{name}`"
-  return decl
+def findFromUserName (name : Name) : MetaM LocalDecl :=
+  withVerboseTraceNode m!"[findFromUserName] {name}" <| do
+    let some decl := (← getLCtx).findFromUserName? name
+      | throwError "Unknown local variable `{name}`"
+    return decl
 
 /-- Find the local declaration that corresponds to `c.h_run`,
 or throw an error if no local variable of that name exists -/
@@ -204,22 +225,12 @@ def toMessageData (c : SymContext) : MetaM MessageData := do
   curr_state_number := {c.currentStateNumber},
   effects := {c.effects} }"
 
-section Tracing
-variable {α : Type} {m : Type → Type} [Monad m] [MonadTrace m] [MonadLiftT IO m]
-  [MonadRef m] [AddMessageContext m] [MonadOptions m] {ε : Type}
-  [MonadAlwaysExcept ε m] [MonadLiftT BaseIO m]
-
-def withTraceNode (msg : MessageData) (k : m α) : m α := do
-  Lean.withTraceNode `Tactic.sym (fun _ => pure msg) k
-def withVerboseTraceNode (msg : MessageData) (k : m α) : m α := do
-  Lean.withTraceNode `Tactic.sym.verbose (fun _ => pure msg) k
-
 def traceSymContext : SymM Unit :=
   withTraceNode m!"SymContext: " <| do
     let m ← (← getThe SymContext).toMessageData
     trace[Tactic.sym] m
 
-end Tracing
+
 
 /-! ## Adding new simp theorems for aggregation -/
 
@@ -422,7 +433,7 @@ we create a new subgoal of this type.
 -/
 def fromMainContext (state? : Option Name) : TacticM SymContext := do
   let msg := m!"Building a `SymContext` from the local context"
-  withTraceNode msg <| withMainContext' do
+  withTraceNode msg (tag := "fromMainContext") <| withMainContext' do
   trace[Tactic.Sym] "state? := {state?}"
   let lctx ← getLCtx
 
@@ -455,16 +466,17 @@ evaluation:
   * the `currentStateNumber` is incremented
 -/
 def prepareForNextStep : SymM Unit := do
-  let pc ← do
-    let { value, ..} ← AxEffects.getFieldM .PC
-    try
-      reflectBitVecLiteral 64 value
-    catch err =>
-      trace[Tactic.sym] "failed to reflect PC: {err.toMessageData}"
-      pure <| (← getThe SymContext).pc + 4
+  withVerboseTraceNode "prepareForNextStep" (tag := "prepareForNextStep") <| do
+    let pc ← do
+      let { value, ..} ← AxEffects.getFieldM .PC
+      try
+        reflectBitVecLiteral 64 value
+      catch err =>
+        trace[Tactic.sym] "failed to reflect PC: {err.toMessageData}"
+        pure <| (← getThe SymContext).pc + 4
 
-  modifyThe SymContext (fun c => { c with
-    pc
-    runSteps?   := (· - 1) <$> c.runSteps?
-    currentStateNumber := c.currentStateNumber + 1
-  })
+    modifyThe SymContext (fun c => { c with
+      pc
+      runSteps?   := (· - 1) <$> c.runSteps?
+      currentStateNumber := c.currentStateNumber + 1
+    })

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -33,6 +33,7 @@ lean_lib «Doc» where
   -- add library configuration options here
 
 lean_lib «Benchmarks» where
+  leanOptions := #[⟨`weak.benchmark.runs, (0 : Nat)⟩]
   -- add library configuration options here
 
 @[default_target]

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+LAKE=lake
+BENCH="$LAKE env lean -Dweak.benchmark.runs=5"
+OUT="data/benchmarks"
+
+timestamp=$(date +"%Y-%m-%d_%H%M%S")
+rev=$(git rev-parse --short HEAD)
+echo "HEAD is on $rev"
+out="$OUT/${timestamp}_${rev}"
+mkdir -p "$out"
+
+$LAKE build Benchmarks
+for file in "$@"; do
+    echo
+    echo + $file
+    echo
+    base="$(basename "$file" ".lean")"
+    $BENCH $file | tee "$out/$base"
+done

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+LAKE=lake
+PROF="$LAKE env lean -Dprofiler=true"
+OUT="data/profiles"
+
+timestamp=$(date +"%Y-%m-%d_%H%M%S")
+rev=$(git rev-parse --short HEAD)
+echo "HEAD is on $rev"
+out="$OUT/${timestamp}_${rev}"
+mkdir -p "$out"
+
+$LAKE build Benchmarks
+for file in "$@"; do
+    echo
+    echo + $file
+    echo
+    base="$(basename "$file" ".lean")"
+    $PROF -Dtrace.profiler.output="$out/$base.json" "$file" | tee "$base.log"
+done


### PR DESCRIPTION
### Description:

WORK IN PROGRESS.

Attempt to spread out the cost of mvar instantiation by eagerly instantiating the original main goal of `sym_n`, after the tactic is finished. This doesn't seem to have any effect.

See also the related issue on Lean: https://github.com/leanprover/lean4/issues/5610

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine?

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
