### PR TITLE
refactor: replace `rewrite` with `mkEqNDRec`

### DIFF
--- a/Tactics/Common.lean
+++ b/Tactics/Common.lean
@@ -277,6 +277,32 @@ def Lean.Expr.eqReadField? (e : Expr) : Option (Expr × Expr × Expr) := do
     | none
   some (field, state, value)
 
+/-- Return `ArmState.program <state> = <program>` -/
+def mkEqProgram (state program : Expr) : Expr :=
+  mkApp3 (.const ``Eq [1]) (mkConst ``Program)
+    (mkApp (mkConst ``ArmState.program) state)
+    program
+
+/-- Return `x = y`, given expressions `x, y : BitVec <n>` -/
+def mkEqBitVec (n x y : Expr) : Expr :=
+  let ty := mkApp (mkConst ``BitVec) n
+  mkApp3 (.const ``Eq [1]) ty x y
+
+/-- Return `read_mem_bytes <n> <addr> <state>` -/
+def mkReadMemBytes (n addr state : Expr) : Expr :=
+  mkApp3 (mkConst ``read_mem_bytes) n addr state
+
+/-- Return `read_mem_bytes <n> <addr> <state> = <value>`, given expressions
+`n : Nat`, `addr : BitVec 64`, `state : ArmState` and `value : BitVec (n*8)` -/
+def mkEqReadMemBytes (n addr state value : Expr) : Expr :=
+  let n8 := mkNatMul n (toExpr 8)
+  mkEqBitVec n8 (mkReadMemBytes n addr state) value
+
+-- def mkForallReadMemBytesEqReadMemBytes (leftState rightState : Expr) : Expr :=
+  -- TODO
+
+-- def mkForallEqReadMem
+
 /-! ## Tracing helpers -/
 
 def traceHeartbeats (cls : Name) (header : Option String := none) :

--- a/Tactics/Sym/Context.lean
+++ b/Tactics/Sym/Context.lean
@@ -333,12 +333,14 @@ protected def searchFor : SearchLCtxForM SymM Unit := do
   searchLCtxForOnce (h_program_type currentState program)
     (whenNotFound := throwNotFound)
     (whenFound := fun decl _ => do
+      let program ← instantiateMVars program
       -- Register the program proof
       modifyThe AxEffects ({· with
+        program
         programProof := decl.toExpr
       })
       -- Assert that `program` is a(n application of a) constant
-      let program := (← instantiateMVars program).getAppFn
+      let program := program.getAppFn
       let .const program _ := program
         | throwError "Expected a constant, found:\n\t{program}"
       -- Retrieve the programInfo from the environment


### PR DESCRIPTION
### Description:

Stacked on
- [ ] #214 

We've replaced uses of `rewrite` in `AxEffects` with a more manual application of `Eq.ndRec`.

This is motivated by the slowdown observed in #210, where the size of hypotheses would grow and a lot of time was being spent on rewriting. With `Eq.ndRec`, the meta-code explicitly constructs the motive, thus, no inspection of the expression being rewritten is needed, hence, the speedup.

That said, in this PR we've not yet switched to intermediate state aggregation, so the observed speedup is less significant.

TODO: put benchmark data here


### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine? Yes

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
