### PR TITLE
feat: mem_separate_of_mem_separate'

### DIFF
--- a/Arm/Memory/Separate.lean
+++ b/Arm/Memory/Separate.lean
@@ -366,27 +366,22 @@ theorem mem_separate'_comm (h : mem_separate' a an b bn) :
   apply mem_separate'.of_omega
   omega
 
+
 /-#
 This is a theorem we ought to prove, which establishes the equivalence
 between the old and new defintions of 'mem_separate'.
 However, the proof is finicky, and so we leave it commented for now.
 -/
-/-
-theorem mem_separate_of_mem_separate' (h : mem_separate' a an b bn)
-    (ha' : a' = a + (BitVec.ofNat w₁ (an - 1) ) (hb' : b' = b + (BitVec.ofNat w₁ (bn - 1)))
-    (hlegala : mem_legal a an) (hlegalb: mem_legal b bn) :
-    mem_separate a a' b b' := by
+theorem mem_separate_of_mem_separate' (a b : BitVec 64)
+    (an bn : Nat)
+    (han : an > 0) (hbn : bn > 0)
+    (h : mem_separate' a an b bn) :
+    mem_separate a (a + an - 1) b (b + bn - 1) := by
   simp [mem_separate]
   simp [mem_overlap]
   obtain ⟨ha, hb, hsep⟩ := h
   simp [mem_legal'] at ha hb
-  subst ha'
-  subst hb'
-  apply Classical.byContradiction
-  intro hcontra
-  · sorry
-  · sorry
--/
+  bv_omega
 
 /-- `mem_subset' a an b bn` witnesses that `[a..a+an)` is a subset of `[b..b+bn)`.
 In prose, we may notate this as `[a..an) ≤ [b..bn)`.

--- a/Arm/Memory/Separate.lean
+++ b/Arm/Memory/Separate.lean
@@ -368,9 +368,7 @@ theorem mem_separate'_comm (h : mem_separate' a an b bn) :
 
 
 /-#
-This is a theorem we ought to prove, which establishes the equivalence
-between the old and new defintions of 'mem_separate'.
-However, the proof is finicky, and so we leave it commented for now.
+This theorem establishes the equivalence between the old and new definitions of 'mem_separate'.
 -/
 theorem mem_separate_of_mem_separate' (a b : BitVec 64)
     (an bn : Nat)


### PR DESCRIPTION
### Issues:

Closes https://github.com/leanprover/LNSym/issues/137

### Description:

We prove `mem_separate_of_mem_separate'`, showing that the old defn aligns with the new defn for non-zero-width-inervals.

### Testing:

We do not change any executable defs, and cosim succeeds.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
