### PR TITLE
Update the gcm_init_v8 proof

### DIFF
--- a/Proofs/AES-GCM/GCMInitV8Sym.lean
+++ b/Proofs/AES-GCM/GCMInitV8Sym.lean
@@ -17,6 +17,7 @@ abbrev H_addr (s : ArmState) : BitVec 64 := r (StateField.GPR 1#5) s
 abbrev Htable_addr (s : ArmState) : BitVec 64 := r (StateField.GPR 0#5) s
 
 set_option maxRecDepth 8000 in
+set_option debug.byAsSorry true in
 -- set_option profiler true in
 theorem gcm_init_v8_program_run_152 (s0 sf : ArmState)
     (h_s0_program : s0.program = gcm_init_v8_program)
@@ -37,6 +38,7 @@ theorem gcm_init_v8_program_run_152 (s0 sf : ArmState)
 set_option maxRecDepth 100000 in
 set_option maxHeartbeats 500000 in
 set_option sat.timeout 120 in
+set_option trace.profiler true in
 -- set_option pp.deepTerms true in
 -- set_option pp.maxSteps 10000 in
 -- set_option trace.profiler true in
@@ -93,19 +95,15 @@ theorem gcm_init_v8_program_correct (s0 sf : ArmState)
   --    unable to be reflected
   sym_n 152
   simp only [Htable_addr, state_value] -- TODO: state_value is needed, why
-  apply And.intro  
+  apply And.intro
   · bv_decide
-  · sorry
-  -- [Shilpi] Commenting out the following because the CI fails with 
-  -- "INTERNAL PANIC: out of memory"
-  /-
-    simp only
+  · simp only
     [shift_left_common_aux_64_2
     , shift_right_common_aux_64_2_tff
     , shift_right_common_aux_32_4_fff
     , DPSFP.AdvSIMDExpandImm
     , DPSFP.dup_aux_0_4_32]
-    generalize read_mem_bytes 16 (r (StateField.GPR 1#5) s0) s0 = Hinit
+    generalize Memory.read_bytes 16 (r (StateField.GPR 1#5) s0) s0.mem = Hinit
     -- change the type of Hinit to be BitVec 128, assuming that's def-eq
     change BitVec 128 at Hinit
     simp only [GCMV8.GCMInitV8, GCMV8.lo, List.get!, GCMV8.hi,
@@ -118,7 +116,6 @@ theorem gcm_init_v8_program_correct (s0 sf : ArmState)
       Nat.zero_mod, Nat.zero_add, Nat.sub_zero, Nat.mul_one, Nat.zero_mul, Nat.one_mul,
       Nat.reduceSub, BitVec.reduceMul, BitVec.reduceXOr, BitVec.mul_one, Nat.add_one_sub_one,
       BitVec.one_mul]
+    bv_decide
     -- bv_check "lrat_files/GCMInitV8Sym.lean-GCMInitV8Program.gcm_init_v8_program_correct-117-4.lrat"
     -- TODO: proof works in vscode but timeout in the CI -- need to investigate further
-    -/
-

--- a/Proofs/AES-GCM/GCMInitV8Sym.lean
+++ b/Proofs/AES-GCM/GCMInitV8Sym.lean
@@ -38,10 +38,9 @@ theorem gcm_init_v8_program_run_152 (s0 sf : ArmState)
 set_option maxRecDepth 100000 in
 set_option maxHeartbeats 500000 in
 set_option sat.timeout 120 in
-set_option trace.profiler true in
+-- set_option trace.profiler true in
 -- set_option pp.deepTerms true in
 -- set_option pp.maxSteps 10000 in
--- set_option trace.profiler true in
 -- set_option linter.unusedVariables false in
 -- set_option profiler true in
 theorem gcm_init_v8_program_correct (s0 sf : ArmState)
@@ -111,11 +110,9 @@ theorem gcm_init_v8_program_correct (s0 sf : ArmState)
       GCMV8.reduce, GCMV8.degree, GCMV8.degree.degreeTR]
     simp only [Nat.reduceAdd, BitVec.ushiftRight_eq, BitVec.reduceExtracLsb',
       BitVec.reduceHShiftLeft, BitVec.reduceAppend, BitVec.reduceHShiftRight, BitVec.ofNat_eq_ofNat,
-      BitVec.reduceEq, ↓reduceIte, BitVec.zero_eq, Nat.sub_self, BitVec.ushiftRight_zero_eq,
-      BitVec.reduceAnd, BitVec.toNat_ofNat, Nat.pow_one, Nat.reduceMod, Nat.mul_zero, Nat.add_zero,
-      Nat.zero_mod, Nat.zero_add, Nat.sub_zero, Nat.mul_one, Nat.zero_mul, Nat.one_mul,
-      Nat.reduceSub, BitVec.reduceMul, BitVec.reduceXOr, BitVec.mul_one, Nat.add_one_sub_one,
-      BitVec.one_mul]
+      BitVec.reduceEq, ↓reduceIte, Nat.sub_self, BitVec.ushiftRight_zero_eq, BitVec.reduceAnd,
+      BitVec.toNat_ofNat, Nat.pow_one, Nat.reduceMod, Nat.mul_zero, Nat.add_zero, Nat.zero_mod,
+      Nat.zero_add, Nat.sub_zero, Nat.mul_one, Nat.zero_mul, Nat.one_mul, Nat.reduceSub,
+      BitVec.and_self, BitVec.zero_and, BitVec.reduceMul, BitVec.xor_zero, BitVec.mul_one,
+      BitVec.zero_xor, Nat.add_one_sub_one, BitVec.one_mul, BitVec.reduceXOr]
     bv_decide
-    -- bv_check "lrat_files/GCMInitV8Sym.lean-GCMInitV8Program.gcm_init_v8_program_correct-117-4.lrat"
-    -- TODO: proof works in vscode but timeout in the CI -- need to investigate further

--- a/Proofs/AES-GCM/GCMInitV8Sym.lean
+++ b/Proofs/AES-GCM/GCMInitV8Sym.lean
@@ -16,12 +16,12 @@ set_option bv.ac_nf false
 abbrev H_addr (s : ArmState) : BitVec 64 := r (StateField.GPR 1#5) s
 abbrev Htable_addr (s : ArmState) : BitVec 64 := r (StateField.GPR 0#5) s
 
-set_option maxRecDepth 100000 in
+set_option maxRecDepth 2000 in
 set_option maxHeartbeats 500000 in
 set_option sat.timeout 120 in
--- set_option trace.profiler true in
 -- set_option pp.deepTerms true in
 -- set_option pp.maxSteps 10000 in
+-- set_option trace.profiler true in
 -- set_option linter.unusedVariables false in
 -- set_option profiler true in
 theorem gcm_init_v8_program_correct (s0 sf : ArmState)

--- a/Proofs/AES-GCM/GCMInitV8Sym.lean
+++ b/Proofs/AES-GCM/GCMInitV8Sym.lean
@@ -16,25 +16,6 @@ set_option bv.ac_nf false
 abbrev H_addr (s : ArmState) : BitVec 64 := r (StateField.GPR 1#5) s
 abbrev Htable_addr (s : ArmState) : BitVec 64 := r (StateField.GPR 0#5) s
 
-set_option maxRecDepth 8000 in
-set_option debug.byAsSorry true in
--- set_option profiler true in
-theorem gcm_init_v8_program_run_152 (s0 sf : ArmState)
-    (h_s0_program : s0.program = gcm_init_v8_program)
-    (h_s0_err : read_err s0 = .None)
-    (h_s0_pc : read_pc s0 = gcm_init_v8_program.min)
-    (h_s0_sp_aligned : CheckSPAlignment s0)
-    (h_run : sf = run gcm_init_v8_program.length s0)
-    (_h_mem : Memory.Region.pairwiseSeparate
-      [ ⟨(H_addr s0), 128⟩,
-        ⟨(Htable_addr s0), 2048⟩ ])
-    : read_err sf = .None := by
-  simp (config := {ground := true}) only at h_s0_pc
-  -- ^^ Still needed, because `gcm_init_v8_program.min` is somehow
-  --    unable to be reflected
-  sym_n 152
-  done
-
 set_option maxRecDepth 100000 in
 set_option maxHeartbeats 500000 in
 set_option sat.timeout 120 in


### PR DESCRIPTION
### Description:

Update the gcm_init_v8 proof by using `Memory.read_bytes` and update the autogenerated `simp only`.

### Testing:

What tests have been run? Did `make all` succeed for your changes? Was
conformance testing successful on an Aarch64 machine? Yes.

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
