### PR TITLE
chore: fix proof building in 'mem.read ... = mem.read ...'

### DIFF
--- a/Arm/Memory/SeparateAutomation.lean
+++ b/Arm/Memory/SeparateAutomation.lean
@@ -314,7 +314,7 @@ we can have some kind of funny situation where both LHS and RHS are ReadBytes.
 For example, `mem1.read base1 n = mem2.read base2 n`.
 In such a scenario, we should record both reads.
 -/
-def ReadBytesEqProof.ofExpr? (eval : Expr) (etype : Expr) :  Array ReadBytesEqProof := Id.run do
+def ReadBytesEqProof.ofExpr? (eval : Expr) (etype : Expr) : MetaM (Array ReadBytesEqProof) := do
   let mut out := #[]
   if let .some ⟨_ty, lhs, rhs⟩ := etype.eq? then do
     let lhs := lhs
@@ -323,7 +323,7 @@ def ReadBytesEqProof.ofExpr? (eval : Expr) (etype : Expr) :  Array ReadBytesEqPr
       out := out.push { val := rhs, read := read, h := eval }
 
     if let .some read := ReadBytesExpr.ofExpr? rhs then
-      out:= out.push { val := lhs, read := read, h := eval }
+      out:= out.push { val := lhs, read := read, h := ← mkEqSymm eval }
   return out
 
 inductive Hypothesis
@@ -583,7 +583,7 @@ def hypothesisOfExpr (h : Expr) (hyps : Array Hypothesis) : MetaM (Array Hypothe
     return hyps
   else
     let mut hyps := hyps
-    for eqProof in ReadBytesEqProof.ofExpr? h ht do
+    for eqProof in ← ReadBytesEqProof.ofExpr? h ht do
       let proof : Hypothesis := .read_eq eqProof
       hyps := hyps.push proof
     return hyps

--- a/Proofs/Experiments/MemoryAliasing.lean
+++ b/Proofs/Experiments/MemoryAliasing.lean
@@ -255,10 +255,6 @@ info: 'ReadOverlappingRead.overlapping_read_test_3' depends on axioms: [propext,
 -/
 #guard_msgs in #print axioms overlapping_read_test_3
 
-/- TODO(@bollu): This test case hangs at `bv_omega_bench`. This is to be debugged.
-/-- A read in the goal state overlaps with a read in the
-right hand side of the hypotheis `h`.
--/
 theorem overlapping_read_test_4
     (hlegal : mem_legal' src_addr 16)
     (h : read_mem_bytes 16 other_addr s = read_mem_bytes 16 src_addr s) :
@@ -268,11 +264,11 @@ theorem overlapping_read_test_4
   simp only [memory_rules] at h ⊢
   simp_mem
   · congr
-    -- ⊢ (src_addr + 6).toNat - src_addr.toNat = 6
-    bv_omega_bench -- TODO: Lean gets stuck here?
+    bv_omega
 
+/-- info: 'ReadOverlappingRead.overlapping_read_test_4' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms overlapping_read_test_4
--/
+
 end ReadOverlappingRead
 
 namespace ReadOverlappingWrite


### PR DESCRIPTION
fixes #115

### Description:

This was a really interesting bugfix, and was my bug. The `simp_mem` tactic tries to handle hypotheses of the form `mem.read addr1 n1 = mem.read addr2 n2` by registering both sides as useful information that it should exploit.

However, the part that flips the equality forgot to flip the equality :) 

Debugging this was enormously painful, because for whatever reason, the kernel spends an enormously long time checking the proof, and then gives up with "deterministic timeout". Regardless, here's the patch that fixes it:

```diff
@@ -314,7 +305,7 @@ we can have some kind of funny situation where both LHS and RHS are ReadBytes.
 For example, `mem1.read base1 n = mem2.read base2 n`.
 In such a scenario, we should record both reads.
 -/
-def ReadBytesEqProof.ofExpr? (eval : Expr) (etype : Expr) :  Array ReadBytesEqProof := Id.run do
+def ReadBytesEqProof.ofExpr? (eval : Expr) (etype : Expr) :  MetaM (Array ReadBytesEqProof) := do
   let mut out := #[]
   if let .some ⟨_ty, lhs, rhs⟩ := etype.eq? then do
     let lhs := lhs
@@ -323,7 +314,7 @@ def ReadBytesEqProof.ofExpr? (eval : Expr) (etype : Expr) :  Array ReadBytesEqPr
       out := out.push { val := rhs, read := read, h := eval }
 
     if let .some read := ReadBytesExpr.ofExpr? rhs then
-      out:= out.push { val := lhs, read := read, h := eval }
+      out:= out.push { val := lhs, read := read, h := ← mkEqSymm eval }
   return out
 
 inductive Hypothesis
@@ -358,8 +349,8 @@ def State.init (cfg : SimpMemConfig) : State :=
```necessary?

### Testing:

cosim succeeds. 


### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
