### PR TITLE
Simplify partInstall to use start and len

### DIFF
--- a/Arm/Insts/Common.lean
+++ b/Arm/Insts/Common.lean
@@ -633,12 +633,10 @@ def elem_get (vector : BitVec n) (e : Nat) (size : Nat) : BitVec size :=
 the `e`'th element in the `vector`. -/
 @[state_simp_rules]
 def elem_set (vector : BitVec n) (e : Nat) (size : Nat)
-  (value : BitVec size) (h: size > 0): BitVec n :=
+  (value : BitVec size) : BitVec n :=
   -- assert (e+1)*size <= n
   let lo := e * size
-  let hi := lo + size - 1
-  have h : size = hi - lo + 1 := by simp only [hi, lo]; omega
-  BitVec.partInstall hi lo (BitVec.cast h value) vector
+  BitVec.partInstall lo size value vector
 
 ----------------------------------------------------------------------
 
@@ -681,7 +679,7 @@ def shift_right_common_aux
     let elem := Int_with_unsigned info.unsigned $ elem_get operand e info.esize
     let shift_elem := RShr info.unsigned elem info.shift info.round
     let acc_elem := elem_get operand2 e info.esize + shift_elem
-    let result := elem_set result e info.esize acc_elem info.h
+    let result := elem_set result e info.esize acc_elem
     have _ : info.elements - (e + 1) < info.elements - e := by omega
     shift_right_common_aux (e + 1) info operand operand2 result
   termination_by (info.elements - e)
@@ -703,7 +701,7 @@ def shift_left_common_aux
   else
     let elem := elem_get operand e info.esize
     let shift_elem := elem <<< info.shift
-    let result := elem_set result e info.esize shift_elem info.h
+    let result := elem_set result e info.esize shift_elem
     have _ : info.elements - (e + 1) < info.elements - e := by omega
     shift_left_common_aux (e + 1) info operand result
   termination_by (info.elements - e)

--- a/Arm/Insts/DPI/Move_wide_imm.lean
+++ b/Arm/Insts/DPI/Move_wide_imm.lean
@@ -25,8 +25,7 @@ def exec_move_wide_imm (inst : Move_wide_imm_cls) (s : ArmState) : ArmState :=
     let result := if inst.opc = 0b11#2
                   then read_gpr datasize inst.Rd s
                   else BitVec.zero datasize
-    have h : 16 = pos + 15 - pos + 1 := by omega
-    let result := partInstall (pos + 15) pos (BitVec.cast h inst.imm16) result
+    let result := partInstall pos 16 inst.imm16 result
     let result := if inst.opc = 0b00#2 then ~~~result else result
     -- State Update
     let s := write_gpr datasize inst.Rd result s

--- a/Arm/Insts/DPI/PC_rel_addressing.lean
+++ b/Arm/Insts/DPI/PC_rel_addressing.lean
@@ -24,7 +24,7 @@ def exec_pc_rel_addressing (inst : PC_rel_addressing_cls) (s : ArmState) : ArmSt
   let result := if inst.op = 0#1 then
                    orig_pc + imm -- ADR
                 else
