### PR TITLE
chore: add better trace nodes to `AxEffects`

### DIFF
--- a/Tactics/Sym.lean
+++ b/Tactics/Sym.lean
@@ -15,6 +15,7 @@ open Lean
 open Lean.Meta Lean.Elab.Tactic
 
 open AxEffects SymContext
+open Sym (withTraceNode withVerboseTraceNode)
 
 /-- A wrapper around `evalTactic` that traces the passed tactic script,
 executes those tactics, and then traces the new goal state -/

--- a/Tactics/Sym/AxEffects.lean
+++ b/Tactics/Sym/AxEffects.lean
@@ -8,10 +8,12 @@ import Arm.State
 import Tactics.Common
 import Tactics.Attr
 import Tactics.Simp
+import Tactics.Sym.Common
 
 import Std.Data.HashMap
 
 open Lean Meta
+open Sym (withTraceNode withVerboseTraceNode)
 
 /-- A reflected `ArmState` field, see `AxEffects.fields` for more context -/
 structure AxEffects.FieldEffect where
@@ -170,9 +172,8 @@ instance : ToMessageData AxEffects where
     }"
 
 private def traceCurrentState (eff : AxEffects)
-    (header : MessageData := "current state") :
-    MetaM Unit :=
-  withTraceNode `Tactic.sym (fun _ => pure header) do
+    (header : MessageData := "current state") : MetaM Unit :=
+  withTraceNode header <| do
     trace[Tactic.sym] "{eff}"
 
 /-! ## Helpers -/
@@ -204,7 +205,7 @@ private def rewriteType (e eq : Expr) : MetaM Expr := do
 by constructing an application of `eff.nonEffectProof` -/
 partial def mkAppNonEffect (eff : AxEffects) (field : Expr) : MetaM Expr := do
   let msg := m!"constructing application of non-effects proof"
-  withTraceNode `Tactic.sym (fun _ => pure msg) <| do
+  withTraceNode msg (tag := "mkAppNonEffect") <| do
     trace[Tactic.sym] "nonEffectProof: {eff.nonEffectProof}"
 
     let nonEffectProof := mkApp eff.nonEffectProof field
@@ -223,8 +224,7 @@ partial def mkAppNonEffect (eff : AxEffects) (field : Expr) : MetaM Expr := do
 /-- Get the value for a field, if one is stored in `eff.fields`,
 or assemble an instantiation of the non-effects proof otherwise -/
 def getField (eff : AxEffects) (fld : StateField) : MetaM FieldEffect :=
-  let msg := m!"getField {fld}"
-  withTraceNode `Tactic.sym (fun _ => pure msg) <| do
+  withTraceNode m!"getField {fld}" (tag := "getField") <| do
     eff.traceCurrentState
 
     if let some val := eff.fields.get? fld then
@@ -275,9 +275,8 @@ and all other fields are updated accordingly.
 Note that no effort is made to preserve `currentStateEq`; it is set to `none`!
 -/
 private def update_write_mem (eff : AxEffects) (n addr val : Expr) :
-    MetaM AxEffects := do
-  trace[Tactic.sym] "adding write of {n} bytes of value {val} \
-    to memory address {addr}"
+    MetaM AxEffects :=
+  withTraceNode m!"processing: write_mem {n} {addr} {val} …" (tag := "updateWriteMem") <| do
 
   -- Update each field
   let fields ← eff.fields.toList.mapM fun ⟨fld, {value, proof}⟩ => do
@@ -327,8 +326,7 @@ private def update_write_mem (eff : AxEffects) (n addr val : Expr) :
     programProof
     stackAlignmentProof?
   }
-  withTraceNode `Tactic.sym (fun _ => pure "new state") <| do
-      trace[Tactic.sym] "{eff}"
+  eff.traceCurrentState
   return eff
 
 /-- Execute `w <fld> <val>` against the state stored in `eff`
@@ -339,8 +337,8 @@ Note that no effort is made to preserve `currentStateEq`; it is set to `none`!
 -/
 private def update_w (eff : AxEffects) (fld val : Expr) :
     MetaM AxEffects := do
+  withTraceNode m!"processing: w {fld} {val} …" (tag := "updateWrite") <| do
   let rField ← reflectStateField fld
