### PR TITLE
feat: generalize to arbitrary bitvec width `zeroextend_bigger_smaller` and `truncate_of_concat_is_lsb`

### DIFF
--- a/Proofs/SHA512/SHA512_block_armv8_rules.lean
+++ b/Proofs/SHA512/SHA512_block_armv8_rules.lean
@@ -138,20 +138,16 @@ theorem truncate_of_concat_is_lsb_64 (x y : BitVec 64) :
   BitVec.zeroExtend 64 (x ++ y) = y := by
   bv_check "lrat_files/Sha512_block_armv8_rules.lean-truncate_of_concat_is_lsb_64-106-2.lrat"
 
-theorem truncate_of_concat_is_lsb (w : Nat) (x y : BitVec w) :
+theorem zeroExtend_append_eq (w : Nat) (x y : BitVec w) :
   BitVec.zeroExtend w (x ++ y) = y := by
   ext
-  simp [BitVec.leftshift_n_or_mod_2n]
+  simp only [truncate_append, Nat.le_refl, ↓reduceDIte, zeroExtend_eq]
 
+-- use BitVec.zeroExtend_zeroExtend_of_le for arbitrary-length bitvec
 theorem zeroextend_bigger_smaller_64 (x : BitVec 64) :
   BitVec.zeroExtend 64 (BitVec.zeroExtend 128 x) =
   BitVec.zeroExtend 64 x := by
   bv_omega
-
-theorem zeroextend_bigger_smaller (w : Nat) (x : BitVec w) :
-  BitVec.zeroExtend w (BitVec.zeroExtend (w + w) x) =
-  BitVec.zeroExtend w x := by
-  simp
 
 -- (FIXME) Generalize to arbitrary-length bitvecs.
 theorem rsh_concat_identity_128 (x : BitVec 128) :

--- a/Proofs/SHA512/SHA512_block_armv8_rules.lean
+++ b/Proofs/SHA512/SHA512_block_armv8_rules.lean
@@ -145,6 +145,11 @@ theorem zeroextend_bigger_smaller_64 (x : BitVec 64) :
   BitVec.zeroExtend 64 x := by
   bv_omega
 
+theorem zeroextend_bigger_smaller (w : Nat) (x : BitVec w) :
+  BitVec.zeroExtend w (BitVec.zeroExtend (w + w) x) =
+  BitVec.zeroExtend w x := by
+  simp
+
 -- (FIXME) Generalize to arbitrary-length bitvecs.
 theorem rsh_concat_identity_128 (x : BitVec 128) :
   zeroExtend 64 (x >>> 64) ++ zeroExtend 64 x = x := by

--- a/Proofs/SHA512/SHA512_block_armv8_rules.lean
+++ b/Proofs/SHA512/SHA512_block_armv8_rules.lean
@@ -160,6 +160,45 @@ theorem rsh_concat_identity_128 (x : BitVec 128) :
   zeroExtend 64 (x >>> 64) ++ zeroExtend 64 x = x := by
   bv_check "lrat_files/Sha512_block_armv8_rules.lean-rsh_concat_identity_128-117-2.lrat"
 