-                   (BitVec.partInstall 11 0 0#12 orig_pc) + imm
+                   (BitVec.partInstall 0 12 0#12 orig_pc) + imm
   -- State Updates
   let s := write_gpr_zr 64 inst.Rd result s
   let s := write_pc (orig_pc + 4#64) s

--- a/Arm/Insts/DPSFP/Advanced_simd_copy.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_copy.lean
@@ -17,13 +17,12 @@ namespace DPSFP
 open BitVec
 
 def dup_aux (e : Nat) (elements : Nat) (esize : Nat)
-  (element : BitVec esize) (result : BitVec datasize) (H : 0 < esize) : BitVec datasize :=
-  if h₀ : elements <= e then
+  (element : BitVec esize) (result : BitVec datasize) : BitVec datasize :=
+  if elements <= e then
     result
   else
-    let result := elem_set result e esize element H
-    have h : elements - (e + 1) < elements - e := by omega
-    dup_aux (e + 1) elements esize element result H
+    let result := elem_set result e esize element
+    dup_aux (e + 1) elements esize element result
   termination_by (elements - e)
 
 @[state_simp_rules]
@@ -38,9 +37,8 @@ def exec_dup_element (inst : Advanced_simd_copy_cls) (s : ArmState) : ArmState :
     let datasize := 64 <<< inst.Q.toNat
     let elements := datasize / esize
     let operand := read_sfp idxdsize inst.Rn s
-    have h₀ : esize > 0 := by apply zero_lt_shift_left_pos (by decide)
     let element := elem_get operand index esize
-    let result := dup_aux 0 elements esize element (BitVec.zero datasize) h₀
+    let result := dup_aux 0 elements esize element (BitVec.zero datasize)
     -- State Updates
     let s := write_pc ((read_pc s) + 4#64) s
     let s := write_sfp datasize inst.Rd result s
@@ -56,8 +54,7 @@ def exec_dup_general (inst : Advanced_simd_copy_cls) (s : ArmState) : ArmState :
     let datasize := 64 <<< inst.Q.toNat
     let elements := datasize / esize
     let element := read_gpr esize inst.Rn s
-    have h₀ : 0 < esize := by apply zero_lt_shift_left_pos (by decide)
-    let result := dup_aux 0 elements esize element (BitVec.zero datasize) h₀
+    let result := dup_aux 0 elements esize element (BitVec.zero datasize)
     -- State Updates
     let s := write_pc ((read_pc s) + 4#64) s
     let s := write_sfp datasize inst.Rd result s
@@ -75,9 +72,8 @@ def exec_ins_element (inst : Advanced_simd_copy_cls) (s : ArmState) : ArmState :
     let esize := 8 <<< size
     let operand := read_sfp idxdsize inst.Rn s
     let result := read_sfp 128 inst.Rd s
-    have h₀ : esize > 0 := by apply zero_lt_shift_left_pos (by decide)
     let elem := elem_get operand src_index esize
-    let result := elem_set result dst_index esize elem h₀
+    let result := elem_set result dst_index esize elem
     -- State Updates
     let s := write_pc ((read_pc s) + 4#64) s
     let s := write_sfp 128 inst.Rd result s
@@ -93,8 +89,7 @@ def exec_ins_general (inst : Advanced_simd_copy_cls) (s : ArmState) : ArmState :
     let esize := 8 <<< size
     let element := read_gpr esize inst.Rn s
     let result := read_sfp 128 inst.Rd s
-    have h₀ : esize > 0 := by apply zero_lt_shift_left_pos (by decide)
-    let result := elem_set result index esize element h₀
+    let result := elem_set result index esize element
     -- State Updates
     let s := write_pc ((read_pc s) + 4#64) s
     let s := write_sfp 128 inst.Rd result s

--- a/Arm/Insts/DPSFP/Advanced_simd_permute.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_permute.lean
@@ -17,17 +17,16 @@ open BitVec
 
 def trn_aux (p : Nat) (pairs : Nat) (esize : Nat) (part : Nat)
   (operand1 : BitVec datasize) (operand2 : BitVec datasize)
-  (result : BitVec datasize) (h : esize > 0) : BitVec datasize :=
-  if h₀ : pairs <= p then
+  (result : BitVec datasize) : BitVec datasize :=
+  if pairs <= p then
     result
   else
     let idx_from := 2 * p + part
     let op1_part := elem_get operand1 idx_from esize
     let op2_part := elem_get operand2 idx_from esize
-    let result := elem_set result (2 * p) esize op1_part h
-    let result := elem_set result (2 * p + 1) esize op2_part h
-    have h₁ : pairs - (p + 1) < pairs - p := by omega
-    trn_aux (p + 1) pairs esize part operand1 operand2 result h
+    let result := elem_set result (2 * p) esize op1_part
+    let result := elem_set result (2 * p + 1) esize op2_part
+    trn_aux (p + 1) pairs esize part operand1 operand2 result
   termination_by (pairs - p)
 
 @[state_simp_rules]
@@ -43,8 +42,7 @@ def exec_trn (inst : Advanced_simd_permute_cls) (s : ArmState) : ArmState :=
     let pairs := elements / 2
     let operand1 := read_sfp datasize inst.Rn s
     let operand2 := read_sfp datasize inst.Rm s
-    have h : esize > 0 := by apply zero_lt_shift_left_pos (by decide)
-    let result := trn_aux 0 pairs esize part operand1 operand2 (BitVec.zero datasize) h
+    let result := trn_aux 0 pairs esize part operand1 operand2 (BitVec.zero datasize)
     -- Update States
     let s := write_sfp datasize inst.Rd result s
     let s := write_pc ((read_pc s) + 4#64) s

--- a/Arm/Insts/DPSFP/Advanced_simd_table_lookup.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_table_lookup.lean
@@ -21,8 +21,7 @@ def create_table (i : Nat) (regs : Nat) (Rn : BitVec 5) (table : BitVec (128 * r
     table
   else
     let val := read_sfp 128 Rn s
-    have h₁ : 128 = 128 * i + 127 - 128 * i + 1 := by omega
-    let table := BitVec.partInstall (128 * i + 127) (128 * i) (BitVec.cast h₁ val) table
+    let table := BitVec.partInstall (128 * i) 128 val table
     let Rn := (Rn + 1) % 32
     have h₂ : regs - (i + 1) < regs - i := by omega
     create_table (i + 1) regs Rn table s
@@ -31,18 +30,16 @@ def create_table (i : Nat) (regs : Nat) (Rn : BitVec 5) (table : BitVec (128 * r
 def tblx_aux (i : Nat) (elements : Nat) (indices : BitVec datasize)
   (regs : Nat) (table : BitVec (128 * regs)) (result: BitVec datasize)
   : BitVec datasize :=
-  if h₀ : elements <= i then
+  if elements <= i then
     result
   else
-    have h₁ : 8 > 0 := by decide
     let index := (elem_get indices i 8).toNat
     let result :=
       if index < 16 * regs then
         let val := elem_get table index 8
-        elem_set result i 8 val h₁
+        elem_set result i 8 val
       else
         result
-    have h₂ : elements - (i + 1) < elements - i := by omega
     tblx_aux (i + 1) elements indices regs table result
   termination_by (elements - i)
 

--- a/Arm/Insts/DPSFP/Advanced_simd_three_different.lean
+++ b/Arm/Insts/DPSFP/Advanced_simd_three_different.lean
@@ -33,18 +33,16 @@ def polynomial_mult (op1 : BitVec m) (op2 : BitVec n) : BitVec (m+n) :=
   polynomial_mult_aux 0 result op1 extended_op2
 
 def pmull_op (e : Nat) (esize : Nat) (elements : Nat) (x : BitVec n)
-  (y : BitVec n) (result : BitVec (n*2)) (H : 0 < esize) : BitVec (n*2) :=
-  if h₀ : elements <= e then
+  (y : BitVec n) (result : BitVec (n*2)) : BitVec (n*2) :=
+  if elements <= e then
     result
   else
     let element1 := elem_get x e esize
     let element2 := elem_get y e esize
     let elem_result := polynomial_mult element1 element2
     have h₁ : esize + esize = 2 * esize := by omega
-    have h₂ : 2 * esize > 0 := by omega
-    let result := elem_set result e (2 * esize) (BitVec.cast h₁ elem_result) h₂
-    have _ : elements - (e + 1) < elements - e := by omega
-    pmull_op (e + 1) esize elements x y result H
+    let result := elem_set result e (2 * esize) (BitVec.cast h₁ elem_result)
+    pmull_op (e + 1) esize elements x y result
   termination_by (elements - e)
 
 @[state_simp_rules]
@@ -54,14 +52,13 @@ def exec_pmull (inst : Advanced_simd_three_different_cls) (s : ArmState) : ArmSt
     write_err (StateError.Illegal s!"Illegal {inst} encountered!") s
   else
     let esize := 8 <<< inst.size.toNat
-    have h₀ : 0 < esize := by apply zero_lt_shift_left_pos (by decide)
     let datasize := 64
     let part := inst.Q.toNat
     let elements := datasize / esize
     let operand1 := Vpart_read inst.Rn part datasize s
     let operand2 := Vpart_read inst.Rm part datasize s
     let result :=
-      pmull_op 0 esize elements operand1 operand2 (BitVec.zero (2*datasize)) h₀
+      pmull_op 0 esize elements operand1 operand2 (BitVec.zero (2*datasize))
     let s := write_sfp (datasize*2) inst.Rd result s
     let s := write_pc ((read_pc s) + 4#64) s
     s

--- a/Proofs/SHA512/SHA512_block_armv8_rules.lean
+++ b/Proofs/SHA512/SHA512_block_armv8_rules.lean
@@ -83,8 +83,8 @@ private theorem extractLsb'_high_64_from_zeroExtend_128_or (x y : BitVec 64) :
 theorem sha512h_rule_1 (a b c d e : BitVec 128) :
   let elements := 2
   let esize := 64
-  let inner_sum := (binary_vector_op_aux 0 elements esize BitVec.add c d (BitVec.zero 128) H)
-  let outer_sum := (binary_vector_op_aux 0 elements esize BitVec.add inner_sum e (BitVec.zero 128) H)
+  let inner_sum := (binary_vector_op_aux 0 elements esize BitVec.add c d (BitVec.zero 128))
+  let outer_sum := (binary_vector_op_aux 0 elements esize BitVec.add inner_sum e (BitVec.zero 128))
   let a0 := extractLsb'  0 64 a
   let a1 := extractLsb' 64 64 a
   let b0 := extractLsb'  0 64 b
@@ -196,12 +196,12 @@ theorem sha512h_rule_2 (a b c d e : BitVec 128) :
   let d1 := extractLsb' 64 64 d
   let e0 := extractLsb'  0 64 e
   let e1 := extractLsb' 64 64 e
-  let inner_sum := binary_vector_op_aux 0 2 64 BitVec.add d e (BitVec.zero 128) h1
+  let inner_sum := binary_vector_op_aux 0 2 64 BitVec.add d e (BitVec.zero 128)
   let concat := inner_sum ++ inner_sum
   let operand := extractLsb' 64 128 concat
   let hi64_spec := compression_update_t1 b1 a0 a1 c1 d0 e0
   let lo64_spec := compression_update_t1 (b0 + hi64_spec) b1 a0 c0 d1 e1
-  sha512h a b (binary_vector_op_aux 0 2 64 BitVec.add c operand (BitVec.zero 128) h2) =
+  sha512h a b (binary_vector_op_aux 0 2 64 BitVec.add c operand (BitVec.zero 128)) =
   hi64_spec ++ lo64_spec := by
   repeat (unfold binary_vector_op_aux; simp)
   repeat (unfold BitVec.partInstall; simp)

--- a/Specs/AESCommon.lean
+++ b/Specs/AESCommon.lean
@@ -50,8 +50,7 @@ def SubBytes_aux (i : Nat) (op : BitVec 128) (out : BitVec 128)
     let i := 16 - i
     let idx := (extractLsb' (i * 8) 8 op).toNat
     let val := extractLsb' (idx * 8) 8 $ BitVec.flatten SBOX
-    have h₁ : 8 = i * 8 + 7 - i * 8 + 1 := by omega
-    let out := BitVec.partInstall (i * 8 + 7) (i * 8) (BitVec.cast h₁ val) out
+    let out := BitVec.partInstall (i * 8) 8 val out
     SubBytes_aux i' op out
 
 def SubBytes (op : BitVec 128) : BitVec 128 :=
@@ -66,20 +65,18 @@ def MixColumns_aux (c : Nat)
   | 0 => (out0, out1, out2, out3)
   | c' + 1 =>
     let lo := (4 - c) * 8
-    let hi := lo + 7
     let in0_byte := extractLsb' lo 8 in0
     let in1_byte := extractLsb' lo 8 in1
     let in2_byte := extractLsb' lo 8 in2
     let in3_byte := extractLsb' lo 8 in3
-    have h : 8 = hi - lo + 1 := by omega
-    let val0 := BitVec.cast h $ FFmul02 in0_byte ^^^ FFmul03 in1_byte ^^^ in2_byte ^^^ in3_byte
-    let out0 := BitVec.partInstall hi lo val0 out0
-    let val1 := BitVec.cast h $ FFmul02 in1_byte ^^^ FFmul03 in2_byte ^^^ in3_byte ^^^ in0_byte
-    let out1 := BitVec.partInstall hi lo val1 out1
-    let val2 := BitVec.cast h $ FFmul02 in2_byte ^^^ FFmul03 in3_byte ^^^ in0_byte ^^^ in1_byte
-    let out2 := BitVec.partInstall hi lo val2 out2
-    let val3 := BitVec.cast h $ FFmul02 in3_byte ^^^ FFmul03 in0_byte ^^^ in1_byte ^^^ in2_byte
-    let out3 := BitVec.partInstall hi lo val3 out3
+    let val0 := FFmul02 in0_byte ^^^ FFmul03 in1_byte ^^^ in2_byte ^^^ in3_byte
+    let out0 := BitVec.partInstall lo 8 val0 out0
+    let val1 := FFmul02 in1_byte ^^^ FFmul03 in2_byte ^^^ in3_byte ^^^ in0_byte
+    let out1 := BitVec.partInstall lo 8 val1 out1
+    let val2 := FFmul02 in2_byte ^^^ FFmul03 in3_byte ^^^ in0_byte ^^^ in1_byte
+    let out2 := BitVec.partInstall lo 8 val2 out2
+    let val3 := FFmul02 in3_byte ^^^ FFmul03 in0_byte ^^^ in1_byte ^^^ in2_byte
+    let out3 := BitVec.partInstall lo 8 val3 out3
     MixColumns_aux c' in0 in1 in2 in3 out0 out1 out2 out3 FFmul02 FFmul03
 
 def MixColumns (op : BitVec 128) (FFmul02 : BitVec 8 -> BitVec 8)

--- a/Specs/AESV8.lean
+++ b/Specs/AESV8.lean
@@ -112,7 +112,6 @@ def AESHWCtr32EncryptBlocks_helper {Param : AESArm.KBR} (in_blocks : BitVec m)
   else
     let lo := m - (i + 1) * 128
     let hi := lo + 127
-    have h5 : hi - lo + 1 = 128 := by omega
     let curr_block : BitVec 128 := BitVec.extractLsb' lo 128 in_blocks
     have h4 : 128 = Param.block_size := by
       cases h3
@@ -126,7 +125,7 @@ def AESHWCtr32EncryptBlocks_helper {Param : AESArm.KBR} (in_blocks : BitVec m)
         (Param := Param) (BitVec.cast h4 ivec_rev) key.rd_key
     let res_block := rev_elems 128 8 res_block (by decide) (by decide)
     let res_block := res_block ^^^ curr_block
-    let new_acc := BitVec.partInstall hi lo (BitVec.cast h5.symm res_block) acc
+    let new_acc := BitVec.partInstall lo 128 res_block acc
     AESHWCtr32EncryptBlocks_helper (Param := Param)
       in_blocks (i + 1) len key (ivec + 1#128) new_acc h1 h2 h3
   termination_by (len - i)

--- a/Specs/GCM.lean
+++ b/Specs/GCM.lean
@@ -67,11 +67,9 @@ def GCTR_aux (CIPH : Cipher (n := 128) (m := m))
     Y
   else
     let lo := (n - i - 1) * 128
-    let hi := lo + 127
-    have h : 128 = hi - lo + 1 := by omega
     let Xi := extractLsb' lo 128 X
     let Yi := Xi ^^^ CIPH ICB K
-    let Y := BitVec.partInstall hi lo (BitVec.cast h Yi) Y
+    let Y := BitVec.partInstall lo 128 Yi Y
     let ICB := inc_s 32 ICB (by omega)
     GCTR_aux CIPH (i + 1) n K ICB X Y
   termination_by (n - i)

--- a/Specs/GCMV8.lean
+++ b/Specs/GCMV8.lean
@@ -76,7 +76,7 @@ def pdiv (x: BitVec n) (y : BitVec m): BitVec n :=
       let zi := extractLsb' 0 m ((GCMV8.reduce y z) ++ xi)
       let bit := extractLsb' (GCMV8.degree y) 1 zi
       let newacc : BitVec n :=
-        partInstall (i - 1) (i - 1) (bit.cast (by omega)) acc
+        partInstall (i - 1) 1 bit acc
       pdivTR x y j zi newacc
   pdivTR x y n (BitVec.zero m) (BitVec.zero n)
 

--- a/Tests/Tactics/CSE.lean
+++ b/Tests/Tactics/CSE.lean
@@ -392,15 +392,16 @@ hx4 : x7 ||| x6 = x4
 x8 : BitVec 128
 hx6 : x8 <<< 64 = x6
 x9 : BitVec 64
-hx8 : BitVec.zeroExtend 128 x9 = x8
+hx7 : BitVec.zeroExtend 128 x9 = x7
 x10 : BitVec 64
-hx7 : BitVec.zeroExtend 128 x10 = x7
-x11 x12 x13 x14 : BitVec 64
-x15 : BitVec 128
-hx12 : BitVec.extractLsb' 64 64 x15 = x12
-hx13 : BitVec.extractLsb' 0 64 x15 = x13
+hx8 : BitVec.zeroExtend 128 x10 = x8
+x11 x12 x13 : BitVec 64
+x14 : BitVec 128
+hx12 : BitVec.extractLsb' 64 64 x14 = x12
+hx13 : BitVec.extractLsb' 0 64 x14 = x13
+x15 : BitVec 64
 x16 : BitVec 256
-hx15 : BitVec.extractLsb' 64 128 x16 = x15
+hx14 : BitVec.extractLsb' 64 128 x16 = x14
 x17 x18 : BitVec 64
 hx2 : x18 + x3 = x2
 x19 : BitVec 128
@@ -410,65 +411,63 @@ hx17 : x20 + x21 = x17
 x22 : BitVec 64
 hx18 : x21 + x22 = x18
 x23 : BitVec 64
-x24 : BitVec 128
-x25 : BitVec 64
-x26 : BitVec 128
-hx19 : x26 ||| x24 = x19
+x24 x25 : BitVec 128
+hx24 : x25 <<< 64 = x24
+x26 : BitVec 64
 x27 : BitVec 128
-hx24 : x27 <<< 64 = x24
+hx19 : x27 ||| x24 = x19
 x28 : BitVec 64
-hx26 : BitVec.zeroExtend 128 x28 = x26
+hx21 : x28 ^^^ x26 = x21
 x29 : BitVec 64
-hx21 : x29 ^^^ x25 = x21
+hx27 : BitVec.zeroExtend 128 x29 = x27
 x30 : BitVec 64
-hx27 : BitVec.zeroExtend 128 x30 = x27
+hx25 : BitVec.zeroExtend 128 x30 = x25
 x31 x32 x33 : BitVec 64
-hx22 : x23 ^^^ x33 = x22
+hx23 : x33 ^^^ x31 = x23
 x34 : BitVec 64
-hx23 : x34 ^^^ x31 = x23
+hx22 : x23 ^^^ x34 = x22
 x35 : BitVec 64
-hx35 : BitVec.extractLsb' 64 64 e = x35
+hx35 : BitVec.extractLsb' 0 64 d = x35
+hx15 : x17 + x35 = x15
 x36 : BitVec 64
-hx36 : BitVec.extractLsb' 64 64 b = x36
-hx31 : x36.rotateRight 18 = x31
-hx32 : ~~~x36 = x32
-hx33 : x36.rotateRight 41 = x33
-hx34 : x36.rotateRight 14 = x34
+hx36 : BitVec.extractLsb' 64 64 d = x36
 x37 : BitVec 64
-hx37 : BitVec.extractLsb' 0 64 c = x37
-hx10 : x37 + x13 = x10
+hx37 : BitVec.extractLsb' 64 64 a = x37
+hx26 : x32 &&& x37 = x26
 x38 : BitVec 64
-hx38 : BitVec.extractLsb' 0 64 d = x38
-hx14 : x17 + x38 = x14
+hx38 : BitVec.extractLsb' 0 64 a = x38
 x39 : BitVec 64
-hx39 : BitVec.extractLsb' 64 64 c = x39
-hx9 : x39 + x12 = x9
-hx20 : x39 + x22 = x20
+hx39 : BitVec.extractLsb' 0 64 e = x39
+hx11 : x15 + x39 = x11
+hx29 : x35 + x39 = x29
 x40 : BitVec 64
-hx40 : BitVec.extractLsb' 0 64 e = x40
-hx11 : x14 + x40 = x11
-hx28 : x38 + x40 = x28
+hx40 : BitVec.extractLsb' 0 64 b = x40
+hx1 : x2 + x40 = x1
+hx5 : x40 + x11 = x5
 x41 : BitVec 64
-hx41 : BitVec.extractLsb' 0 64 b = x41
-hx1 : x2 + x41 = x1
-hx5 : x41 + x11 = x5
+hx41 : BitVec.extractLsb' 64 64 c = x41
+hx10 : x41 + x12 = x10
+hx20 : x41 + x22 = x20
 x42 : BitVec 64
-hx42 : BitVec.extractLsb' 64 64 d = x42
-hx30 : x42 + x35 = x30
+hx42 : BitVec.extractLsb' 64 64 b = x42
+hx31 : x42.rotateRight 18 = x31
+hx32 : ~~~x42 = x32
+hx33 : x42.rotateRight 14 = x33
+hx34 : x42.rotateRight 41 = x34
+hx28 : x42 &&& x38 = x28
 x43 : BitVec 64
-hx43 : BitVec.extractLsb' 0 64 a = x43
-hx29 : x36 &&& x43 = x29
+hx43 : BitVec.extractLsb' 0 64 c = x43
+hx9 : x43 + x13 = x9
 x44 : BitVec 64
-hx44 : BitVec.extractLsb' 64 64 a = x44
-hx25 : x32 &&& x44 = x25
+hx44 : BitVec.extractLsb' 64 64 e = x44
+hx30 : x36 + x44 = x30
 ⊢ x2 ++
-      ((x1 &&& x36 ^^^ ~~~x1 &&& x43) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
+      ((x1 &&& x42 ^^^ ~~~x1 &&& x38) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
         BitVec.extractLsb' 0 64 x4) =
     x11 ++
-      (x37 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x36 ^^^ ~~~x5 &&& x43) + x42 +
-        x35)
+      (x43 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x42 ^^^ ~~~x5 &&& x38) + x36 +
+        x44)
 -/
-
 #guard_msgs in theorem sha512h_rule_2 (a b c d e : BitVec 128) :
   let a0 := extractLsb'  0 64 a
   let a1 := extractLsb' 64 64 a

--- a/Tests/Tactics/CSE.lean
+++ b/Tests/Tactics/CSE.lean
@@ -256,11 +256,9 @@ hx2 : BitVec.zeroExtend 128 x3 = x2
 namespace SHA
 
 open BitVec sha512_helpers DPSFP SHA2 in
-/--
-warning: declaration uses 'sorry'
+/--warning: declaration uses 'sorry'
 ---
-info: H : 64 > 0
-a b c d e : BitVec 128
+info: a b c d e : BitVec 128
 x1 x2 x3 : BitVec 64
 x4 : BitVec 128
 hx3 : BitVec.extractLsb' 64 64 x4 = x3
@@ -269,86 +267,87 @@ hx2 : x9 + x3 = x2
 x10 x11 : BitVec 128
 hx4 : x10 ||| x11 = x4
 x12 : BitVec 128
-hx11 : x12 <<< 64 = x11
+hx10 : x12 &&& 18446744073709551615#128 = x10
 x13 : BitVec 128
-hx10 : x13 &&& 18446744073709551615#128 = x10
+hx11 : x13 <<< 64 = x11
 x14 : BitVec 64
 hx12 : BitVec.zeroExtend 128 x14 = x12
 x15 : BitVec 64
 hx13 : BitVec.zeroExtend 128 x15 = x13
 x16 x17 : BitVec 64
 x18 : BitVec 128
-hx16 : BitVec.extractLsb' 0 64 x18 = x16
-hx17 : BitVec.extractLsb' 64 64 x18 = x17
+hx16 : BitVec.extractLsb' 64 64 x18 = x16
+hx17 : BitVec.extractLsb' 0 64 x18 = x17
 x19 x20 : BitVec 64
 hx8 : x19 + x20 = x8
 x21 : BitVec 64
 hx9 : x20 + x21 = x9
-x22 x23 : BitVec 128
-hx18 : x22 ||| x23 = x18
-x24 : BitVec 64
+x22 : BitVec 128
+x23 : BitVec 64
+x24 : BitVec 128
+hx18 : x22 ||| x24 = x18
 x25 : BitVec 128
-hx23 : x25 <<< 64 = x23
+hx24 : x25 <<< 64 = x24
 x26 : BitVec 128
 hx22 : x26 &&& 18446744073709551615#128 = x22
 x27 x28 : BitVec 64
-hx25 : BitVec.zeroExtend 128 x28 = x25
+hx26 : BitVec.zeroExtend 128 x28 = x26
 x29 : BitVec 64
-hx20 : x29 ^^^ x27 = x20
+hx25 : BitVec.zeroExtend 128 x29 = x25
 x30 : BitVec 64
-hx26 : BitVec.zeroExtend 128 x30 = x26
-x31 : BitVec 64
-hx21 : x24 ^^^ x31 = x21
-x32 x33 : BitVec 64
-hx24 : x33 ^^^ x32 = x24
-x34 x35 : BitVec 64
-hx35 : BitVec.extractLsb' 0 64 a = x35
+hx20 : x30 ^^^ x27 = x20
+x31 x32 : BitVec 64
+hx23 : x31 ^^^ x32 = x23
+x33 x34 : BitVec 64
+hx21 : x23 ^^^ x34 = x21
+x35 : BitVec 64
+hx35 : BitVec.extractLsb' 0 64 b = x35
+hx1 : x2 + x35 = x1
+hx5 : x35 + x6 = x5
 x36 : BitVec 64
-hx36 : BitVec.extractLsb' 64 64 a = x36
-hx27 : x34 &&& x36 = x27
+hx36 : BitVec.extractLsb' 64 64 e = x36
+hx6 : x7 + x36 = x6
+hx15 : x16 + x36 = x15
 x37 : BitVec 64
-hx37 : BitVec.extractLsb' 0 64 b = x37
-hx1 : x2 + x37 = x1
-hx5 : x37 + x6 = x5
+hx37 : BitVec.extractLsb' 64 64 b = x37
+hx31 : x37.rotateRight 14 = x31
+hx32 : x37.rotateRight 18 = x32
+hx33 : ~~~x37 = x33
+hx34 : x37.rotateRight 41 = x34
 x38 : BitVec 64
-hx38 : BitVec.extractLsb' 0 64 e = x38
-hx15 : x16 + x38 = x15
+hx38 : BitVec.extractLsb' 64 64 c = x38
+hx19 : x38 + x21 = x19
 x39 : BitVec 64
-hx39 : BitVec.extractLsb' 64 64 b = x39
-hx31 : x39.rotateRight 41 = x31
-hx32 : x39.rotateRight 18 = x32
-hx33 : x39.rotateRight 14 = x33
-hx34 : ~~~x39 = x34
-hx29 : x39 &&& x35 = x29
+hx39 : BitVec.extractLsb' 0 64 d = x39
 x40 : BitVec 64
-hx40 : BitVec.extractLsb' 64 64 c = x40
-hx19 : x40 + x21 = x19
+hx40 : BitVec.extractLsb' 0 64 e = x40
+hx14 : x17 + x40 = x14
 x41 : BitVec 64
-hx41 : BitVec.extractLsb' 64 64 d = x41
-hx7 : x8 + x41 = x7
-hx28 : x40 + x41 = x28
+hx41 : BitVec.extractLsb' 64 64 a = x41
+hx27 : x33 &&& x41 = x27
 x42 : BitVec 64
-hx42 : BitVec.extractLsb' 64 64 e = x42
-hx6 : x7 + x42 = x6
-hx14 : x17 + x42 = x14
+hx42 : BitVec.extractLsb' 64 64 d = x42
+hx7 : x8 + x42 = x7
+hx29 : x38 + x42 = x29
 x43 : BitVec 64
-hx43 : BitVec.extractLsb' 0 64 d = x43
+hx43 : BitVec.extractLsb' 0 64 a = x43
+hx30 : x37 &&& x43 = x30
 x44 : BitVec 64
 hx44 : BitVec.extractLsb' 0 64 c = x44
-hx30 : x44 + x43 = x30
+hx28 : x44 + x39 = x28
 ⊢ x2 ++
-      ((x1 &&& x39 ^^^ ~~~x1 &&& x35) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
+      ((x1 &&& x37 ^^^ ~~~x1 &&& x43) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
         BitVec.extractLsb' 0 64 x4) =
     x6 ++
-      (x44 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x39 ^^^ ~~~x5 &&& x35) + x43 +
-        x38)
+      (x44 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x37 ^^^ ~~~x5 &&& x43) + x39 +
+        x40)
 -/
 
 #guard_msgs in theorem sha512h_rule_1 (a b c d e : BitVec 128) :
   let elements := 2
   let esize := 64
-  let inner_sum := (binary_vector_op_aux 0 elements esize BitVec.add c d (BitVec.zero 128) H)
-  let outer_sum := (binary_vector_op_aux 0 elements esize BitVec.add inner_sum e (BitVec.zero 128) H)
+  let inner_sum := (binary_vector_op_aux 0 elements esize BitVec.add c d (BitVec.zero 128))
+  let outer_sum := (binary_vector_op_aux 0 elements esize BitVec.add inner_sum e (BitVec.zero 128))
   let a0 := extractLsb'  0 64 a
   let a1 := extractLsb' 64 64 a
   let b0 := extractLsb'  0 64 b
@@ -378,95 +377,95 @@ private theorem and_nop_lemma (x : BitVec 64) :
   bv_decide
 
 open BitVec sha512_helpers DPSFP SHA2 in
-/--
-warning: declaration uses 'sorry'
+/--warning: declaration uses 'sorry'
 ---
-info: h1 h2 : 64 > 0
-a b c d e : BitVec 128
+info: a b c d e : BitVec 128
 x1 x2 x3 : BitVec 64
 x4 : BitVec 128
 hx3 : BitVec.extractLsb' 64 64 x4 = x3
-x5 : BitVec 64
-x6 x7 : BitVec 128
-hx4 : x7 ||| x6 = x4
+x5 : BitVec 128
+x6 : BitVec 64
+x7 : BitVec 128
+hx4 : x7 ||| x5 = x4
 x8 : BitVec 128
-hx6 : x8 <<< 64 = x6
+hx5 : x8 <<< 64 = x5
 x9 : BitVec 64
 hx7 : BitVec.zeroExtend 128 x9 = x7
 x10 : BitVec 64
 hx8 : BitVec.zeroExtend 128 x10 = x8
-x11 x12 x13 : BitVec 64
-x14 : BitVec 128
-hx12 : BitVec.extractLsb' 64 64 x14 = x12
-hx13 : BitVec.extractLsb' 0 64 x14 = x13
-x15 : BitVec 64
+x11 x12 x13 x14 : BitVec 64
+x15 : BitVec 128
+hx12 : BitVec.extractLsb' 0 64 x15 = x12
+hx13 : BitVec.extractLsb' 64 64 x15 = x13
 x16 : BitVec 256
-hx14 : BitVec.extractLsb' 64 128 x16 = x14
+hx15 : BitVec.extractLsb' 64 128 x16 = x15
 x17 x18 : BitVec 64
 hx2 : x18 + x3 = x2
-x19 : BitVec 128
-hx16 : x19 ++ x19 = x16
-x20 x21 : BitVec 64
-hx17 : x20 + x21 = x17
+x19 : BitVec 64
+x20 : BitVec 128
+hx16 : x20 ++ x20 = x16
+x21 : BitVec 64
+hx17 : x19 + x21 = x17
 x22 : BitVec 64
 hx18 : x21 + x22 = x18
-x23 : BitVec 64
-x24 x25 : BitVec 128
-hx24 : x25 <<< 64 = x24
+x23 : BitVec 128
+x24 : BitVec 64
+x25 : BitVec 128
+hx23 : x25 <<< 64 = x23
 x26 : BitVec 64
 x27 : BitVec 128
-hx19 : x27 ||| x24 = x19
+hx20 : x27 ||| x23 = x20
 x28 : BitVec 64
-hx21 : x28 ^^^ x26 = x21
+hx27 : BitVec.zeroExtend 128 x28 = x27
 x29 : BitVec 64
-hx27 : BitVec.zeroExtend 128 x29 = x27
+hx25 : BitVec.zeroExtend 128 x29 = x25
 x30 : BitVec 64
-hx25 : BitVec.zeroExtend 128 x30 = x25
-x31 x32 x33 : BitVec 64
-hx23 : x33 ^^^ x31 = x23
-x34 : BitVec 64
-hx22 : x23 ^^^ x34 = x22
-x35 : BitVec 64
-hx35 : BitVec.extractLsb' 0 64 d = x35
-hx15 : x17 + x35 = x15
+hx21 : x30 ^^^ x26 = x21
+x31 x32 : BitVec 64
+hx24 : x32 ^^^ x31 = x24
+x33 : BitVec 64
+hx22 : x24 ^^^ x33 = x22
+x34 x35 : BitVec 64
+hx35 : BitVec.extractLsb' 64 64 e = x35
 x36 : BitVec 64
-hx36 : BitVec.extractLsb' 64 64 d = x36
+hx36 : BitVec.extractLsb' 0 64 e = x36
+hx11 : x14 + x36 = x11
 x37 : BitVec 64
-hx37 : BitVec.extractLsb' 64 64 a = x37
-hx26 : x32 &&& x37 = x26
+hx37 : BitVec.extractLsb' 0 64 b = x37
+hx1 : x2 + x37 = x1
+hx6 : x37 + x11 = x6
 x38 : BitVec 64
-hx38 : BitVec.extractLsb' 0 64 a = x38
+hx38 : BitVec.extractLsb' 64 64 a = x38
+hx26 : x34 &&& x38 = x26
 x39 : BitVec 64
-hx39 : BitVec.extractLsb' 0 64 e = x39
-hx11 : x15 + x39 = x11
-hx29 : x35 + x39 = x29
+hx39 : BitVec.extractLsb' 64 64 c = x39
+hx10 : x39 + x13 = x10
+hx19 : x39 + x22 = x19
 x40 : BitVec 64
-hx40 : BitVec.extractLsb' 0 64 b = x40
-hx1 : x2 + x40 = x1
-hx5 : x40 + x11 = x5
+hx40 : BitVec.extractLsb' 64 64 d = x40
+hx29 : x40 + x35 = x29
 x41 : BitVec 64
-hx41 : BitVec.extractLsb' 64 64 c = x41
-hx10 : x41 + x12 = x10
-hx20 : x41 + x22 = x20
+hx41 : BitVec.extractLsb' 0 64 c = x41
+hx9 : x41 + x12 = x9
 x42 : BitVec 64
-hx42 : BitVec.extractLsb' 64 64 b = x42
-hx31 : x42.rotateRight 18 = x31
-hx32 : ~~~x42 = x32
-hx33 : x42.rotateRight 14 = x33
-hx34 : x42.rotateRight 41 = x34
-hx28 : x42 &&& x38 = x28
+hx42 : BitVec.extractLsb' 0 64 d = x42
+hx14 : x17 + x42 = x14
+hx28 : x42 + x36 = x28
 x43 : BitVec 64
-hx43 : BitVec.extractLsb' 0 64 c = x43
-hx9 : x43 + x13 = x9
+hx43 : BitVec.extractLsb' 64 64 b = x43
+hx31 : x43.rotateRight 18 = x31
+hx32 : x43.rotateRight 14 = x32
+hx33 : x43.rotateRight 41 = x33
+hx34 : ~~~x43 = x34
 x44 : BitVec 64
-hx44 : BitVec.extractLsb' 64 64 e = x44
-hx30 : x36 + x44 = x30
+hx44 : BitVec.extractLsb' 0 64 a = x44
+hx30 : x43 &&& x44 = x30
 ⊢ x2 ++
-      ((x1 &&& x42 ^^^ ~~~x1 &&& x38) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
+      ((x1 &&& x43 ^^^ ~~~x1 &&& x44) + (x1.rotateRight 14 ^^^ x1.rotateRight 18 ^^^ x1.rotateRight 41) +
         BitVec.extractLsb' 0 64 x4) =
     x11 ++
-      (x43 + (x5.rotateRight 14 ^^^ x5.rotateRight 18 ^^^ x5.rotateRight 41) + (x5 &&& x42 ^^^ ~~~x5 &&& x38) + x36 +
-        x44)
+      (x41 + (x6.rotateRight 14 ^^^ x6.rotateRight 18 ^^^ x6.rotateRight 41) + (x6 &&& x43 ^^^ ~~~x6 &&& x44) + x40 +
+        x35)
 -/
 #guard_msgs in theorem sha512h_rule_2 (a b c d e : BitVec 128) :
   let a0 := extractLsb'  0 64 a
@@ -479,12 +478,12 @@ hx30 : x36 + x44 = x30
   let d1 := extractLsb' 64 64 d
   let e0 := extractLsb'  0 64 e
   let e1 := extractLsb' 64 64 e
-  let inner_sum := binary_vector_op_aux 0 2 64 BitVec.add d e (BitVec.zero 128) h1
+  let inner_sum := binary_vector_op_aux 0 2 64 BitVec.add d e (BitVec.zero 128)
   let concat := inner_sum ++ inner_sum
   let operand := extractLsb' 64 128 concat
   let hi64_spec := compression_update_t1 b1 a0 a1 c1 d0 e0
   let lo64_spec := compression_update_t1 (b0 + hi64_spec) b1 a0 c0 d1 e1
-  sha512h a b (binary_vector_op_aux 0 2 64 BitVec.add c operand (BitVec.zero 128) h2) =
+  sha512h a b (binary_vector_op_aux 0 2 64 BitVec.add c operand (BitVec.zero 128)) =
   hi64_spec ++ lo64_spec := by
   repeat (unfold binary_vector_op_aux; simp)
   repeat (unfold BitVec.partInstall; simp)


### PR DESCRIPTION
### Description:

This PR simplifies the definition of `partInstall`. Its signature used to be:
```
abbrev partInstall (hi lo : Nat) (val : BitVec (hi - lo + 1)) (x : BitVec n): BitVec n
```
and now it becomes:
```
abbrev partInstall (start len : Nat) (val : BitVec len) (x : BitVec n): BitVec n
```
This follows the same pattern in `extractLsb` vs `extractLsb'`. By doing this, we are able to simplify several functions that depends on `partInstall`.

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine? Yes

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