-  trace[Tactic.sym] "adding write of value {val} to register {rField}"
 
   -- Update all other fields
   let fields ←
@@ -454,20 +452,27 @@ private def assertIsDefEq (e expected : Expr) : MetaM Unit := do
 /-- Given an expression `e : ArmState`,
 which is a sequence of `w`/`write_mem`s to `eff.currentState`,
 return an `AxEffects` where `e` is the new `currentState`. -/
+private partial def updateWithExprAux (eff : AxEffects) (e : Expr) : MetaM AxEffects := do
+  match_expr e with
+  | write_mem_bytes n addr val e =>
+      let eff ← eff.updateWithExprAux e
+      eff.update_write_mem n addr val
+
+  | w field value e =>
+      let eff ← eff.updateWithExprAux e
+      eff.update_w field value
+
+  | _ =>
+      assertIsDefEq e eff.currentState
+      return eff
+
+/-- Given an expression `e : ArmState`,
+which is a sequence of `w`/`write_mem`s to `eff.currentState`,
+return an `AxEffects` where `e` is the new `currentState`. -/
 partial def updateWithExpr (eff : AxEffects) (e : Expr) : MetaM AxEffects := do
   let msg := m!"Updating effects with writes from: {e}"
-  withTraceNode `Tactic.sym (fun _ => pure msg) <| do match_expr e with
-    | write_mem_bytes n addr val e =>
-        let eff ← eff.updateWithExpr e
-        eff.update_write_mem n addr val
-
-    | w field value e =>
-        let eff ← eff.updateWithExpr e
-        eff.update_w field value
-
-    | _ =>
-        assertIsDefEq e eff.currentState
-        return eff
+  withTraceNode msg (tag := "updateWithExpr") <|
+    updateWithExprAux eff e
 
 /-- Given an expression `e : ArmState`,
 which is a sequence of `w`/`write_mem`s to the some state `s`,
@@ -482,55 +487,55 @@ def fromExpr (e : Expr) : MetaM AxEffects := do
   let eff ← eff.updateWithExpr e
   return { eff with initialState := ← instantiateMVars eff.initialState}
 
-
 /-- Given a proof `eq : s = <currentState>`,
 set `s` to be the new `currentState`, and update all proofs accordingly -/
 def adjustCurrentStateWithEq (eff : AxEffects) (s eq : Expr) :
     MetaM AxEffects := do
-  withTraceNode `Tactic.sym (fun _ => pure "adjusting `currenstState`") do
-    eff.traceCurrentState
+  withTraceNode m!"adjustCurrentStateWithEq" (tag := "adjustCurrentStateWithEq") do
     trace[Tactic.sym] "rewriting along {eq}"
+    eff.traceCurrentState
+
     assertHasType eq <| mkEqArmState s eff.currentState
     let eq ← mkEqSymm eq
 
     let currentState := s
 
     let fields ← eff.fields.toList.mapM fun (field, fieldEff) => do
-      withTraceNode `Tactic.sym (fun _ => pure m!"rewriting field {field}") do
+      withTraceNode m!"rewriting field {field}" (tag := "rewriteField") do
         trace[Tactic.sym] "original proof: {fieldEff.proof}"
         let proof ← rewriteType fieldEff.proof eq
         trace[Tactic.sym] "new proof: {proof}"
         pure (field, {fieldEff with proof})
     let fields := .ofList fields
 
-    let nonEffectProof ← rewriteType eff.nonEffectProof eq
-    let memoryEffectProof ← rewriteType eff.memoryEffectProof eq
-    -- ^^ TODO: what happens if `memoryEffect` is the same as `currentState`?
-    --    Presumably, we would *not* want to encapsulate `memoryEffect` here
-    let programProof ← rewriteType eff.programProof eq
-    let stackAlignmentProof? ← eff.stackAlignmentProof?.mapM
-      (rewriteType · eq)
+    withTraceNode m!"rewriting other proofs" (tag := "rewriteMisc") <| do
+      let nonEffectProof ← rewriteType eff.nonEffectProof eq
+      let memoryEffectProof ← rewriteType eff.memoryEffectProof eq
+      -- ^^ TODO: what happens if `memoryEffect` is the same as `currentState`?
+      --    Presumably, we would *not* want to encapsulate `memoryEffect` here
+      let programProof ← rewriteType eff.programProof eq
+      let stackAlignmentProof? ← eff.stackAlignmentProof?.mapM
+        (rewriteType · eq)
 
-    return { eff with
-      currentState, fields, nonEffectProof, memoryEffectProof, programProof,
-      stackAlignmentProof?
-    }
+      return { eff with
+        currentState, fields, nonEffectProof, memoryEffectProof, programProof,
+        stackAlignmentProof?
+      }
 
 /-- Given a proof `eq : ?s = <sequence of w/write_mem to eff.currentState>`,
 where `?s` and `?s0` are arbitrary `ArmState`s,
 return an `AxEffect` with the rhs of the equality as the current state,
 and the (non-)effects updated accordingly -/
 def updateWithEq (eff : AxEffects) (eq : Expr) : MetaM AxEffects :=
-  let msg := m!"Building effects with equality: {eq}"
-  withTraceNode `Tactic.sym (fun _ => pure msg) <| do
+  withTraceNode m!"Building effects with equality: {eq}"
+                (tag := "updateWithEq") <| do
     let s ← mkFreshExprMVar mkArmState
     let rhs ← mkFreshExprMVar mkArmState
     assertHasType eq <| mkEqArmState s rhs
 
     let eff ← eff.updateWithExpr (← instantiateMVars rhs)
     let eff ← eff.adjustCurrentStateWithEq s eq