+theorem ushiftRight_add (w n m: Nat) (x : BitVec w):
+  x.toNat >>> (n + m) = x.toNat >>> n >>> m := by
+  induction m
+  case zero =>
+    simp
+  case succ nn ih =>
+
+    sorry
+
+
+theorem ushiftRight_width (w : Nat) (x : BitVec w) :
+  x.toNat >>> w = 0 := by
+  induction w
+  case zero =>
+    simp
+    omega
+  case succ n ih =>
+    rw [ushiftRight_add (m := 1)]
+
+
+
+    sorry
+
+-- (FIXME) Generalize to arbitrary-length bitvecs.
+theorem rsh_concat_identity (w : Nat) (x : BitVec (w + w)) :
+  zeroExtend w (x >>> w) ++ zeroExtend w x = x := by
+  simp only [BitVec.append_def, shiftLeftZeroExtend, ushiftRight_width]
+  ext
+  simp
+
+
+  ext
+  simp only [toNat_or, toNat_zeroExtend', toNat_truncate]
+  simp only [toNat_append]
+  simp only [toNat_truncate]
+  simp only [toNat_ushiftRight]
+  rw [Bi]
+
+
 -- (FIXME) Generalize to arbitrary-length bitvecs.
 theorem rev_vector_of_rev_vector_128_64_8 (x : BitVec 128) :
   rev_vector 128 64 8

--- a/Proofs/SHA512/SHA512_block_armv8_rules.lean
+++ b/Proofs/SHA512/SHA512_block_armv8_rules.lean
@@ -139,6 +139,11 @@ theorem truncate_of_concat_is_lsb_64 (x y : BitVec 64) :
   BitVec.zeroExtend 64 (x ++ y) = y := by
   bv_check "lrat_files/Sha512_block_armv8_rules.lean-truncate_of_concat_is_lsb_64-106-2.lrat"
 
+theorem truncate_of_concat_is_lsb (w : Nat) (x y : BitVec w) :
+  BitVec.zeroExtend w (x ++ y) = y := by
+  ext
+  simp [BitVec.leftshift_n_or_mod_2n]
+
 -- (FIXME) Generalize to arbitrary-length bitvecs.
 theorem zeroextend_bigger_smaller_64 (x : BitVec 64) :
   BitVec.zeroExtend 64 (BitVec.zeroExtend 128 x) =

--- a/Proofs/SHA512/SHA512_block_armv8_rules.lean
+++ b/Proofs/SHA512/SHA512_block_armv8_rules.lean
@@ -134,7 +134,6 @@ theorem concat_of_rsh_is_msb_128 (x y : BitVec 64) :
   (x ++ y) >>> 64 = BitVec.zeroExtend 128 x := by
   bv_check "lrat_files/Sha512_block_armv8_rules.lean-concat_of_rsh_is_msb_128-101-2.lrat"
 
--- (FIXME) Generalize to arbitrary-length bitvecs.
 theorem truncate_of_concat_is_lsb_64 (x y : BitVec 64) :
   BitVec.zeroExtend 64 (x ++ y) = y := by
   bv_check "lrat_files/Sha512_block_armv8_rules.lean-truncate_of_concat_is_lsb_64-106-2.lrat"
@@ -144,7 +143,6 @@ theorem truncate_of_concat_is_lsb (w : Nat) (x y : BitVec w) :
   ext
   simp [BitVec.leftshift_n_or_mod_2n]
 
--- (FIXME) Generalize to arbitrary-length bitvecs.
 theorem zeroextend_bigger_smaller_64 (x : BitVec 64) :
   BitVec.zeroExtend 64 (BitVec.zeroExtend 128 x) =
   BitVec.zeroExtend 64 x := by

--- a/Proofs/SHA512/SHA512_block_armv8_rules.lean
+++ b/Proofs/SHA512/SHA512_block_armv8_rules.lean
@@ -138,7 +138,7 @@ theorem truncate_of_concat_is_lsb_64 (x y : BitVec 64) :
   BitVec.zeroExtend 64 (x ++ y) = y := by
   bv_check "lrat_files/Sha512_block_armv8_rules.lean-truncate_of_concat_is_lsb_64-106-2.lrat"
 
-theorem zeroExtend_append_eq_right {w v : Nat} {x : BitVec w} {y : BitVec v} :
+theorem zeroExtend_append_eq_right {w v : Nat} (x : BitVec w) (y : BitVec v) :
     BitVec.zeroExtend v (x ++ y) = y := by
   ext
   simp only [truncate_append, Nat.le_refl, ↓reduceDIte, zeroExtend_eq]

--- a/Proofs/SHA512/SHA512_block_armv8_rules.lean
+++ b/Proofs/SHA512/SHA512_block_armv8_rules.lean
@@ -138,8 +138,8 @@ theorem truncate_of_concat_is_lsb_64 (x y : BitVec 64) :
   BitVec.zeroExtend 64 (x ++ y) = y := by
   bv_check "lrat_files/Sha512_block_armv8_rules.lean-truncate_of_concat_is_lsb_64-106-2.lrat"
 
-theorem zeroExtend_append_eq (w : Nat) (x y : BitVec w) :
-  BitVec.zeroExtend w (x ++ y) = y := by
+theorem zeroExtend_append_eq_right {w v : Nat} {x : BitVec w} {y : BitVec v} :
+    BitVec.zeroExtend v (x ++ y) = y := by
   ext
   simp only [truncate_append, Nat.le_refl, ↓reduceDIte, zeroExtend_eq]
 

--- a/Proofs/SHA512/SHA512_block_armv8_rules.lean
+++ b/Proofs/SHA512/SHA512_block_armv8_rules.lean
@@ -160,45 +160,6 @@ theorem rsh_concat_identity_128 (x : BitVec 128) :
   zeroExtend 64 (x >>> 64) ++ zeroExtend 64 x = x := by
   bv_check "lrat_files/Sha512_block_armv8_rules.lean-rsh_concat_identity_128-117-2.lrat"
 
-theorem ushiftRight_add (w n m: Nat) (x : BitVec w):
-  x.toNat >>> (n + m) = x.toNat >>> n >>> m := by
-  induction m
-  case zero =>
-    simp
-  case succ nn ih =>
-
-    sorry
-
-
-theorem ushiftRight_width (w : Nat) (x : BitVec w) :
-  x.toNat >>> w = 0 := by
-  induction w
-  case zero =>
-    simp
-    omega
-  case succ n ih =>
-    rw [ushiftRight_add (m := 1)]
-
-
-
-    sorry
-
--- (FIXME) Generalize to arbitrary-length bitvecs.
-theorem rsh_concat_identity (w : Nat) (x : BitVec (w + w)) :
-  zeroExtend w (x >>> w) ++ zeroExtend w x = x := by
-  simp only [BitVec.append_def, shiftLeftZeroExtend, ushiftRight_width]
-  ext
-  simp
-
-
-  ext
-  simp only [toNat_or, toNat_zeroExtend', toNat_truncate]
-  simp only [toNat_append]
-  simp only [toNat_truncate]
-  simp only [toNat_ushiftRight]
-  rw [Bi]
-
-
 -- (FIXME) Generalize to arbitrary-length bitvecs.
 theorem rev_vector_of_rev_vector_128_64_8 (x : BitVec 128) :
   rev_vector 128 64 8


### PR DESCRIPTION
### Description:

This PR extends `truncate_of_concat_is_lsb_64` to arbitrary-width bitvectors. 

### Testing:

What tests have been run? Did `make all` succeed for your changes? Yes
Was conformance testing successful on an Aarch64 machine? yes 

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.