-    withTraceNode `Tactic.sym (fun _ => pure "new state") do
-      trace[Tactic.sym] "{eff}"
+    eff.traceCurrentState "new state"
     return eff
 
 /-- Given a proof `eq : ?s = <sequence of w/write_mem to ?s0>`,
@@ -572,8 +577,7 @@ Note: throws an error when `initialState = currentState` *and*
 the field already has a value stored, as the rewrite might produce expressions
 of unexpected types. -/
 def withField (eff : AxEffects) (eq : Expr) : MetaM AxEffects := do
-  let msg := m!"withField {eq}"
-  withTraceNode `Tactic.sym (fun _ => pure msg) <| do
+  withTraceNode m!"withField {eq}" (tag := "withField") <| do
     eff.traceCurrentState
     let fieldE ← mkFreshExprMVar (mkConst ``StateField)
     let value ← mkFreshExprMVar none
@@ -631,8 +635,8 @@ NOTE: does not necessarily validate *which* type an expression has,
 validation will still pass if types are different to those we claim in the
 docstrings -/
 def validate (eff : AxEffects) : MetaM Unit := do
-  let msg := "validating that the axiomatic effects are well-formed"
-  withTraceNode `Tactic.sym (fun _ => pure msg) <| do
+  withTraceNode "validating that the axiomatic effects are well-formed"
+                (tag := "validate") <| do
     eff.traceCurrentState
 
     assertHasType eff.initialState mkArmState
@@ -667,8 +671,8 @@ that was just added to the local context -/
 def addHypothesesToLContext (eff : AxEffects) (hypPrefix : String := "h_")
     (mvar : Option MVarId := none) :
     TacticM AxEffects :=
-  let msg := m!"adding hypotheses to local context"
-  withTraceNode `Tactic.sym (fun _ => pure msg) do
+  withTraceNode m!"adding hypotheses to local context"
+                (tag := "addHypothesesToLContext") do
     eff.traceCurrentState
     let mut goal ← mvar.getDM getMainGoal
 
@@ -731,8 +735,8 @@ where
   replaceOrNote (goal : MVarId)
       (h : Name) (v : Expr) (t? : Option Expr := none) :
       MetaM (FVarId × MVarId) :=
-    let msg := m!"adding {h} to the local context"
-    withTraceNode `Tactic.sym (fun _ => pure msg) <| do
+    withTraceNode m!"adding {h} to the local context"
+                  (tag := "replaceOrNote") <| do
       trace[Tactic.sym] "with value {v} and type {t?}"
       if let some decl := (← getLCtx).findFromUserName? h then
         let ⟨fvar, goal, _⟩ ← goal.replace decl.fvarId v t?
@@ -744,8 +748,8 @@ where
 /-- Return an array of `SimpTheorem`s of the proofs contained in
 the given `AxEffects` -/
 def toSimpTheorems (eff : AxEffects) : MetaM (Array SimpTheorem) := do
-  let msg := m!"computing SimpTheorems for (non-)effect hypotheses"
-  withTraceNode `Tactic.sym (fun _ => pure msg) <| do
+  withTraceNode m!"computing SimpTheorems for (non-)effect hypotheses"
+                (tag := "toSimpTheorems") <| do
     let lctx ← getLCtx
     let baseName? :=
       if eff.currentState.isFVar then
@@ -757,8 +761,7 @@ def toSimpTheorems (eff : AxEffects) : MetaM (Array SimpTheorem) := do
 
     let add (thms : Array SimpTheorem) (e : Expr) (name : String)
         (prio : Nat := 1000) :=
-      let msg := m!"adding {e} with name {name}"
-      withTraceNode `Tactic.sym (fun _ => pure msg) <| do
+      withTraceNode m!"adding {e} with name {name}" <| do
         let origin : Origin :=
           if e.isFVar then
             .fvar e.fvarId!

--- a/Tactics/Sym/Common.lean
+++ b/Tactics/Sym/Common.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
+import Lean
+
+open Lean
+
+namespace Sym
+
+/-! ## Trace Nodes -/
+section Tracing
+variable {α : Type} {m : Type → Type} [Monad m] [MonadTrace m] [MonadLiftT IO m]
+  [MonadRef m] [AddMessageContext m] [MonadOptions m] {ε : Type}
+  [MonadAlwaysExcept ε m] [MonadLiftT BaseIO m]
+
+def withTraceNode (msg : MessageData) (k : m α)
+    (collapsed : Bool := true)
+    (tag : String := "")
+    : m α := do
+  Lean.withTraceNode `Tactic.sym (fun _ => pure msg) k collapsed tag
+
+def withVerboseTraceNode (msg : MessageData) (k : m α)
+    (collapsed : Bool := true)
+    (tag : String := "")
+    : m α := do
+  Lean.withTraceNode `Tactic.sym.verbose (fun _ => pure msg) k collapsed tag
+
+end Tracing

--- a/Tactics/Sym/Context.lean
+++ b/Tactics/Sym/Context.lean
@@ -9,6 +9,7 @@ import Lean.Meta
 import Arm.Exec
 import Tactics.Common
 import Tactics.Attr
+import Tactics.Sym.Common
 import Tactics.Sym.ProgramInfo
 import Tactics.Sym.AxEffects
 import Tactics.Sym.LCtxSearch
@@ -33,6 +34,7 @@ and is likely to be deprecated and removed in the near future. -/
 
 open Lean Meta Elab.Tactic
 open BitVec
+open Sym (withTraceNode withVerboseTraceNode)
 
 /-- A `SymContext` collects the names of various variables/hypotheses in
 the local context required for symbolic evaluation -/
@@ -146,26 +148,6 @@ end SymM
 
 namespace SymContext
 
-/-! ## Trace Nodes -/
-section Tracing
-variable {α : Type} {m : Type → Type} [Monad m] [MonadTrace m] [MonadLiftT IO m]
-  [MonadRef m] [AddMessageContext m] [MonadOptions m] {ε : Type}
-  [MonadAlwaysExcept ε m] [MonadLiftT BaseIO m]
-
-def withTraceNode (msg : MessageData) (k : m α)
-    (collapsed : Bool := true)
-    (tag : String := "")
-    : m α := do
-  Lean.withTraceNode `Tactic.sym (fun _ => pure msg) k collapsed tag
-
-def withVerboseTraceNode (msg : MessageData) (k : m α)
-    (collapsed : Bool := true)
-    (tag : String := "")
-    : m α := do
-  Lean.withTraceNode `Tactic.sym.verbose (fun _ => pure msg) k collapsed tag
-
-end Tracing
-
 /-! ## Simple projections -/
 section
 open Lean (Ident mkIdent)
@@ -229,8 +211,6 @@ def traceSymContext : SymM Unit :=
   withTraceNode m!"SymContext: " <| do
     let m ← (← getThe SymContext).toMessageData
     trace[Tactic.sym] m
-
-
 
 /-! ## Adding new simp theorems for aggregation -/
 


### PR DESCRIPTION
### Description:

Stacked on: #213 

Adds tags to the `AxEffects` trace nodes, to make profile data more informative (messages don't show up in the JSON, but tags do)

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine? Yes

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
